### PR TITLE
feat: added ability to set use_frameworks to static

### DIFF
--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,1 +1,1 @@
-module.exports = require("./build/src");
+module.exports = require("./lib/commonjs/index");

--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -1,5 +1,6 @@
 export const LOCAL_PATH_TO_CIO_NSE_FILES = `node_modules/customerio-expo-plugin/src/helpers/native-files/ios`;
 export const IOS_DEPLOYMENT_TARGET = '13.0';
+export const CIO_SDK_VERSION = '1.2.5';
 export const CIO_PODFILE_REGEX = /pod 'RCT-Folly'/;
 export const CIO_CIO_TARGET_REGEX = /cio_target_names/;
 export const CIO_PODFILE_NOTIFICATION_REGEX = /target 'NotificationService' do/;
@@ -67,12 +68,17 @@ export const CIO_WILLPRESENTNOTIFICATIONHANDLER_SNIPPET = `
 }`;
 export const CIO_PODFILE_NOTIFICATION_SNIPPET = `
 target '${CIO_NOTIFICATION_TARGET_NAME}' do
-  pod 'CustomerIO/MessagingPushAPN', '~> 1.2.5'
+  pod 'CustomerIO/MessagingPushAPN', '~> ${CIO_SDK_VERSION}'
+end`;
+export const CIO_PODFILE_NOTIFICATION_STATIC_FRAMEWORK_SNIPPET = `
+target '${CIO_NOTIFICATION_TARGET_NAME}' do
+  use_frameworks! :linkage => :static
+  pod 'CustomerIO/MessagingPushAPN', '~> ${CIO_SDK_VERSION}'
 end`;
 export const CIO_PODFILE_SNIPPET = `
   pod 'RCT-Folly', :podspec => '../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec'
   pod 'boost', :podspec => '../node_modules/react-native/third-party-podspecs/boost.podspec'
-  pod 'CustomerIO/MessagingPushAPN', '~> 1.2.5'`;
+  pod 'CustomerIO/MessagingPushAPN', '~> ${CIO_SDK_VERSION}'`;
 export const CIO_PODFILE_TARGET_NAMES_SNIPPET = `
   cio_target_names = [
     'CustomerIOTracking',

--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -1,7 +1,7 @@
 export const LOCAL_PATH_TO_CIO_NSE_FILES = `node_modules/customerio-expo-plugin/src/helpers/native-files/ios`;
 export const IOS_DEPLOYMENT_TARGET = '13.0';
-export const CIO_SDK_VERSION = '1.2.5';
-export const CIO_PODFILE_REGEX = /pod 'RCT-Folly'/;
+export const CIO_SDK_VERSION = '1.2.6';
+export const CIO_PODFILE_REGEX = /pod 'CustomerIO\/MessagingPushAPN'/;
 export const CIO_CIO_TARGET_REGEX = /cio_target_names/;
 export const CIO_PODFILE_NOTIFICATION_REGEX = /target 'NotificationService' do/;
 export const GROUP_IDENTIFIER_TEMPLATE_REGEX = /{{GROUP_IDENTIFIER}}/gm;

--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -66,19 +66,16 @@ export const CIO_WILLPRESENTNOTIFICATIONHANDLER_SNIPPET = `
 - (void)userNotificationCenter:(UNUserNotificationCenter* )center willPresentNotification:(UNNotification* )notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler {
   completionHandler( UNNotificationPresentationOptionAlert + UNNotificationPresentationOptionSound);
 }`;
+export const CIO_PODFILE_SNIPPET = `  pod 'CustomerIO/MessagingPushAPN', '~> ${CIO_SDK_VERSION}'`;
 export const CIO_PODFILE_NOTIFICATION_SNIPPET = `
 target '${CIO_NOTIFICATION_TARGET_NAME}' do
-  pod 'CustomerIO/MessagingPushAPN', '~> ${CIO_SDK_VERSION}'
+${CIO_PODFILE_SNIPPET}
 end`;
 export const CIO_PODFILE_NOTIFICATION_STATIC_FRAMEWORK_SNIPPET = `
 target '${CIO_NOTIFICATION_TARGET_NAME}' do
   use_frameworks! :linkage => :static
-  pod 'CustomerIO/MessagingPushAPN', '~> ${CIO_SDK_VERSION}'
+${CIO_PODFILE_SNIPPET}
 end`;
-export const CIO_PODFILE_SNIPPET = `
-  pod 'RCT-Folly', :podspec => '../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec'
-  pod 'boost', :podspec => '../node_modules/react-native/third-party-podspecs/boost.podspec'
-  pod 'CustomerIO/MessagingPushAPN', '~> ${CIO_SDK_VERSION}'`;
 export const CIO_PODFILE_TARGET_NAMES_SNIPPET = `
   cio_target_names = [
     'CustomerIOTracking',

--- a/src/helpers/utils/injectCIOPodfileCode.ts
+++ b/src/helpers/utils/injectCIOPodfileCode.ts
@@ -1,3 +1,4 @@
+import type { CustomerIOPluginOptionsIOS } from '../../types/cio-types';
 import {
   CIO_PODFILE_REGEX,
   CIO_PODFILE_SNIPPET,
@@ -6,6 +7,7 @@ import {
   CIO_PODFILE_POST_INSTALL_SNIPPET,
   CIO_PODFILE_POST_INSTALL_FALLBACK_SNIPPET,
   CIO_PODFILE_NOTIFICATION_SNIPPET,
+  CIO_PODFILE_NOTIFICATION_STATIC_FRAMEWORK_SNIPPET,
   CIO_PODFILE_NOTIFICATION_REGEX,
   CIO_CIO_TARGET_REGEX,
 } from '../constants/ios';
@@ -42,12 +44,19 @@ export async function injectCIOPodfileCode(iosPath: string) {
   }
 }
 
-export async function injectCIONotificationPodfileCode(iosPath: string) {
+export async function injectCIONotificationPodfileCode(
+  iosPath: string,
+  useFrameworks: CustomerIOPluginOptionsIOS['useFrameworks']
+) {
   const filename = `${iosPath}/Podfile`;
   const podfile = await FileManagement.read(filename);
   const matches = podfile.match(CIO_PODFILE_NOTIFICATION_REGEX);
 
   if (!matches) {
-    FileManagement.append(filename, CIO_PODFILE_NOTIFICATION_SNIPPET);
+    const snippet =
+      useFrameworks === 'static'
+        ? CIO_PODFILE_NOTIFICATION_STATIC_FRAMEWORK_SNIPPET
+        : CIO_PODFILE_NOTIFICATION_SNIPPET;
+    FileManagement.append(filename, snippet);
   }
 }

--- a/src/ios/withNotificationsXcodeProject.ts
+++ b/src/ios/withNotificationsXcodeProject.ts
@@ -24,6 +24,7 @@ const addNotificationServiceExtension = async (
     bundleShortVersion,
     bundleVersion,
     iosPath,
+    useFrameworks,
     appName,
     iosDeploymentTarget,
   } = options;
@@ -37,7 +38,7 @@ const addNotificationServiceExtension = async (
       throw new Error(`Error parsing iOS project: ${JSON.stringify(err)}`);
     }
 
-    await injectCIONotificationPodfileCode(iosPath);
+    await injectCIONotificationPodfileCode(iosPath, useFrameworks);
 
     FileManagement.mkdir(`${iosPath}/${CIO_NOTIFICATION_TARGET_NAME}`, {
       recursive: true,

--- a/src/ios/withNotificationsXcodeProject.ts
+++ b/src/ios/withNotificationsXcodeProject.ts
@@ -164,7 +164,7 @@ export const withCioNotificationsXcodeProject: ConfigPlugin<
 > = (configOuter, props) => {
   return withXcodeProject(configOuter, async (config) => {
     const { modRequest, ios, version: bundleShortVersion } = config;
-    const { appleTeamId, iosDeploymentTarget } = props;
+    const { appleTeamId, iosDeploymentTarget, useFrameworks } = props;
 
     if (ios === undefined)
       throw new Error(
@@ -199,6 +199,7 @@ export const withCioNotificationsXcodeProject: ConfigPlugin<
       bundleVersion: buildNumber || DEFAULT_BUNDLE_VERSION,
       iosPath: platformProjectRoot,
       appName: projectName,
+      useFrameworks,
       iosDeploymentTarget,
     };
 

--- a/src/types/cio-types.ts
+++ b/src/types/cio-types.ts
@@ -15,6 +15,7 @@ export type CustomerIOPluginOptionsIOS = {
   iosDeploymentTarget?: string;
   appleTeamId?: string;
   appName?: string;
+  useFrameworks?: 'static' | 'dynamic';
   pushNotification?: {
     useRichPush: boolean;
   };


### PR DESCRIPTION
This PR resolves: https://github.com/customerio/issues/issues/8667

## Summary
It's a simple feature that adds the ability to set `use_frameworks! :linkage => :static` in `NotificationService` to make it compatible with `expo-build-properties`'s `ios.useFrameworks` feature

example:
If we have 
```
[
        "expo-build-properties",
        {
          "ios": {
            "useFrameworks": "static"
          }
        }
]
```
We can set this to avoid an error in `Podfile`
```
ios: {
          useFrameworks: 'static', // can be 'static' | 'dynamic' and is not required
          pushNotification: {
            useRichPush: true,
        },
},
```