### PR TITLE
fix: fixed info.plist formatting issue

### DIFF
--- a/src/helpers/utils/codeInjection.ts
+++ b/src/helpers/utils/codeInjection.ts
@@ -22,6 +22,14 @@ export function injectCodeByMultiLineRegex(
   return fileContent.replace(lineRegex, `$&\n${snippet}`);
 }
 
+export function replaceCodeByRegex(
+  fileContent: string,
+  lineRegex: RegExp,
+  snippet: string
+) {
+  return fileContent.replace(lineRegex, snippet);
+}
+
 export function injectCodeByMultiLineRegexAndReplaceLine(
   fileContent: string,
   lineRegex: RegExp,

--- a/src/ios/withNotificationsXcodeProject.ts
+++ b/src/ios/withNotificationsXcodeProject.ts
@@ -6,7 +6,7 @@ import {
   DEFAULT_BUNDLE_VERSION,
   LOCAL_PATH_TO_CIO_NSE_FILES,
 } from '../helpers/constants/ios';
-import { injectCodeByMultiLineRegex } from '../helpers/utils/codeInjection';
+import { replaceCodeByRegex } from '../helpers/utils/codeInjection';
 import { injectCIONotificationPodfileCode } from '../helpers/utils/injectCIOPodfileCode';
 import type { CustomerIOPluginOptionsIOS } from '../types/cio-types';
 import { FileManagement } from './../helpers/utils/fileManagement';
@@ -220,7 +220,7 @@ const updateNseInfoPlist = (payload: {
   let plistFileString = FileManagement.readFile(payload.infoPlistTargetFile);
 
   if (payload.bundleVersion) {
-    plistFileString = injectCodeByMultiLineRegex(
+    plistFileString = replaceCodeByRegex(
       plistFileString,
       BUNDLE_VERSION_RE,
       payload.bundleVersion
@@ -228,7 +228,7 @@ const updateNseInfoPlist = (payload: {
   }
 
   if (payload.bundleShortVersion) {
-    plistFileString = injectCodeByMultiLineRegex(
+    plistFileString = replaceCodeByRegex(
       plistFileString,
       BUNDLE_SHORT_VERSION_RE,
       payload.bundleShortVersion


### PR DESCRIPTION
https://github.com/customerio/issues/issues/8857

The function that should handle replacements in `.plist` file calls `injectCodeByMultiLineRegex`, which is wrong since this function does not replace the values; it only injects a new value.
This PR adds a new function, `replaceCodeByRegex` which does the replacement correctly