### PR TITLE
chore: update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "customerio-expo-plugin",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "description": "Expo config plugin for the Customer IO React Native SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
For some reason, the CI updates the package version to `1.0.0-alpha.4`.
This PR attempts to address it by updating the version to `1.0.0-alpha.5`, but this doesn't solve the underlying issue this only attempts to allow the release to go through.