### PR TITLE
fix: update .releaserc.json

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -16,7 +16,7 @@
       "changelogFile": "CHANGELOG.md"
     }],
     ["@semantic-release/exec",{
-        "verifyReleaseCmd": "./scripts/update-version.sh 1.0.0-alpha.4"
+        "verifyReleaseCmd": "./scripts/update-version.sh ${nextRelease.version}"
       }
     ],
     ["@semantic-release/git", {


### PR DESCRIPTION
The last time we did a release, we had issues with the `CI`, and to get around it, I tried to set the version manually.
I fixed it on `develop`, but the change has not been merged to `alpha` yet, so this PR fixes it on `alpha`