### PR TITLE
fix: minor fix with path

### DIFF
--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -1,4 +1,4 @@
-export const LOCAL_PATH_TO_CIO_NSE_FILES = `node_modules/customerio-expo-plugin/src/helpers/native-files/ios`;
+export const LOCAL_PATH_TO_CIO_NSE_FILES = `./node_modules/customerio-expo-plugin/src/helpers/native-files/ios`;
 export const IOS_DEPLOYMENT_TARGET = '13.0';
 export const CIO_SDK_VERSION = '1.2.6';
 export const CIO_PODFILE_REGEX = /pod 'CustomerIO\/MessagingPushAPN'/;


### PR DESCRIPTION
A customer got an error related to a file path: https://secure.helpscout.net/conversation/2079296191/184737/
It is unclear what caused the error because they had been able to run prebuild before and only got an error when trying to run their app.

This PR attempts to fix this issue with the path.
