### PR TITLE
fix: prevent plugin from creating duplicate folders/groups

### DIFF
--- a/src/ios/withNotificationsXcodeProject.ts
+++ b/src/ios/withNotificationsXcodeProject.ts
@@ -320,6 +320,8 @@ async function addPushNotificationFile(
   const appPath = `${iosPath}/${appName}`;
   const getTargetFile = (filename: string) => `${appPath}/${filename}`;
 
+  // Check whether {file} exists in the project. If false, then add the file
+  // If {file} exists then skip and return
   if (!FileManagement.exists(getTargetFile(file))) {
     FileManagement.mkdir(appPath, {
       recursive: true,
@@ -332,6 +334,7 @@ async function addPushNotificationFile(
     );
   } else {
     console.log(`${getTargetFile(file)} already exists. Skipping...`);
+    return
   }
 
   const group = xcodeProject.pbxCreateGroup('CustomerIONotifications');

--- a/src/ios/withNotificationsXcodeProject.ts
+++ b/src/ios/withNotificationsXcodeProject.ts
@@ -117,6 +117,15 @@ const addRichPushXcodeProj = async (
 
   await injectCIONotificationPodfileCode(iosPath, useFrameworks);
 
+  // Check if `CIO_NOTIFICATION_TARGET_NAME` group already exist in the project
+  // If true then skip creating a new group to avoid duplicate folders
+  if (xcodeProject.pbxTargetByName(CIO_NOTIFICATION_TARGET_NAME)) {
+    console.warn(
+      `${CIO_NOTIFICATION_TARGET_NAME} already exists in project. Skipping...`
+    );
+    return;
+  }
+
   const nsePath = `${iosPath}/${CIO_NOTIFICATION_TARGET_NAME}`;
   FileManagement.mkdir(nsePath, {
     recursive: true,


### PR DESCRIPTION
### THIS IS A HOTFIX ON BETA BRANCH, DEV & QA TESTING REQUIRED

Closes: https://github.com/customerio/opsbugs/issues/3083

Fix to prevent expo config plugin to create duplicate folders when running `expo prebuild` multiple times. 

