### PR TITLE
ci: fix chance for hitting github rate limit on deploy

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -27,6 +27,10 @@
         "message": "chore: prepare for ${nextRelease.version}\n\n${nextRelease.notes}"
       }
     ],
-    "@semantic-release/github"
+    ["@semantic-release/github", {
+      "labels": false,
+      "successComment": false,
+      "failTitle": false
+    }]
   ]
 }


### PR DESCRIPTION
During a recent iOS SDK deployment, the deployment bot hit a rate limit while adding comments and labels like this:

![CleanShot 2023-02-22 at 14 27 57@2x](https://user-images.githubusercontent.com/2041082/220751368-6e65c3d5-1750-4daa-83b6-cff986853dbf.png)

This PR removed the ability for the deployment bot to make these comments and labels on PRs. This is to remove the chance of hitting the rate limit, but also because there is no longer a need for the 
deployment bot doing this behavior since GitHub released a feature that shows this information for us. 
