### PR TITLE
ci: fix github ref in npm publish step of deploy action

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -16,6 +16,7 @@ jobs:
     name: Deploy git tag
     runs-on: ubuntu-latest
     outputs:
+      new_release_git_head: ${{ steps.semantic-release.outputs.new_release_git_head }}
       new_release_published: ${{ steps.semantic-release.outputs.new_release_published }}
       new_release_version: ${{ steps.semantic-release.outputs.new_release_version }}
     steps:
@@ -114,6 +115,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.deploy-git-tag.outputs.new_release_git_head }}
+
       - uses: actions/setup-node@v3
         with:
           node-version: '16'


### PR DESCRIPTION
The `deploy-npm` job was checking out the $GITHUB_REF that triggered the workflow. The prior job (deploy-git-tag) bumps the version in the package.json and updates the changelog, which would not be picked up by the final job.

See https://github.com/customerio/customerio-reactnative/pull/100 for more information.
