### PR TITLE
feat: support for React Native and iOS SDK v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-expo-plugin",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-expo-plugin",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
@@ -25,7 +25,7 @@
         "xcode": "^3.0.1"
       },
       "peerDependencies": {
-        "customerio-reactnative": "^2.0.0-beta.1"
+        "customerio-reactnative": "^2.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -8446,9 +8446,9 @@
       "dev": true
     },
     "node_modules/customerio-reactnative": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-2.0.0-beta.1.tgz",
-      "integrity": "sha512-szI+p91v/3ouzzvakH39dIPFY6fBy2ZRvvKF2BKZacC0Y5N5Yq3CwbhB43XLYtjWfMyWf/lIa2SC60FYhpPL/g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-2.2.0.tgz",
+      "integrity": "sha512-wwzG4kQkcqFe0DiOa9udkyEqYn039qqeWduikM6loKFuAMYASkJqq19yLeec7eyjcz1OWROQ/IsjPLubtiH7Uw==",
       "hasInstallScript": true,
       "peer": true,
       "peerDependencies": {
@@ -31365,9 +31365,9 @@
       "dev": true
     },
     "customerio-reactnative": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-2.0.0-beta.1.tgz",
-      "integrity": "sha512-szI+p91v/3ouzzvakH39dIPFY6fBy2ZRvvKF2BKZacC0Y5N5Yq3CwbhB43XLYtjWfMyWf/lIa2SC60FYhpPL/g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-2.2.0.tgz",
+      "integrity": "sha512-wwzG4kQkcqFe0DiOa9udkyEqYn039qqeWduikM6loKFuAMYASkJqq19yLeec7eyjcz1OWROQ/IsjPLubtiH7Uw==",
       "peer": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "customerio-reactnative": "^2.0.0-beta.1"
+    "customerio-reactnative": "^2.0.0"
   },
   "devDependencies": {
     "@expo/config-plugins": "^4.1.4",

--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -1,6 +1,6 @@
 export const LOCAL_PATH_TO_CIO_NSE_FILES = `./node_modules/customerio-expo-plugin/src/helpers/native-files/ios`;
 export const IOS_DEPLOYMENT_TARGET = '13.0';
-export const CIO_SDK_VERSION = "'>= 2.0.0', '< 3.0'";
+export const CIO_SDK_VERSION = "'~> 2.0'";
 export const CIO_PODFILE_REGEX = /pod 'CustomerIO\/MessagingPushAPN'/;
 export const CIO_CIO_TARGET_REGEX = /cio_target_names/;
 export const CIO_PODFILE_NOTIFICATION_REGEX = /target 'NotificationService' do/;

--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -1,6 +1,6 @@
 export const LOCAL_PATH_TO_CIO_NSE_FILES = `./node_modules/customerio-expo-plugin/src/helpers/native-files/ios`;
 export const IOS_DEPLOYMENT_TARGET = '13.0';
-export const CIO_SDK_VERSION = '~> 2.0.0';
+export const CIO_SDK_VERSION = "'>= 2.0.0', '< 3.0'";
 export const CIO_PODFILE_REGEX = /pod 'CustomerIO\/MessagingPushAPN'/;
 export const CIO_CIO_TARGET_REGEX = /cio_target_names/;
 export const CIO_PODFILE_NOTIFICATION_REGEX = /target 'NotificationService' do/;
@@ -64,7 +64,7 @@ export const CIO_WILLPRESENTNOTIFICATIONHANDLER_SNIPPET = `
 - (void)userNotificationCenter:(UNUserNotificationCenter* )center willPresentNotification:(UNNotification* )notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler {
   completionHandler( UNNotificationPresentationOptionAlert + UNNotificationPresentationOptionSound);
 }`;
-export const CIO_PODFILE_SNIPPET = `  pod 'CustomerIO/MessagingPushAPN', '${CIO_SDK_VERSION}'`;
+export const CIO_PODFILE_SNIPPET = `  pod 'CustomerIO/MessagingPushAPN', ${CIO_SDK_VERSION}`;
 export const CIO_PODFILE_NOTIFICATION_SNIPPET = `
 target '${CIO_NOTIFICATION_TARGET_NAME}' do
 ${CIO_PODFILE_SNIPPET}

--- a/src/ios/withAppDelegateModifications.ts
+++ b/src/ios/withAppDelegateModifications.ts
@@ -146,7 +146,7 @@ export const withAppDelegateModifications: ConfigPlugin<
 
       // any other value would be treated as true, it has to be explicitly false to disable
       if (
-        typeof props.disableNotificationRegistration !== 'undefined' &&
+        props.disableNotificationRegistration !== undefined &&
         props.disableNotificationRegistration === false
       ) {
         stringContents = addNotificationConfiguration(stringContents);

--- a/src/ios/withAppDelegateModifications.ts
+++ b/src/ios/withAppDelegateModifications.ts
@@ -143,7 +143,9 @@ export const withAppDelegateModifications: ConfigPlugin<
         config.modRequest.projectName as string
       );
       stringContents = addNotificationHandlerDeclaration(stringContents);
-      if (!props.disableNotificationRegistration) {
+
+      // any other value would be treated as true, it has to be explicitly false to disable
+      if (props.disableNotificationRegistration === false) {
         stringContents = addNotificationConfiguration(stringContents);
       }
       stringContents = addAdditionalMethodsForPushNotifications(stringContents);

--- a/src/ios/withAppDelegateModifications.ts
+++ b/src/ios/withAppDelegateModifications.ts
@@ -145,7 +145,10 @@ export const withAppDelegateModifications: ConfigPlugin<
       stringContents = addNotificationHandlerDeclaration(stringContents);
 
       // any other value would be treated as true, it has to be explicitly false to disable
-      if (props.disableNotificationRegistration === false) {
+      if (
+        typeof props.disableNotificationRegistration !== 'undefined' &&
+        props.disableNotificationRegistration === false
+      ) {
         stringContents = addNotificationConfiguration(stringContents);
       }
       stringContents = addAdditionalMethodsForPushNotifications(stringContents);

--- a/src/ios/withNotificationsXcodeProject.ts
+++ b/src/ios/withNotificationsXcodeProject.ts
@@ -367,7 +367,10 @@ const updatePushFile = (
   let envFileContent = FileManagement.readFile(envFileName);
 
   let snippet = '';
-  if (!options.disableNotificationRegistration) {
+  if (
+    options.disableNotificationRegistration !== undefined &&
+    options.disableNotificationRegistration === false
+  ) {
     snippet = CIO_REGISTER_PUSHNOTIFICATION_SNIPPET;
   }
 


### PR DESCRIPTION
Resolves: https://github.com/customerio/issues/issues/8792

This adds support for iOS SDk v2 only.

## QA Instructions
- Create a new Expo project or use an existing one
- install Expo plugin on this branch
- install the latest RN SDK
- run `expo prebuild --clean`
- install older versions of RN SDK and run `expo prebuild --clean` for each version
- also set `ios.disableNotificationRegistration` to `true` and then `false` and also leave it out

## Expected Result
Prebuild should only be successful only on RN SDK with iOS SDK v2 or higher.
RN SDK with iOS SDK lower than v2 should throw an error relating to dependencies.
The code for registering push notification should only be added when `ios.disableNotificationRegistration` is set to `false`