### PR TITLE
fix: expo-notifications compatibility with customerio-expo-plugin

### DIFF
--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -47,6 +47,11 @@ export const CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_SNIPPET = `
   return [pnHandlerObj application:application deviceToken:deviceToken];
 `;
 
+export const CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_EXPO_SUPPORT_SNIPPET = `
+  [super application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken]
+  return [pnHandlerObj application:application deviceToken:deviceToken];
+`;
+
 export const CIO_CONFIGURECIOSDKPUSHNOTIFICATION_SNIPPET = `
   // Register for push notifications
   [pnHandlerObj registerPushNotification:self];

--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -40,6 +40,7 @@ CIOAppPushNotificationsHandler* pnHandlerObj = [[CIOAppPushNotificationsHandler 
 `;
 
 export const CIO_DIDFAILTOREGISTERFORREMOTENOTIFICATIONSWITHERROR_SNIPPET = `
+  [super application:application didFailToRegisterForRemoteNotificationsWithError:error];
   [pnHandlerObj application:application error:error];
 `;
 

--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -44,10 +44,6 @@ export const CIO_DIDFAILTOREGISTERFORREMOTENOTIFICATIONSWITHERROR_SNIPPET = `
 `;
 
 export const CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_SNIPPET = `
-  return [pnHandlerObj application:application deviceToken:deviceToken];
-`;
-
-export const CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_EXPO_SUPPORT_SNIPPET = `
   [super application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken]
   return [pnHandlerObj application:application deviceToken:deviceToken];
 `;

--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -45,7 +45,7 @@ export const CIO_DIDFAILTOREGISTERFORREMOTENOTIFICATIONSWITHERROR_SNIPPET = `
 `;
 
 export const CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_SNIPPET = `
-  [super application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken]
+  [super application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
   return [pnHandlerObj application:application deviceToken:deviceToken];
 `;
 

--- a/src/ios/withAppDelegateModifications.ts
+++ b/src/ios/withAppDelegateModifications.ts
@@ -11,6 +11,7 @@ import {
   CIO_DIDFAILTOREGISTERFORREMOTENOTIFICATIONSWITHERROR_SNIPPET,
   CIO_DIDFINISHLAUNCHINGMETHOD_REGEX,
   CIO_DIDRECEIVENOTIFICATIONRESPONSEHANDLER_SNIPPET,
+  CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_EXPO_SUPPORT_SNIPPET,
   CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_REGEX,
   CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_SNIPPET,
   CIO_PUSHNOTIFICATIONHANDLERDECLARATION_SNIPPET,
@@ -88,13 +89,25 @@ const addDidFailToRegisterForRemoteNotificationsWithError = (
   return stringContents;
 };
 
-const AddDidRegisterForRemoteNotificationsWithDeviceToken = (
+const addDidRegisterForRemoteNotificationsWithDeviceToken = (
   stringContents: string
 ) => {
   stringContents = injectCodeByMultiLineRegexAndReplaceLine(
     stringContents,
     CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_REGEX,
     CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_SNIPPET
+  );
+
+  return stringContents;
+};
+
+const addDidRegisterForRemoteNotificationsWithDeviceTokenWithExpoSupport = (
+  stringContents: string
+) => {
+  stringContents = injectCodeByMultiLineRegexAndReplaceLine(
+    stringContents,
+    CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_REGEX,
+    CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_EXPO_SUPPORT_SNIPPET
   );
 
   return stringContents;
@@ -150,12 +163,17 @@ export const withAppDelegateModifications: ConfigPlugin<
         props.disableNotificationRegistration === false
       ) {
         stringContents = addNotificationConfiguration(stringContents);
+        stringContents =
+          addDidRegisterForRemoteNotificationsWithDeviceTokenWithExpoSupport(
+            stringContents
+          );
+      } else {
+        stringContents =
+          addDidRegisterForRemoteNotificationsWithDeviceToken(stringContents);
       }
       stringContents = addAdditionalMethodsForPushNotifications(stringContents);
       stringContents =
         addDidFailToRegisterForRemoteNotificationsWithError(stringContents);
-      stringContents =
-        AddDidRegisterForRemoteNotificationsWithDeviceToken(stringContents);
 
       config.modResults.contents = stringContents;
     } else {

--- a/src/ios/withAppDelegateModifications.ts
+++ b/src/ios/withAppDelegateModifications.ts
@@ -11,7 +11,6 @@ import {
   CIO_DIDFAILTOREGISTERFORREMOTENOTIFICATIONSWITHERROR_SNIPPET,
   CIO_DIDFINISHLAUNCHINGMETHOD_REGEX,
   CIO_DIDRECEIVENOTIFICATIONRESPONSEHANDLER_SNIPPET,
-  CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_EXPO_SUPPORT_SNIPPET,
   CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_REGEX,
   CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_SNIPPET,
   CIO_PUSHNOTIFICATIONHANDLERDECLARATION_SNIPPET,
@@ -101,18 +100,6 @@ const addDidRegisterForRemoteNotificationsWithDeviceToken = (
   return stringContents;
 };
 
-const addDidRegisterForRemoteNotificationsWithDeviceTokenWithExpoSupport = (
-  stringContents: string
-) => {
-  stringContents = injectCodeByMultiLineRegexAndReplaceLine(
-    stringContents,
-    CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_REGEX,
-    CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_EXPO_SUPPORT_SNIPPET
-  );
-
-  return stringContents;
-};
-
 const addAdditionalMethodsForPushNotifications = (stringContents: string) => {
   stringContents = injectCodeByMultiLineRegex(
     stringContents,
@@ -163,17 +150,12 @@ export const withAppDelegateModifications: ConfigPlugin<
         props.disableNotificationRegistration === false
       ) {
         stringContents = addNotificationConfiguration(stringContents);
-        stringContents =
-          addDidRegisterForRemoteNotificationsWithDeviceTokenWithExpoSupport(
-            stringContents
-          );
-      } else {
-        stringContents =
-          addDidRegisterForRemoteNotificationsWithDeviceToken(stringContents);
       }
       stringContents = addAdditionalMethodsForPushNotifications(stringContents);
       stringContents =
         addDidFailToRegisterForRemoteNotificationsWithError(stringContents);
+      stringContents =
+        addDidRegisterForRemoteNotificationsWithDeviceToken(stringContents);
 
       config.modResults.contents = stringContents;
     } else {


### PR DESCRIPTION
Resolves: https://github.com/customerio/opsbugs/issues/3389

Solution:
Call the following in `didRegisterForRemoteNotificationsWithDeviceToken` delegate method.
[super application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken]

Example:
```
- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
{
  [super application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken]
  return [pnHandlerObj application:application deviceToken:deviceToken];
}

```
