### PR TITLE
fix: initialize cio sdk in appdelegate

### DIFF
--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -65,6 +65,11 @@ export const CIO_DIDRECEIVENOTIFICATIONRESPONSEHANDLER_SNIPPET = `
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void(^)(void))completionHandler {
   [pnHandlerObj userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
 }`;
+// Initialize Customer.io iOS SDK
+export const CIO_INITIALIZECIOSDK_SNIPPET = `
+  // Initialize Customer.io SDK
+  [pnHandlerObj initializeCioSdk];
+`;
 
 // Foreground push handling
 export const CIO_WILLPRESENTNOTIFICATIONHANDLER_SNIPPET = `

--- a/src/helpers/native-files/ios/PushService.swift
+++ b/src/helpers/native-files/ios/PushService.swift
@@ -6,30 +6,34 @@ import UIKit
 
 @objc
 public class CIOAppPushNotificationsHandler : NSObject {
-
-  public override init() {}
-
-  {{REGISTER_SNIPPET}}
-
-  @objc(application:deviceToken:)
-  public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-    MessagingPush.shared.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
-  }
-
-  @objc(application:error:)
-  public func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-    MessagingPush.shared.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
-  }
-
-  @objc(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:)
-  public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-    let handled = MessagingPush.shared.userNotificationCenter(center, didReceive: response,
-  withCompletionHandler: completionHandler)
-
-    // If the Customer.io SDK does not handle the push, it's up to you to handle it and call the
-    // completion handler. If the SDK did handle it, it called the completion handler for you.
-    if !handled {
-      completionHandler()
+    
+    public override init() {}
+    
+    {{REGISTER_SNIPPET}}
+    
+    @objc(initializeCioSdk)
+    public func initializeCioSdk() {
+        CustomerIO.initialize(siteId: Env.customerIOSiteId, apiKey: Env.customerIOApiKey, region: Env.customerIORegion, configure: nil)
     }
-  }
+    @objc(application:deviceToken:)
+    public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        MessagingPush.shared.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+    }
+    
+    @objc(application:error:)
+    public func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        MessagingPush.shared.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+    }
+    
+    @objc(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:)
+    public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        let handled = MessagingPush.shared.userNotificationCenter(center, didReceive: response,
+                                                                  withCompletionHandler: completionHandler)
+        
+        // If the Customer.io SDK does not handle the push, it's up to you to handle it and call the
+        // completion handler. If the SDK did handle it, it called the completion handler for you.
+        if !handled {
+            completionHandler()
+        }
+    }
 }

--- a/src/ios/withAppDelegateModifications.ts
+++ b/src/ios/withAppDelegateModifications.ts
@@ -15,6 +15,7 @@ import {
   CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_SNIPPET,
   CIO_PUSHNOTIFICATIONHANDLERDECLARATION_SNIPPET,
   CIO_WILLPRESENTNOTIFICATIONHANDLER_SNIPPET,
+  CIO_INITIALIZECIOSDK_SNIPPET,
 } from '../helpers/constants/ios';
 import {
   injectCodeByLineNumber,
@@ -73,6 +74,15 @@ const addNotificationConfiguration = (stringContents: string) => {
     CIO_CONFIGURECIOSDKPUSHNOTIFICATION_SNIPPET
   );
 
+  return stringContents;
+};
+
+const addCioSdkInitialization = (stringContents: string) => {
+  stringContents = injectCodeByMultiLineRegex(
+    stringContents,
+    CIO_DIDFINISHLAUNCHINGMETHOD_REGEX,
+    CIO_INITIALIZECIOSDK_SNIPPET
+  );
   return stringContents;
 };
 
@@ -151,6 +161,7 @@ export const withAppDelegateModifications: ConfigPlugin<
       ) {
         stringContents = addNotificationConfiguration(stringContents);
       }
+      stringContents = addCioSdkInitialization(stringContents);
       stringContents = addAdditionalMethodsForPushNotifications(stringContents);
       stringContents =
         addDidFailToRegisterForRemoteNotificationsWithError(stringContents);


### PR DESCRIPTION
closes https://github.com/customerio/issues/issues/10611

This pull request adds the initialization of the Customer.io SDK in the `didFinishLaunchingWithOptions` method of AppDelegate. This [resolves an issue](https://github.com/customerio/issues/issues/10195) where push notification [metric tracking was failing](https://github.com/customerio/issues/issues/10195#issuecomment-1610074816) because the SDK was not properly initialized. 

### DO NOT MERGE THIS PR. STILL IN QA.
