### PR TITLE
fix: path fix for monorepo support

### DIFF
--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -15,6 +15,11 @@ export const LOCAL_PATH_TO_CIO_NSE_FILES = path.join(
   pluginPackageRoot,
   'src/helpers/native-files/ios'
 );
+
+export function getRelativePathToRNSDK(currentFile: string) {
+  return path.relative(path.dirname(currentFile), LOCAL_PATH_TO_RN_SDK);
+}
+
 export const IOS_DEPLOYMENT_TARGET = '13.0';
 export const GROUP_IDENTIFIER_TEMPLATE_REGEX = /{{GROUP_IDENTIFIER}}/gm;
 export const BUNDLE_SHORT_VERSION_TEMPLATE_REGEX = /{{BUNDLE_SHORT_VERSION}}/gm;

--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -6,6 +6,11 @@ let pluginPackageRoot = f.next().filename;
 // This is the path to the root of the customerio-expo-plugin package
 pluginPackageRoot = path.dirname(pluginPackageRoot);
 
+export const LOCAL_PATH_TO_RN_SDK = path.join(
+  pluginPackageRoot,
+  '../customerio-reactnative'
+)
+
 export const LOCAL_PATH_TO_CIO_NSE_FILES = path.join(
   pluginPackageRoot,
   'src/helpers/native-files/ios'

--- a/src/helpers/utils/injectCIOPodfileCode.ts
+++ b/src/helpers/utils/injectCIOPodfileCode.ts
@@ -1,5 +1,5 @@
 import type { CustomerIOPluginOptionsIOS } from '../../types/cio-types';
-import { LOCAL_PATH_TO_RN_SDK } from '../constants/ios';
+import { getRelativePathToRNSDK } from '../constants/ios';
 import { injectCodeByRegex } from './codeInjection';
 import { FileManagement } from './fileManagement';
 
@@ -19,7 +19,7 @@ export async function injectCIOPodfileCode(iosPath: string) {
 
     const snippetToInjectInPodfile = `
 ${blockStart}
-  pod 'customerio-reactnative/apn', :path => '${LOCAL_PATH_TO_RN_SDK}'
+  pod 'customerio-reactnative/apn', :path => '${getRelativePathToRNSDK(filename)}'
 ${blockEnd}
 `.trim();
 
@@ -53,7 +53,7 @@ export async function injectCIONotificationPodfileCode(
 ${blockStart}
 target 'NotificationService' do
   ${useFrameworks === 'static' ? 'use_frameworks! :linkage => :static' : ''}
-  pod 'customerio-reactnative-richpush/apn', :path => '${LOCAL_PATH_TO_RN_SDK}'
+  pod 'customerio-reactnative-richpush/apn', :path => '${getRelativePathToRNSDK(filename)}'
 end
 ${blockEnd}
 `.trim();

--- a/src/helpers/utils/injectCIOPodfileCode.ts
+++ b/src/helpers/utils/injectCIOPodfileCode.ts
@@ -1,4 +1,5 @@
 import type { CustomerIOPluginOptionsIOS } from '../../types/cio-types';
+import { LOCAL_PATH_TO_RN_SDK } from '../constants/ios';
 import { injectCodeByRegex } from './codeInjection';
 import { FileManagement } from './fileManagement';
 
@@ -18,7 +19,7 @@ export async function injectCIOPodfileCode(iosPath: string) {
 
     const snippetToInjectInPodfile = `
 ${blockStart}
-  pod 'customerio-reactnative/apn', :path => '../node_modules/customerio-reactnative'
+  pod 'customerio-reactnative/apn', :path => '${LOCAL_PATH_TO_RN_SDK}'
 ${blockEnd}
 `.trim();
 
@@ -52,7 +53,7 @@ export async function injectCIONotificationPodfileCode(
 ${blockStart}
 target 'NotificationService' do
   ${useFrameworks === 'static' ? 'use_frameworks! :linkage => :static' : ''}
-  pod 'customerio-reactnative-richpush/apn', :path => '../node_modules/customerio-reactnative'
+  pod 'customerio-reactnative-richpush/apn', :path => '${LOCAL_PATH_TO_RN_SDK}'
 end
 ${blockEnd}
 `.trim();


### PR DESCRIPTION
Resolves: https://github.com/customerio/customerio-expo-plugin/issues/89
### Changes
- Added a function to evaluate the relative path to React Native SDK from ios folder