### PR TITLE
feat: added setting notification center delegate as configurable property

### DIFF
--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -54,7 +54,7 @@ export const CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_SNIPPET = `
 
 export const CIO_CONFIGURECIOSDKPUSHNOTIFICATION_SNIPPET = `
   // Register for push notifications
-  [pnHandlerObj registerPushNotification:self];
+  [pnHandlerObj registerPushNotification];
 `;
 
 export const CIO_CONFIGURECIOSDKUSERNOTIFICATIONCENTER_SNIPPET = `
@@ -75,11 +75,10 @@ export const CIO_WILLPRESENTNOTIFICATIONHANDLER_SNIPPET = `
   completionHandler( UNNotificationPresentationOptionAlert + UNNotificationPresentationOptionSound);
 }`;
 export const CIO_REGISTER_PUSHNOTIFICATION_SNIPPET = `
-@objc(registerPushNotification:)
-  public func registerPushNotification(withNotificationDelegate notificationDelegate: UNUserNotificationCenterDelegate) {
+@objc(registerPushNotification)
+  public func registerPushNotification() {
 
     let center  = UNUserNotificationCenter.current()
-    center.delegate = notificationDelegate
     center.requestAuthorization(options: [.sound, .alert, .badge]) { (granted, error) in
       if error == nil{
         DispatchQueue.main.async {

--- a/src/ios/withAppDelegateModifications.ts
+++ b/src/ios/withAppDelegateModifications.ts
@@ -179,7 +179,12 @@ export const withAppDelegateModifications: ConfigPlugin<
       ) {
         stringContents = addNotificationConfiguration(stringContents);
       }
-      stringContents = addUserNotificationCenterConfiguration(stringContents);
+      if (
+        props.disableNotificationCenter !== undefined &&
+        props.disableNotificationCenter === false
+      ) {
+        stringContents = addUserNotificationCenterConfiguration(stringContents);
+      }
       stringContents = addAdditionalMethodsForPushNotifications(stringContents);
       stringContents =
         addDidFailToRegisterForRemoteNotificationsWithError(stringContents);

--- a/src/types/cio-types.ts
+++ b/src/types/cio-types.ts
@@ -16,6 +16,7 @@ export type CustomerIOPluginOptionsIOS = {
   appleTeamId?: string;
   appName?: string;
   disableNotificationRegistration?: boolean;
+  disableNotificationCenter?:boolean;
   useFrameworks?: 'static' | 'dynamic';
   pushNotification?: {
     useRichPush: boolean;


### PR DESCRIPTION
closes : https://github.com/customerio/issues/issues/10367

Customers reported that they are able to get push notification only in background and that the deeplinks do not work when the app is in killed state. With this feature fix, we are letting the user set `UNUserNotificationCenter` delegate as a configurable property i.e. `disableNotificationCenter`. 

Default value of `disableNotificationCenter` is `true`.

The code snippet to set delegate for `UNUserNotificationCenter` has been made a configurable property so that the customers using `expo-notification` may prevent adding this snippet as it conflicts with the library.

This PR has been Dev tested.