### PR TITLE
chore: set pr limit for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      github-action-dependencies:
+        patterns:
+        - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1
     reviewers:
       - "customerio/mobile"
     commit-message:


### PR DESCRIPTION
## Summary

This PR modifies our Dependabot configuration to combine updates into a single pull request(hopefully). 
By setting the `open-pull-requests-limit` to 1, we hope that Dependabot will batch multiple updates together, helping to reduce the number of PRs we need to review and merge. 