### PR TITLE
ci: remove workaround for semantic-release issue skipping deployment

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -27,7 +27,6 @@ jobs:
         id: semantic-release
         with:
           # version numbers below can be in many forms: M, M.m, M.m.p
-          semantic_version: 19
           extra_plugins: |
             conventional-changelog-conventionalcommits@4
             @semantic-release/changelog@6

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           # version numbers below can be in many forms: M, M.m, M.m.p
           extra_plugins: |
-            conventional-changelog-conventionalcommits@4
+            conventional-changelog-conventionalcommits
             @semantic-release/changelog
             @semantic-release/git
             @semantic-release/github

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -29,10 +29,10 @@ jobs:
           # version numbers below can be in many forms: M, M.m, M.m.p
           extra_plugins: |
             conventional-changelog-conventionalcommits@4
-            @semantic-release/changelog@6
-            @semantic-release/git@10
-            @semantic-release/github@8
-            @semantic-release/exec@6
+            @semantic-release/changelog
+            @semantic-release/git
+            @semantic-release/github
+            @semantic-release/exec
         env:
           # Needs to push git commits to repo. Needs write access.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
semantic-release has fixed the conventional-commits issue in v22. Therefore, we can remove the workaround from our CI configurations and use the latest version of semantic-release for deployments. 

This PR updates the CI config to have the latest version of semantic-release. 