### PR TITLE
feat: automatically handle push click events and increase compatibility with 3rd party push modules

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -27,13 +27,12 @@ jobs:
         id: semantic-release
         with:
           # version numbers below can be in many forms: M, M.m, M.m.p
-          semantic_version: 19
           extra_plugins: |
-            conventional-changelog-conventionalcommits@4
-            @semantic-release/changelog@6
-            @semantic-release/git@10
-            @semantic-release/github@8
-            @semantic-release/exec@6
+            conventional-changelog-conventionalcommits
+            @semantic-release/changelog
+            @semantic-release/git
+            @semantic-release/github
+            @semantic-release/exec
         env:
           # Needs to push git commits to repo. Needs write access.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -126,7 +126,7 @@ jobs:
           ref: ${{ needs.deploy-git-tag.outputs.new_release_git_head }}
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '20'
       - run: npm ci
 
       - name: Deploy to npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '20'
       - run: npm ci
 
       - name: Compile

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-expo-plugin",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-expo-plugin",
-      "version": "1.0.0-beta.10",
+      "version": "1.0.0-beta.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -28,7 +28,7 @@
         "xcode": "^3.0.1"
       },
       "peerDependencies": {
-        "customerio-reactnative": "^3.0.0"
+        "customerio-reactnative": ">=3.4.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -9324,9 +9324,9 @@
       "dev": true
     },
     "node_modules/customerio-reactnative": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-3.0.0.tgz",
-      "integrity": "sha512-x5Ys2CRUQkNeqMfjmalM9sde9W8YLztXojjMiAKhDcvCHEZN3YhjmkDAxGJqoCjVHtvuOZzas8GCdnHf+npehg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-3.4.0.tgz",
+      "integrity": "sha512-N+n8nbuqioxEDaLXY4JUI4nnuMEYUhwJUHvHaXYx4Hjynz8w5G3ZIVGzlcO5vAjh1qM++CVDwOm8OuQrxERZiA==",
       "hasInstallScript": true,
       "peer": true,
       "peerDependencies": {
@@ -33825,9 +33825,9 @@
       "dev": true
     },
     "customerio-reactnative": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-3.0.0.tgz",
-      "integrity": "sha512-x5Ys2CRUQkNeqMfjmalM9sde9W8YLztXojjMiAKhDcvCHEZN3YhjmkDAxGJqoCjVHtvuOZzas8GCdnHf+npehg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-3.4.0.tgz",
+      "integrity": "sha512-N+n8nbuqioxEDaLXY4JUI4nnuMEYUhwJUHvHaXYx4Hjynz8w5G3ZIVGzlcO5vAjh1qM++CVDwOm8OuQrxERZiA==",
       "peer": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "customerio-reactnative": ">=3.X.Y"
+    "customerio-reactnative": ">=3.4.0"
   },
   "devDependencies": {
     "@expo/config-plugins": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "customerio-reactnative": "^3.0.0"
+    "customerio-reactnative": ">=3.X.Y"
   },
   "devDependencies": {
     "@expo/config-plugins": "^4.1.4",

--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -85,9 +85,7 @@ export const CIO_CONFIGURECIOSDKPUSHNOTIFICATION_SNIPPET = `
 
 export const CIO_INITIALIZECIOSDK_SNIPPET = `  
   [pnHandlerObj initializeCioSdk];
-`;
 
-export const CIO_CONFIGURECIOSDKUSERNOTIFICATIONCENTER_SNIPPET = `
 // Code to make the CIO SDK compatible with expo-notifications package.
 // 
 // The CIO SDK and expo-notifications both need to handle when a push gets clicked. However, iOS only allows one click handler to be set per app.

--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -9,7 +9,7 @@ pluginPackageRoot = path.dirname(pluginPackageRoot);
 export const LOCAL_PATH_TO_RN_SDK = path.join(
   pluginPackageRoot,
   '../customerio-reactnative'
-)
+);
 
 export const LOCAL_PATH_TO_CIO_NSE_FILES = path.join(
   pluginPackageRoot,
@@ -42,20 +42,22 @@ export const CIO_APPDELEGATEDECLARATION_REGEX =
 export const CIO_APPDELEGATEHEADER_REGEX =
   /(@interface AppDelegate\s*:\s*EXAppDelegateWrapper\s*)(<([^>]+)>)?/;
 
-export const CIO_RCTBRIDGE_DEEPLINK_MODIFIEDOPTIONS_REGEX = 
-/^\s*RCTBridge\s*\*\s*\w+\s*=\s*\[\s*self\.reactDelegate\s+createBridgeWithDelegate:self\s+launchOptions:launchOptions\s*\];\s*$/gm;
+export const CIO_RCTBRIDGE_DEEPLINK_MODIFIEDOPTIONS_REGEX =
+  /^\s*RCTBridge\s*\*\s*\w+\s*=\s*\[\s*self\.reactDelegate\s+createBridgeWithDelegate:self\s+launchOptions:launchOptions\s*\];\s*$/gm;
 
-export const CIO_LAUNCHOPTIONS_DEEPLINK_MODIFIEDOPTIONS_REGEX = 
-/^\s*return\s\[\s*super\s*application:\s*application\s*didFinishLaunchingWithOptions\s*:\s*launchOptions\s*\];/gm;
+export const CIO_LAUNCHOPTIONS_DEEPLINK_MODIFIEDOPTIONS_REGEX =
+  /^\s*return\s\[\s*super\s*application:\s*application\s*didFinishLaunchingWithOptions\s*:\s*launchOptions\s*\];/gm;
 
-export const CIO_DEEPLINK_COMMENT_REGEX = /\sDeep link workaround for app killed state start/gm;
+export const CIO_DEEPLINK_COMMENT_REGEX =
+  /\sDeep link workaround for app killed state start/gm;
 export const DEFAULT_BUNDLE_VERSION = '1';
 export const DEFAULT_BUNDLE_SHORT_VERSION = '1.0';
 export const CIO_TARGET_NAME = 'CustomerIOSDK';
 export const CIO_NOTIFICATION_TARGET_NAME = 'NotificationService';
 
 export const CIO_APPDELEGATEHEADER_IMPORT_SNIPPET = `#import <UserNotifications/UserNotifications.h>`;
-export const CIO_APPDELEGATEHEADER_USER_NOTIFICATION_CENTER_SNIPPET = 'UNUserNotificationCenterDelegate';
+export const CIO_APPDELEGATEHEADER_USER_NOTIFICATION_CENTER_SNIPPET =
+  'UNUserNotificationCenterDelegate';
 export const CIO_PUSHNOTIFICATIONHANDLERDECLARATION_SNIPPET = `
 CIOAppPushNotificationsHandler* pnHandlerObj = [[CIOAppPushNotificationsHandler alloc] init];
 `;
@@ -64,7 +66,7 @@ RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOpti
 `;
 
 export const CIO_LAUNCHOPTIONS_MODIFIEDOPTIONS_SNIPPET = `
-return [super application:application didFinishLaunchingWithOptions:modifiedLaunchOptions];`
+return [super application:application didFinishLaunchingWithOptions:modifiedLaunchOptions];`;
 
 export const CIO_DIDFAILTOREGISTERFORREMOTENOTIFICATIONSWITHERROR_SNIPPET = `
   [super application:application didFailToRegisterForRemoteNotificationsWithError:error];
@@ -82,8 +84,15 @@ export const CIO_CONFIGURECIOSDKPUSHNOTIFICATION_SNIPPET = `
 `;
 
 export const CIO_CONFIGURECIOSDKUSERNOTIFICATIONCENTER_SNIPPET = `
+[pnHandlerObj setupCioClickHandler];
+
+// Be compatible with expo-notifications package by manually setting it as the delegate since the CIO SDK already set it. 
+#if __has_include(<EXNotifications/EXNotificationCenterDelegate.h>)
+  id<UNUserNotificationCenterDelegate> notificationCenterDelegate = (id<UNUserNotificationCenterDelegate>) [EXModuleRegistryProvider getSingletonModuleForClass:[EXNotificationCenterDelegate class]];
+
   UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-  center.delegate = self;
+  center.delegate = notificationCenterDelegate;
+#endif
 `;
 
 export const CIO_CONFIGUREDEEPLINK_KILLEDSTATE_SNIPPET = `

--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -83,16 +83,23 @@ export const CIO_CONFIGURECIOSDKPUSHNOTIFICATION_SNIPPET = `
   [pnHandlerObj registerPushNotification];
 `;
 
+export const CIO_INITIALIZECIOSDK_SNIPPET = `  
+  [pnHandlerObj initializeCioSdk];
+`;
+
 export const CIO_CONFIGURECIOSDKUSERNOTIFICATIONCENTER_SNIPPET = `
-[pnHandlerObj setupCioClickHandler];
+// Be compatible with expo-notifications package by manually setting it as the click handler after the CIO SDK sets itself as the click handler. 
+// expo-notifications will not set itself as click handler if it detects a click handler is already set in the app. So, it must be done manually. 
+# if __has_include(<EXNotifications/EXNotificationCenterDelegate.h>)
+  // Creating a new instance, as the comments in expo-notifications suggests, does not work. With this code, if you send a CIO push to device and click on it,
+  // no push metrics reporting will occur.
+  // EXNotificationCenterDelegate *notificationCenterDelegate = [[EXNotificationCenterDelegate alloc] init];
 
-// Be compatible with expo-notifications package by manually setting it as the delegate since the CIO SDK already set it. 
-#if __has_include(<EXNotifications/EXNotificationCenterDelegate.h>)
+  // ...instead, get the singleton reference from Expo. 
   id<UNUserNotificationCenterDelegate> notificationCenterDelegate = (id<UNUserNotificationCenterDelegate>) [EXModuleRegistryProvider getSingletonModuleForClass:[EXNotificationCenterDelegate class]];
-
   UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
   center.delegate = notificationCenterDelegate;
-#endif
+# endif
 `;
 
 export const CIO_CONFIGUREDEEPLINK_KILLEDSTATE_SNIPPET = `
@@ -110,18 +117,6 @@ NSMutableDictionary *modifiedLaunchOptions = [NSMutableDictionary dictionaryWith
 //Deep link workaround for app killed state ends
 `;
 
-// Enable push handling - notification response
-export const CIO_DIDRECEIVENOTIFICATIONRESPONSEHANDLER_SNIPPET = `
-- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void(^)(void))completionHandler {
-  [pnHandlerObj userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
-}`;
-
-// Foreground push handling
-export const CIO_WILLPRESENTNOTIFICATIONHANDLER_SNIPPET = `
-// show push when the app is in foreground
-- (void)userNotificationCenter:(UNUserNotificationCenter* )center willPresentNotification:(UNNotification* )notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler {
-  completionHandler( UNNotificationPresentationOptionAlert + UNNotificationPresentationOptionSound);
-}`;
 export const CIO_REGISTER_PUSHNOTIFICATION_SNIPPET = `
 @objc(registerPushNotification)
   public func registerPushNotification() {

--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -88,8 +88,19 @@ export const CIO_INITIALIZECIOSDK_SNIPPET = `
 `;
 
 export const CIO_CONFIGURECIOSDKUSERNOTIFICATIONCENTER_SNIPPET = `
-// Be compatible with expo-notifications package by manually setting it as the click handler after the CIO SDK sets itself as the click handler. 
-// expo-notifications will not set itself as click handler if it detects a click handler is already set in the app. So, it must be done manually. 
+// Code to make the CIO SDK compatible with expo-notifications package.
+// 
+// The CIO SDK and expo-notifications both need to handle when a push gets clicked. However, iOS only allows one click handler to be set per app.
+// To get around this limitation, we set the CIO SDK as the click handler. The CIO SDK sets itself up so that when another SDK or host iOS app 
+// sets itself as the click handler, the CIO SDK will still be able to handle when the push gets clicked, even though it's not the designated 
+// click handler in iOS at runtime. 
+// 
+// This should work for most SDKs. However, expo-notifications is unique in it's implementation. It will not setup push click handling it if detects 
+// that another SDK or host iOS app has already set itself as the click handler:
+// https://github.com/expo/expo/blob/1b29637bec0b9888e8bc8c310476293a3e2d9786/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m#L31-L37
+// ...to get around this, we must manually set it as the click handler after the CIO SDK. That's what this code block does.
+//
+// Note: Initialize the native iOS SDK and setup SDK push click handling before running this code. 
 # if __has_include(<EXNotifications/EXNotificationCenterDelegate.h>)
   // Creating a new instance, as the comments in expo-notifications suggests, does not work. With this code, if you send a CIO push to device and click on it,
   // no push metrics reporting will occur.

--- a/src/helpers/native-files/ios/PushService.swift
+++ b/src/helpers/native-files/ios/PushService.swift
@@ -13,15 +13,10 @@ public class CIOAppPushNotificationsHandler : NSObject {
 
   @objc(initializeCioSdk)
   public func initializeCioSdk() {
-    let configAutoTrackPushEvents = {{AUTO_TRACK_PUSH_EVENTS}}
-
     CustomerIO.initialize(siteId: "{{SITE_ID}}", apiKey: "{{API_KEY}}", region: .{{REGION}}) { config in
-      config.autoTrackPushEvents = configAutoTrackPushEvents
+      config.autoTrackPushEvents = {{AUTO_TRACK_PUSH_EVENTS}}
     }
-
-    if configAutoTrackPushEvents {
-      MessagingPush.initialize()
-    }
+    MessagingPushAPN.initialize()
   }
 
   @objc(application:deviceToken:)

--- a/src/helpers/native-files/ios/PushService.swift
+++ b/src/helpers/native-files/ios/PushService.swift
@@ -19,9 +19,10 @@ public class CIOAppPushNotificationsHandler : NSObject {
       // This is because after AppDelegate.didFinishLaunching is called, the app will start handling push click events. 
       // Configuring auto track push events after this point will not work.
       config.autoTrackPushEvents = {{AUTO_TRACK_PUSH_EVENTS}}
+    }
+    MessagingPushAPN.initialize { config in
       config.showPushAppInForeground = {{SHOW_PUSH_APP_IN_FOREGROUND}}
     }
-    MessagingPushAPN.initialize()
   }
 
   @objc(application:deviceToken:)

--- a/src/helpers/native-files/ios/PushService.swift
+++ b/src/helpers/native-files/ios/PushService.swift
@@ -11,6 +11,11 @@ public class CIOAppPushNotificationsHandler : NSObject {
 
   {{REGISTER_SNIPPET}}
 
+  @objc(setupCioClickHandler)
+  public func setupCioClickHandler() {
+    MessagingPush.initialize()
+  }
+
   @objc(application:deviceToken:)
   public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
     MessagingPush.shared.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)

--- a/src/helpers/native-files/ios/PushService.swift
+++ b/src/helpers/native-files/ios/PushService.swift
@@ -19,6 +19,7 @@ public class CIOAppPushNotificationsHandler : NSObject {
       // This is because after AppDelegate.didFinishLaunching is called, the app will start handling push click events. 
       // Configuring auto track push events after this point will not work.
       config.autoTrackPushEvents = {{AUTO_TRACK_PUSH_EVENTS}}
+      config.showPushAppInForeground = {{SHOW_PUSH_APP_IN_FOREGROUND}}
     }
     MessagingPushAPN.initialize()
   }

--- a/src/helpers/native-files/ios/PushService.swift
+++ b/src/helpers/native-files/ios/PushService.swift
@@ -13,7 +13,11 @@ public class CIOAppPushNotificationsHandler : NSObject {
 
   @objc(initializeCioSdk)
   public func initializeCioSdk() {
+    // Must initialize Customer.io before initializing MessagingPushAPN. 
     CustomerIO.initialize(siteId: "{{SITE_ID}}", apiKey: "{{API_KEY}}", region: .{{REGION}}) { config in
+      // Must configure auto track push events before initializing MessagingPushAPN. 
+      // This is because after AppDelegate.didFinishLaunching is called, the app will start handling push click events. 
+      // Configuring auto track push events after this point will not work.
       config.autoTrackPushEvents = {{AUTO_TRACK_PUSH_EVENTS}}
     }
     MessagingPushAPN.initialize()

--- a/src/helpers/native-files/ios/PushService.swift
+++ b/src/helpers/native-files/ios/PushService.swift
@@ -11,9 +11,17 @@ public class CIOAppPushNotificationsHandler : NSObject {
 
   {{REGISTER_SNIPPET}}
 
-  @objc(setupCioClickHandler)
-  public func setupCioClickHandler() {
-    MessagingPush.initialize()
+  @objc(initializeCioSdk)
+  public func initializeCioSdk() {
+    let configAutoTrackPushEvents = {{AUTO_TRACK_PUSH_EVENTS}}
+
+    CustomerIO.initialize(siteId: "{{SITE_ID}}", apiKey: "{{API_KEY}}", region: .{{REGION}}) { config in
+      config.autoTrackPushEvents = configAutoTrackPushEvents
+    }
+
+    if configAutoTrackPushEvents {
+      MessagingPush.initialize()
+    }
   }
 
   @objc(application:deviceToken:)
@@ -24,17 +32,5 @@ public class CIOAppPushNotificationsHandler : NSObject {
   @objc(application:error:)
   public func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
     MessagingPush.shared.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
-  }
-
-  @objc(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:)
-  public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-    let handled = MessagingPush.shared.userNotificationCenter(center, didReceive: response,
-  withCompletionHandler: completionHandler)
-
-    // If the Customer.io SDK does not handle the push, it's up to you to handle it and call the
-    // completion handler. If the SDK did handle it, it called the completion handler for you.
-    if !handled {
-      completionHandler()
-    }
   }
 }

--- a/src/helpers/utils/codeInjection.ts
+++ b/src/helpers/utils/codeInjection.ts
@@ -61,5 +61,5 @@ export function injectCodeByLineNumber(
     content = [...lines.slice(0, index), snippet, ...lines.slice(index)];
   }
 
-  return content;
+  return content.join('\n');
 }

--- a/src/helpers/utils/injectCIOPodfileCode.ts
+++ b/src/helpers/utils/injectCIOPodfileCode.ts
@@ -23,9 +23,11 @@ ${blockStart}
     filename
   )}'
 
+  pod 'CustomerIOCommon', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
   pod 'CustomerIOTracking', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
   pod 'CustomerIOMessagingInApp', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
   pod 'CustomerIOMessagingPushAPN', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
+  pod 'CustomerIOMessagingPush', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
 ${blockEnd}
 `.trim();
 
@@ -63,8 +65,10 @@ target 'NotificationService' do
     filename
   )}'
 
+  pod 'CustomerIOCommon', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
   pod 'CustomerIOTracking', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
   pod 'CustomerIOMessagingPushAPN', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
+  pod 'CustomerIOMessagingPush', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
 end
 ${blockEnd}
 `.trim();

--- a/src/helpers/utils/injectCIOPodfileCode.ts
+++ b/src/helpers/utils/injectCIOPodfileCode.ts
@@ -22,12 +22,6 @@ ${blockStart}
   pod 'customerio-reactnative/apn', :path => '${getRelativePathToRNSDK(
     filename
   )}'
-
-  pod 'CustomerIOCommon', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics-prototyping'
-  pod 'CustomerIOTracking', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics-prototyping'
-  pod 'CustomerIOMessagingInApp', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics-prototyping'
-  pod 'CustomerIOMessagingPushAPN', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics-prototyping'
-  pod 'CustomerIOMessagingPush', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics-prototyping'
 ${blockEnd}
 `.trim();
 
@@ -64,11 +58,6 @@ target 'NotificationService' do
   pod 'customerio-reactnative-richpush/apn', :path => '${getRelativePathToRNSDK(
     filename
   )}'
-
-  pod 'CustomerIOCommon', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics-prototyping'
-  pod 'CustomerIOTracking', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics-prototyping'
-  pod 'CustomerIOMessagingPushAPN', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics-prototyping'
-  pod 'CustomerIOMessagingPush', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics-prototyping'
 end
 ${blockEnd}
 `.trim();

--- a/src/helpers/utils/injectCIOPodfileCode.ts
+++ b/src/helpers/utils/injectCIOPodfileCode.ts
@@ -19,7 +19,13 @@ export async function injectCIOPodfileCode(iosPath: string) {
 
     const snippetToInjectInPodfile = `
 ${blockStart}
-  pod 'customerio-reactnative/apn', :path => '${getRelativePathToRNSDK(filename)}'
+  pod 'customerio-reactnative/apn', :path => '${getRelativePathToRNSDK(
+    filename
+  )}'
+
+  pod 'CustomerIOTracking', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
+  pod 'CustomerIOMessagingInApp', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
+  pod 'CustomerIOMessagingPushAPN', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
 ${blockEnd}
 `.trim();
 
@@ -53,7 +59,12 @@ export async function injectCIONotificationPodfileCode(
 ${blockStart}
 target 'NotificationService' do
   ${useFrameworks === 'static' ? 'use_frameworks! :linkage => :static' : ''}
-  pod 'customerio-reactnative-richpush/apn', :path => '${getRelativePathToRNSDK(filename)}'
+  pod 'customerio-reactnative-richpush/apn', :path => '${getRelativePathToRNSDK(
+    filename
+  )}'
+
+  pod 'CustomerIOTracking', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
+  pod 'CustomerIOMessagingPushAPN', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
 end
 ${blockEnd}
 `.trim();

--- a/src/helpers/utils/injectCIOPodfileCode.ts
+++ b/src/helpers/utils/injectCIOPodfileCode.ts
@@ -23,11 +23,11 @@ ${blockStart}
     filename
   )}'
 
-  pod 'CustomerIOCommon', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
-  pod 'CustomerIOTracking', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
-  pod 'CustomerIOMessagingInApp', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
-  pod 'CustomerIOMessagingPushAPN', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
-  pod 'CustomerIOMessagingPush', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
+  pod 'CustomerIOCommon', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics-prototyping'
+  pod 'CustomerIOTracking', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics-prototyping'
+  pod 'CustomerIOMessagingInApp', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics-prototyping'
+  pod 'CustomerIOMessagingPushAPN', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics-prototyping'
+  pod 'CustomerIOMessagingPush', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics-prototyping'
 ${blockEnd}
 `.trim();
 
@@ -65,10 +65,10 @@ target 'NotificationService' do
     filename
   )}'
 
-  pod 'CustomerIOCommon', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
-  pod 'CustomerIOTracking', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
-  pod 'CustomerIOMessagingPushAPN', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
-  pod 'CustomerIOMessagingPush', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics'
+  pod 'CustomerIOCommon', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics-prototyping'
+  pod 'CustomerIOTracking', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics-prototyping'
+  pod 'CustomerIOMessagingPushAPN', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics-prototyping'
+  pod 'CustomerIOMessagingPush', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'levi/reliable-open-metrics-prototyping'
 end
 ${blockEnd}
 `.trim();

--- a/src/ios/withAppDelegateModifications.ts
+++ b/src/ios/withAppDelegateModifications.ts
@@ -7,7 +7,6 @@ import {
   CIO_APPDELEGATEHEADER_REGEX,
   CIO_APPDELEGATEHEADER_USER_NOTIFICATION_CENTER_SNIPPET,
   CIO_CONFIGURECIOSDKPUSHNOTIFICATION_SNIPPET,
-  CIO_CONFIGURECIOSDKUSERNOTIFICATIONCENTER_SNIPPET,
   CIO_CONFIGUREDEEPLINK_KILLEDSTATE_SNIPPET,
   CIO_RCTBRIDGE_DEEPLINK_MODIFIEDOPTIONS_REGEX,
   CIO_DIDFAILTOREGISTERFORREMOTENOTIFICATIONSWITHERROR_REGEX,
@@ -81,16 +80,6 @@ const addInitializeNativeCioSdk = (stringContents: string) => {
     stringContents,
     CIO_DIDFINISHLAUNCHINGMETHOD_REGEX,
     CIO_INITIALIZECIOSDK_SNIPPET
-  );
-
-  return stringContents;
-};
-
-const addUserNotificationCenterConfiguration = (stringContents: string) => {
-  stringContents = injectCodeBeforeMultiLineRegex(
-    stringContents,
-    CIO_DIDFINISHLAUNCHINGMETHOD_REGEX,
-    CIO_CONFIGURECIOSDKUSERNOTIFICATIONCENTER_SNIPPET
   );
 
   return stringContents;
@@ -248,13 +237,6 @@ export const withAppDelegateModifications: ConfigPlugin<
       }
 
       stringContents = addInitializeNativeCioSdk(stringContents);
-
-      if (
-        props.handleNotificationClick === undefined ||
-        props.handleNotificationClick === true
-      ) {
-        stringContents = addUserNotificationCenterConfiguration(stringContents);
-      }
 
       if (
         props.handleDeeplinkInKilledState !== undefined &&

--- a/src/ios/withAppDelegateModifications.ts
+++ b/src/ios/withAppDelegateModifications.ts
@@ -30,7 +30,7 @@ import {
   injectCodeByMultiLineRegex,
   injectCodeByMultiLineRegexAndReplaceLine,
   replaceCodeByRegex,
-  matchRegexExists
+  matchRegexExists,
 } from '../helpers/utils/codeInjection';
 import { FileManagement } from '../helpers/utils/fileManagement';
 import type { CustomerIOPluginOptionsIOS } from '../types/cio-types';
@@ -97,7 +97,10 @@ const addUserNotificationCenterConfiguration = (stringContents: string) => {
   return stringContents;
 };
 
-const addHandleDeeplinkInKilledStateConfiguration = (stringContents: string, regex: RegExp) => {
+const addHandleDeeplinkInKilledStateConfiguration = (
+  stringContents: string,
+  regex: RegExp
+) => {
   stringContents = injectCodeBeforeMultiLineRegex(
     stringContents,
     regex,
@@ -142,11 +145,26 @@ const addAdditionalMethodsForPushNotifications = (stringContents: string) => {
 };
 
 const addAppdelegateHeaderModification = (stringContents: string) => {
+  stringContents = injectCodeByLineNumber(
+    stringContents,
+    1,
+    `
+#if __has_include(<EXNotifications/EXNotificationCenterDelegate.h>)
+#import <EXNotifications/EXNotificationCenterDelegate.h>
+#endif
+`
+  ).join('\n');
+
   // Add UNUserNotificationCenterDelegate if needed
   stringContents = stringContents.replace(
     CIO_APPDELEGATEHEADER_REGEX,
     (match, interfaceDeclaration, _groupedDelegates, existingDelegates) => {
-      if (existingDelegates && existingDelegates.includes(CIO_APPDELEGATEHEADER_USER_NOTIFICATION_CENTER_SNIPPET)) {
+      if (
+        existingDelegates &&
+        existingDelegates.includes(
+          CIO_APPDELEGATEHEADER_USER_NOTIFICATION_CENTER_SNIPPET
+        )
+      ) {
         // The AppDelegate declaration already includes UNUserNotificationCenterDelegate, so we don't need to modify it
         return match;
       } else if (existingDelegates) {
@@ -169,26 +187,38 @@ ${interfaceDeclaration.trim()} <${CIO_APPDELEGATEHEADER_USER_NOTIFICATION_CENTER
 const addHandleDeeplinkInKilledState = (stringContents: string) => {
   // Find if the deep link code snippet is already present
   if (matchRegexExists(stringContents, CIO_DEEPLINK_COMMENT_REGEX)) {
-    return stringContents
+    return stringContents;
   }
 
   // Check if the app delegate is using RCTBridge or LaunchOptions
-  var snippet = undefined
-  var regex = CIO_LAUNCHOPTIONS_DEEPLINK_MODIFIEDOPTIONS_REGEX;
-  if (matchRegexExists(stringContents, CIO_RCTBRIDGE_DEEPLINK_MODIFIEDOPTIONS_REGEX)) {
+  let snippet = undefined;
+  let regex = CIO_LAUNCHOPTIONS_DEEPLINK_MODIFIEDOPTIONS_REGEX;
+  if (
+    matchRegexExists(
+      stringContents,
+      CIO_RCTBRIDGE_DEEPLINK_MODIFIEDOPTIONS_REGEX
+    )
+  ) {
     snippet = CIO_RCTBRIDGE_DEEPLINK_MODIFIEDOPTIONS_SNIPPET;
     regex = CIO_RCTBRIDGE_DEEPLINK_MODIFIEDOPTIONS_REGEX;
-  }
-  else if (matchRegexExists(stringContents, CIO_LAUNCHOPTIONS_DEEPLINK_MODIFIEDOPTIONS_REGEX)) {
+  } else if (
+    matchRegexExists(
+      stringContents,
+      CIO_LAUNCHOPTIONS_DEEPLINK_MODIFIEDOPTIONS_REGEX
+    )
+  ) {
     snippet = CIO_LAUNCHOPTIONS_MODIFIEDOPTIONS_SNIPPET;
   }
   // Add code only if the app delegate is using RCTBridge or LaunchOptions
   if (snippet !== undefined) {
-  stringContents = addHandleDeeplinkInKilledStateConfiguration(stringContents, regex);
-  stringContents = replaceCodeByRegex(stringContents, regex, snippet);
+    stringContents = addHandleDeeplinkInKilledStateConfiguration(
+      stringContents,
+      regex
+    );
+    stringContents = replaceCodeByRegex(stringContents, regex, snippet);
   }
-  return stringContents
-}
+  return stringContents;
+};
 
 export const withAppDelegateModifications: ConfigPlugin<
   CustomerIOPluginOptionsIOS
@@ -234,7 +264,7 @@ export const withAppDelegateModifications: ConfigPlugin<
       ) {
         stringContents = addHandleDeeplinkInKilledState(stringContents);
       }
-  
+
       stringContents = addAdditionalMethodsForPushNotifications(stringContents);
       stringContents =
         addDidFailToRegisterForRemoteNotificationsWithError(stringContents);

--- a/src/ios/withAppDelegateModifications.ts
+++ b/src/ios/withAppDelegateModifications.ts
@@ -9,20 +9,18 @@ import {
   CIO_CONFIGURECIOSDKPUSHNOTIFICATION_SNIPPET,
   CIO_CONFIGURECIOSDKUSERNOTIFICATIONCENTER_SNIPPET,
   CIO_CONFIGUREDEEPLINK_KILLEDSTATE_SNIPPET,
-  CIO_DIDFAILTOREGISTERFORREMOTENOTIFICATIONSWITHERRORFULL_REGEX,
   CIO_RCTBRIDGE_DEEPLINK_MODIFIEDOPTIONS_REGEX,
   CIO_DIDFAILTOREGISTERFORREMOTENOTIFICATIONSWITHERROR_REGEX,
   CIO_DIDFAILTOREGISTERFORREMOTENOTIFICATIONSWITHERROR_SNIPPET,
   CIO_DIDFINISHLAUNCHINGMETHOD_REGEX,
-  CIO_DIDRECEIVENOTIFICATIONRESPONSEHANDLER_SNIPPET,
   CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_REGEX,
   CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_SNIPPET,
   CIO_LAUNCHOPTIONS_DEEPLINK_MODIFIEDOPTIONS_REGEX,
   CIO_PUSHNOTIFICATIONHANDLERDECLARATION_SNIPPET,
-  CIO_WILLPRESENTNOTIFICATIONHANDLER_SNIPPET,
   CIO_LAUNCHOPTIONS_MODIFIEDOPTIONS_SNIPPET,
   CIO_RCTBRIDGE_DEEPLINK_MODIFIEDOPTIONS_SNIPPET,
   CIO_DEEPLINK_COMMENT_REGEX,
+  CIO_INITIALIZECIOSDK_SNIPPET,
 } from '../helpers/constants/ios';
 import {
   injectCodeBeforeMultiLineRegex,
@@ -34,15 +32,6 @@ import {
 } from '../helpers/utils/codeInjection';
 import { FileManagement } from '../helpers/utils/fileManagement';
 import type { CustomerIOPluginOptionsIOS } from '../types/cio-types';
-
-const pushCodeSnippets = [
-  CIO_DIDRECEIVENOTIFICATIONRESPONSEHANDLER_SNIPPET,
-  CIO_WILLPRESENTNOTIFICATIONHANDLER_SNIPPET,
-];
-
-const additionalMethodsForPushNotifications = `${pushCodeSnippets.join(
-  '\n'
-)}\n`; // Join newlines and ensure a newline at the end.
 
 const addImport = (stringContents: string, appName: string) => {
   const importRegex = /^(#import .*)\n/gm;
@@ -82,6 +71,16 @@ const addNotificationConfiguration = (stringContents: string) => {
     stringContents,
     CIO_DIDFINISHLAUNCHINGMETHOD_REGEX,
     CIO_CONFIGURECIOSDKPUSHNOTIFICATION_SNIPPET
+  );
+
+  return stringContents;
+};
+
+const addInitializeNativeCioSdk = (stringContents: string) => {
+  stringContents = injectCodeBeforeMultiLineRegex(
+    stringContents,
+    CIO_DIDFINISHLAUNCHINGMETHOD_REGEX,
+    CIO_INITIALIZECIOSDK_SNIPPET
   );
 
   return stringContents;
@@ -129,16 +128,6 @@ const addDidRegisterForRemoteNotificationsWithDeviceToken = (
     stringContents,
     CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_REGEX,
     CIO_DIDREGISTERFORREMOTENOTIFICATIONSWITHDEVICETOKEN_SNIPPET
-  );
-
-  return stringContents;
-};
-
-const addAdditionalMethodsForPushNotifications = (stringContents: string) => {
-  stringContents = injectCodeByMultiLineRegex(
-    stringContents,
-    CIO_DIDFAILTOREGISTERFORREMOTENOTIFICATIONSWITHERRORFULL_REGEX,
-    additionalMethodsForPushNotifications
   );
 
   return stringContents;
@@ -255,6 +244,9 @@ export const withAppDelegateModifications: ConfigPlugin<
       ) {
         stringContents = addNotificationConfiguration(stringContents);
       }
+
+      stringContents = addInitializeNativeCioSdk(stringContents);
+
       if (
         props.handleNotificationClick === undefined ||
         props.handleNotificationClick === true
@@ -269,7 +261,6 @@ export const withAppDelegateModifications: ConfigPlugin<
         stringContents = addHandleDeeplinkInKilledState(stringContents);
       }
 
-      stringContents = addAdditionalMethodsForPushNotifications(stringContents);
       stringContents =
         addDidFailToRegisterForRemoteNotificationsWithError(stringContents);
       stringContents =

--- a/src/ios/withAppDelegateModifications.ts
+++ b/src/ios/withAppDelegateModifications.ts
@@ -62,7 +62,7 @@ const addImport = (stringContents: string, appName: string) => {
     stringContents,
     endOfMatchIndex,
     addedImport
-  ).join('\n');
+  );
 
   return stringContents;
 };
@@ -144,17 +144,21 @@ const addAdditionalMethodsForPushNotifications = (stringContents: string) => {
   return stringContents;
 };
 
-const addAppdelegateHeaderModification = (stringContents: string) => {
+const addExpoNotificationsHeaderModification = (stringContents: string) => {
   stringContents = injectCodeByLineNumber(
     stringContents,
-    1,
+    0,
     `
 #if __has_include(<EXNotifications/EXNotificationCenterDelegate.h>)
 #import <EXNotifications/EXNotificationCenterDelegate.h>
 #endif
 `
-  ).join('\n');
+  );
 
+  return stringContents;
+};
+
+const addAppdelegateHeaderModification = (stringContents: string) => {
   // Add UNUserNotificationCenterDelegate if needed
   stringContents = stringContents.replace(
     CIO_APPDELEGATEHEADER_REGEX,
@@ -270,6 +274,8 @@ export const withAppDelegateModifications: ConfigPlugin<
         addDidFailToRegisterForRemoteNotificationsWithError(stringContents);
       stringContents =
         addDidRegisterForRemoteNotificationsWithDeviceToken(stringContents);
+
+      stringContents = addExpoNotificationsHeaderModification(stringContents);
 
       config.modResults.contents = stringContents;
     } else {

--- a/src/ios/withAppDelegateModifications.ts
+++ b/src/ios/withAppDelegateModifications.ts
@@ -133,6 +133,8 @@ const addDidRegisterForRemoteNotificationsWithDeviceToken = (
   return stringContents;
 };
 
+// Adds required import for Expo Notifications package in AppDelegate.
+// Required to call functions from the package.
 const addExpoNotificationsHeaderModification = (stringContents: string) => {
   stringContents = injectCodeByLineNumber(
     stringContents,

--- a/src/ios/withNotificationsXcodeProject.ts
+++ b/src/ios/withNotificationsXcodeProject.ts
@@ -403,5 +403,14 @@ const updatePushFile = (
     autoTrackPushEvents.toString()
   );
 
+  const showPushAppInForeground =
+    options.showPushAppInForeground === undefined ||
+    options.showPushAppInForeground === true;
+  envFileContent = replaceCodeByRegex(
+    envFileContent,
+    /\{\{SHOW_PUSH_APP_IN_FOREGROUND\}\}/,
+    showPushAppInForeground.toString()
+  );
+
   FileManagement.writeFile(envFileName, envFileContent);
 };

--- a/src/ios/withNotificationsXcodeProject.ts
+++ b/src/ios/withNotificationsXcodeProject.ts
@@ -374,8 +374,34 @@ const updatePushFile = (
   ) {
     snippet = CIO_REGISTER_PUSHNOTIFICATION_SNIPPET;
   }
-
   envFileContent = replaceCodeByRegex(envFileContent, REGISTER_RE, snippet);
+
+  if (options.pushNotification) {
+    envFileContent = replaceCodeByRegex(
+      envFileContent,
+      /\{\{SITE_ID\}\}/,
+      options.pushNotification.env.siteId
+    );
+    envFileContent = replaceCodeByRegex(
+      envFileContent,
+      /\{\{API_KEY\}\}/,
+      options.pushNotification.env.apiKey
+    );
+    envFileContent = replaceCodeByRegex(
+      envFileContent,
+      /\{\{REGION\}\}/,
+      options.pushNotification.env.region.toUpperCase()
+    );
+  }
+
+  const autoTrackPushEvents =
+    options.handleNotificationClick === undefined ||
+    options.handleNotificationClick === true;
+  envFileContent = replaceCodeByRegex(
+    envFileContent,
+    /\{\{AUTO_TRACK_PUSH_EVENTS\}\}/,
+    autoTrackPushEvents.toString()
+  );
 
   FileManagement.writeFile(envFileName, envFileContent);
 };

--- a/src/ios/withNotificationsXcodeProject.ts
+++ b/src/ios/withNotificationsXcodeProject.ts
@@ -395,8 +395,8 @@ const updatePushFile = (
   }
 
   const autoTrackPushEvents =
-    options.handleNotificationClick === undefined ||
-    options.handleNotificationClick === true;
+    options.autoTrackPushEvents === undefined ||
+    options.autoTrackPushEvents === true;
   envFileContent = replaceCodeByRegex(
     envFileContent,
     /\{\{AUTO_TRACK_PUSH_EVENTS\}\}/,

--- a/src/types/cio-types.ts
+++ b/src/types/cio-types.ts
@@ -16,7 +16,11 @@ export type CustomerIOPluginOptionsIOS = {
   appleTeamId?: string;
   appName?: string;
   disableNotificationRegistration?: boolean;
+  /**
+   * @deprecated No longer has any effect. Use autoTrackPushEvents to control if push metrics should be automatically tracked by SDK.
+   */
   handleNotificationClick?: boolean;
+  autoTrackPushEvents?: boolean;
   handleDeeplinkInKilledState?: boolean;
   useFrameworks?: 'static' | 'dynamic';
   pushNotification?: {

--- a/src/types/cio-types.ts
+++ b/src/types/cio-types.ts
@@ -20,6 +20,7 @@ export type CustomerIOPluginOptionsIOS = {
    * @deprecated No longer has any effect. Use autoTrackPushEvents to control if push metrics should be automatically tracked by SDK.
    */
   handleNotificationClick?: boolean;
+  showPushAppInForeground?: boolean;
   autoTrackPushEvents?: boolean;
   handleDeeplinkInKilledState?: boolean;
   useFrameworks?: 'static' | 'dynamic';

--- a/src/types/cio-types.ts
+++ b/src/types/cio-types.ts
@@ -16,8 +16,8 @@ export type CustomerIOPluginOptionsIOS = {
   appleTeamId?: string;
   appName?: string;
   disableNotificationRegistration?: boolean;
-  handleNotificationClick?:boolean;
-  handleDeeplinkInKilledState?:boolean;
+  handleNotificationClick?: boolean;
+  handleDeeplinkInKilledState?: boolean;
   useFrameworks?: 'static' | 'dynamic';
   pushNotification?: {
     useRichPush: boolean;


### PR DESCRIPTION
Part of: https://github.com/customerio/issues/issues/11289

# Goals of PR

- Install new feature in iOS SDK of automatic push click handling. This is done by installing a specific version of the RN SDK that has this iOS feature installed. 
- Remove all native iOS code modifications that previously handled push click handling. 
- Add compatibility with `expo-notifications` package. Closes: https://github.com/customerio/customerio-expo-plugin/issues/83

# Blocked by
- Deploy native iOS https://github.com/customerio/customerio-ios/pull/403
- Update RN SDK to include ^^^ iOS feature. 

# Docs 

[PR](https://github.com/customerio/docs/pull/1670)
