### PR TITLE
refactor: run lint against main branch

### DIFF
--- a/src/helpers/constants/ios.ts
+++ b/src/helpers/constants/ios.ts
@@ -9,7 +9,7 @@ pluginPackageRoot = path.dirname(pluginPackageRoot);
 export const LOCAL_PATH_TO_RN_SDK = path.join(
   pluginPackageRoot,
   '../customerio-reactnative'
-)
+);
 
 export const LOCAL_PATH_TO_CIO_NSE_FILES = path.join(
   pluginPackageRoot,
@@ -42,20 +42,22 @@ export const CIO_APPDELEGATEDECLARATION_REGEX =
 export const CIO_APPDELEGATEHEADER_REGEX =
   /(@interface AppDelegate\s*:\s*EXAppDelegateWrapper\s*)(<([^>]+)>)?/;
 
-export const CIO_RCTBRIDGE_DEEPLINK_MODIFIEDOPTIONS_REGEX = 
-/^\s*RCTBridge\s*\*\s*\w+\s*=\s*\[\s*self\.reactDelegate\s+createBridgeWithDelegate:self\s+launchOptions:launchOptions\s*\];\s*$/gm;
+export const CIO_RCTBRIDGE_DEEPLINK_MODIFIEDOPTIONS_REGEX =
+  /^\s*RCTBridge\s*\*\s*\w+\s*=\s*\[\s*self\.reactDelegate\s+createBridgeWithDelegate:self\s+launchOptions:launchOptions\s*\];\s*$/gm;
 
-export const CIO_LAUNCHOPTIONS_DEEPLINK_MODIFIEDOPTIONS_REGEX = 
-/^\s*return\s\[\s*super\s*application:\s*application\s*didFinishLaunchingWithOptions\s*:\s*launchOptions\s*\];/gm;
+export const CIO_LAUNCHOPTIONS_DEEPLINK_MODIFIEDOPTIONS_REGEX =
+  /^\s*return\s\[\s*super\s*application:\s*application\s*didFinishLaunchingWithOptions\s*:\s*launchOptions\s*\];/gm;
 
-export const CIO_DEEPLINK_COMMENT_REGEX = /\sDeep link workaround for app killed state start/gm;
+export const CIO_DEEPLINK_COMMENT_REGEX =
+  /\sDeep link workaround for app killed state start/gm;
 export const DEFAULT_BUNDLE_VERSION = '1';
 export const DEFAULT_BUNDLE_SHORT_VERSION = '1.0';
 export const CIO_TARGET_NAME = 'CustomerIOSDK';
 export const CIO_NOTIFICATION_TARGET_NAME = 'NotificationService';
 
 export const CIO_APPDELEGATEHEADER_IMPORT_SNIPPET = `#import <UserNotifications/UserNotifications.h>`;
-export const CIO_APPDELEGATEHEADER_USER_NOTIFICATION_CENTER_SNIPPET = 'UNUserNotificationCenterDelegate';
+export const CIO_APPDELEGATEHEADER_USER_NOTIFICATION_CENTER_SNIPPET =
+  'UNUserNotificationCenterDelegate';
 export const CIO_PUSHNOTIFICATIONHANDLERDECLARATION_SNIPPET = `
 CIOAppPushNotificationsHandler* pnHandlerObj = [[CIOAppPushNotificationsHandler alloc] init];
 `;
@@ -64,7 +66,7 @@ RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOpti
 `;
 
 export const CIO_LAUNCHOPTIONS_MODIFIEDOPTIONS_SNIPPET = `
-return [super application:application didFinishLaunchingWithOptions:modifiedLaunchOptions];`
+return [super application:application didFinishLaunchingWithOptions:modifiedLaunchOptions];`;
 
 export const CIO_DIDFAILTOREGISTERFORREMOTENOTIFICATIONSWITHERROR_SNIPPET = `
   [super application:application didFailToRegisterForRemoteNotificationsWithError:error];

--- a/src/helpers/utils/injectCIOPodfileCode.ts
+++ b/src/helpers/utils/injectCIOPodfileCode.ts
@@ -19,7 +19,9 @@ export async function injectCIOPodfileCode(iosPath: string) {
 
     const snippetToInjectInPodfile = `
 ${blockStart}
-  pod 'customerio-reactnative/apn', :path => '${getRelativePathToRNSDK(filename)}'
+  pod 'customerio-reactnative/apn', :path => '${getRelativePathToRNSDK(
+    filename
+  )}'
 ${blockEnd}
 `.trim();
 
@@ -53,7 +55,9 @@ export async function injectCIONotificationPodfileCode(
 ${blockStart}
 target 'NotificationService' do
   ${useFrameworks === 'static' ? 'use_frameworks! :linkage => :static' : ''}
-  pod 'customerio-reactnative-richpush/apn', :path => '${getRelativePathToRNSDK(filename)}'
+  pod 'customerio-reactnative-richpush/apn', :path => '${getRelativePathToRNSDK(
+    filename
+  )}'
 end
 ${blockEnd}
 `.trim();

--- a/src/ios/withAppDelegateModifications.ts
+++ b/src/ios/withAppDelegateModifications.ts
@@ -30,7 +30,7 @@ import {
   injectCodeByMultiLineRegex,
   injectCodeByMultiLineRegexAndReplaceLine,
   replaceCodeByRegex,
-  matchRegexExists
+  matchRegexExists,
 } from '../helpers/utils/codeInjection';
 import { FileManagement } from '../helpers/utils/fileManagement';
 import type { CustomerIOPluginOptionsIOS } from '../types/cio-types';
@@ -97,7 +97,10 @@ const addUserNotificationCenterConfiguration = (stringContents: string) => {
   return stringContents;
 };
 
-const addHandleDeeplinkInKilledStateConfiguration = (stringContents: string, regex: RegExp) => {
+const addHandleDeeplinkInKilledStateConfiguration = (
+  stringContents: string,
+  regex: RegExp
+) => {
   stringContents = injectCodeBeforeMultiLineRegex(
     stringContents,
     regex,
@@ -146,7 +149,12 @@ const addAppdelegateHeaderModification = (stringContents: string) => {
   stringContents = stringContents.replace(
     CIO_APPDELEGATEHEADER_REGEX,
     (match, interfaceDeclaration, _groupedDelegates, existingDelegates) => {
-      if (existingDelegates && existingDelegates.includes(CIO_APPDELEGATEHEADER_USER_NOTIFICATION_CENTER_SNIPPET)) {
+      if (
+        existingDelegates &&
+        existingDelegates.includes(
+          CIO_APPDELEGATEHEADER_USER_NOTIFICATION_CENTER_SNIPPET
+        )
+      ) {
         // The AppDelegate declaration already includes UNUserNotificationCenterDelegate, so we don't need to modify it
         return match;
       } else if (existingDelegates) {
@@ -169,26 +177,38 @@ ${interfaceDeclaration.trim()} <${CIO_APPDELEGATEHEADER_USER_NOTIFICATION_CENTER
 const addHandleDeeplinkInKilledState = (stringContents: string) => {
   // Find if the deep link code snippet is already present
   if (matchRegexExists(stringContents, CIO_DEEPLINK_COMMENT_REGEX)) {
-    return stringContents
+    return stringContents;
   }
 
   // Check if the app delegate is using RCTBridge or LaunchOptions
-  var snippet = undefined
-  var regex = CIO_LAUNCHOPTIONS_DEEPLINK_MODIFIEDOPTIONS_REGEX;
-  if (matchRegexExists(stringContents, CIO_RCTBRIDGE_DEEPLINK_MODIFIEDOPTIONS_REGEX)) {
+  let snippet = undefined;
+  let regex = CIO_LAUNCHOPTIONS_DEEPLINK_MODIFIEDOPTIONS_REGEX;
+  if (
+    matchRegexExists(
+      stringContents,
+      CIO_RCTBRIDGE_DEEPLINK_MODIFIEDOPTIONS_REGEX
+    )
+  ) {
     snippet = CIO_RCTBRIDGE_DEEPLINK_MODIFIEDOPTIONS_SNIPPET;
     regex = CIO_RCTBRIDGE_DEEPLINK_MODIFIEDOPTIONS_REGEX;
-  }
-  else if (matchRegexExists(stringContents, CIO_LAUNCHOPTIONS_DEEPLINK_MODIFIEDOPTIONS_REGEX)) {
+  } else if (
+    matchRegexExists(
+      stringContents,
+      CIO_LAUNCHOPTIONS_DEEPLINK_MODIFIEDOPTIONS_REGEX
+    )
+  ) {
     snippet = CIO_LAUNCHOPTIONS_MODIFIEDOPTIONS_SNIPPET;
   }
   // Add code only if the app delegate is using RCTBridge or LaunchOptions
   if (snippet !== undefined) {
-  stringContents = addHandleDeeplinkInKilledStateConfiguration(stringContents, regex);
-  stringContents = replaceCodeByRegex(stringContents, regex, snippet);
+    stringContents = addHandleDeeplinkInKilledStateConfiguration(
+      stringContents,
+      regex
+    );
+    stringContents = replaceCodeByRegex(stringContents, regex, snippet);
   }
-  return stringContents
-}
+  return stringContents;
+};
 
 export const withAppDelegateModifications: ConfigPlugin<
   CustomerIOPluginOptionsIOS
@@ -234,7 +254,7 @@ export const withAppDelegateModifications: ConfigPlugin<
       ) {
         stringContents = addHandleDeeplinkInKilledState(stringContents);
       }
-  
+
       stringContents = addAdditionalMethodsForPushNotifications(stringContents);
       stringContents =
         addDidFailToRegisterForRemoteNotificationsWithError(stringContents);

--- a/src/types/cio-types.ts
+++ b/src/types/cio-types.ts
@@ -16,8 +16,8 @@ export type CustomerIOPluginOptionsIOS = {
   appleTeamId?: string;
   appName?: string;
   disableNotificationRegistration?: boolean;
-  handleNotificationClick?:boolean;
-  handleDeeplinkInKilledState?:boolean;
+  handleNotificationClick?: boolean;
+  handleDeeplinkInKilledState?: boolean;
   useFrameworks?: 'static' | 'dynamic';
   pushNotification?: {
     useRichPush: boolean;


### PR DESCRIPTION
I noticed when trying to open [another pr](https://github.com/customerio/customerio-expo-plugin/pull/112), lint has not been run against the main `beta` branch. This made my PR longer then it needed to be because it included a lot of lint fixes in it. 

This PR only includes changes caused by running: 
```
npm install
npm run lint
```
