### PR TITLE
feat: show a push while app in foreground

### DIFF
--- a/src/helpers/native-files/ios/PushService.swift
+++ b/src/helpers/native-files/ios/PushService.swift
@@ -19,6 +19,7 @@ public class CIOAppPushNotificationsHandler : NSObject {
       // This is because after AppDelegate.didFinishLaunching is called, the app will start handling push click events. 
       // Configuring auto track push events after this point will not work.
       config.autoTrackPushEvents = {{AUTO_TRACK_PUSH_EVENTS}}
+      config.showPushAppInForeground = {{SHOW_PUSH_APP_IN_FOREGROUND}}
     }
     MessagingPushAPN.initialize()
   }

--- a/src/ios/withNotificationsXcodeProject.ts
+++ b/src/ios/withNotificationsXcodeProject.ts
@@ -403,5 +403,14 @@ const updatePushFile = (
     autoTrackPushEvents.toString()
   );
 
+  const showPushAppInForeground =
+    options.showPushAppInForeground === undefined ||
+    options.showPushAppInForeground === true;
+  envFileContent = replaceCodeByRegex(
+    envFileContent,
+    /\{\{SHOW_PUSH_APP_IN_FOREGROUND\}\}/,
+    showPushAppInForeground.toString()
+  );
+
   FileManagement.writeFile(envFileName, envFileContent);
 };

--- a/src/types/cio-types.ts
+++ b/src/types/cio-types.ts
@@ -17,6 +17,7 @@ export type CustomerIOPluginOptionsIOS = {
   appName?: string;
   disableNotificationRegistration?: boolean;
   handleNotificationClick?: boolean;
+  showPushAppInForeground?: boolean;
   handleDeeplinkInKilledState?: boolean;
   useFrameworks?: 'static' | 'dynamic';
   pushNotification?: {


### PR DESCRIPTION
Enables [this feature being added to iOS SDK](https://github.com/customerio/customerio-ios/pull/407) of configuring the SDK's behavior with automated push click handling. 

By default, pushes will show while app is in the foreground, just like on native iOS. 

Merges into: https://github.com/customerio/customerio-expo-plugin/pull/112 