### PR TITLE
fix: update nse class name to avoid conflicts with other libraries

### DIFF
--- a/src/helpers/native-files/ios/NotificationService.h
+++ b/src/helpers/native-files/ios/NotificationService.h
@@ -1,5 +1,5 @@
 #import <UserNotifications/UserNotifications.h>
 
-@interface NotificationService : UNNotificationServiceExtension
+@interface CIONotificationService : UNNotificationServiceExtension
 
 @end

--- a/src/helpers/native-files/ios/NotificationService.m
+++ b/src/helpers/native-files/ios/NotificationService.m
@@ -2,14 +2,14 @@
 #import "NotificationService.h"
 #import "NotificationService-Swift.h"
 
-@interface NotificationService ()
+@interface CIONotificationService ()
 
 @property (nonatomic, strong) void (^contentHandler)(UNNotificationContent *contentToDeliver);
 @property (nonatomic, strong) UNMutableNotificationContent *bestAttemptContent;
 
 @end
 
-@implementation NotificationService
+@implementation CIONotificationService
 
 - (void)didReceiveNotificationRequest:(UNNotificationRequest *)request withContentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler {
     NotificationServiceCioManager* cioManagerObj = [[NotificationServiceCioManager alloc] init];


### PR DESCRIPTION
helps: https://github.com/customerio/customerio-expo-plugin/issues/118

The customer is having issues when multiple libraries have same class name such as `NotificationService` in NotificationServiceExtension target. The customer specifically mentioned about OneSignal and our expo plugin showing conflicts because of the same class name. 


