### PR TITLE
fix: expo-doctor plugin error

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
   "react-native": "src/index",
   "license": "MIT",
   "files": [
+    "app.plugin.js",
     "src",
     "lib/**/*"
   ],
   "exports": {
+    "./app.plugin.js": "./app.plugin.js",
     ".": "./lib/commonjs/index.js",
     "./postinstall": "./src/postInstallHelper.js"
   },


### PR DESCRIPTION
Linear ticket: https://linear.app/customerio/issue/MBL-611/plugin-not-found-error-running-expo-doctor-1101

### Problem:
Customers are facing an issue where the `npx expo-doctor` command fails with the error `PLUGIN_NOT_FOUND`
when using the Customer.io Expo plugin. The customers reported that they do have the plugin rightly installed and can find it in `node_modules` but still see the error on running the command hence becoming a blocker for the customers. 

### Solution:
This PR makes sure to include `app.plugin.js` on installing the customerio-expo-plugin in a customer app so that on running npx expo-doctor the file is found and the customers no longer see the error.

### Testing:
Before the fix:
`PluginError: Failed to resolve plugin for module "customerio-expo-plugin" relative to "/Users/xxx/xxxx/xxxxx"`
<img width="969" alt="Screenshot 2024-10-24 at 11 03 06 PM" src="https://github.com/user-attachments/assets/37f3bc02-1e95-4de0-a078-dc088e7f8b61">


After the fix:
expo-doctor runs successfully.
<img width="812" alt="Screenshot 2024-10-24 at 11 00 28 PM" src="https://github.com/user-attachments/assets/40a9f674-67f2-4ae2-ae21-3ac5ef4b56f3">