### PR TITLE
feat: bumped iOS deployment target for compatibility with Expo SDK 52

### DIFF
--- a/src/ios/withNotificationsXcodeProject.ts
+++ b/src/ios/withNotificationsXcodeProject.ts
@@ -234,7 +234,7 @@ const addRichPushXcodeProj = async (
       const buildSettingsObj = configurations[key].buildSettings;
       buildSettingsObj.DEVELOPMENT_TEAM = appleTeamId;
       buildSettingsObj.IPHONEOS_DEPLOYMENT_TARGET =
-        iosDeploymentTarget || '13.4';
+        iosDeploymentTarget || '15.1';
       buildSettingsObj.TARGETED_DEVICE_FAMILY = TARGETED_DEVICE_FAMILY;
       buildSettingsObj.CODE_SIGN_STYLE = 'Automatic';
       buildSettingsObj.SWIFT_VERSION = 4.2;


### PR DESCRIPTION
Linear ticket : https://linear.app/customerio/issue/MBL-640/ios-build-error-on-expo-sdk-52-with-react-native-076

### Problem:
A customer reported that their app is not compiling when using the latest versions of Expo and React Native (0.76). The error message indicates a mismatch in the iOS deployment targets. This occurs because the `NotificationServiceExtension` defaults to an iOS deployment target of 13.4 currently, while `CioTracking` now requires a minimum target of 15.1. For a managed workflow, when expo plugin is used, then it is the responsibility of the plugin to set the deployment target for extension as the developer does not have flexibility to manually update the extension target, hence the error is only in the extension.

### Solution:
In our plugin, update the minimum default version from `13.4` to `15.1` as supported by latest react native and Expo SDK 52 beta.
