### PR TITLE
chore: Temporarily disable iOS Native code generation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import type { ExpoConfig } from '@expo/config-types';
 
 import { withCIOAndroid } from './android/withCIOAndroid';
-import { withCIOIos } from './ios/withCIOIos';
+// import { withCIOIos } from './ios/withCIOIos';
 import type { CustomerIOPluginOptions } from './types/cio-types';
 
 // Entry point for config plugin
@@ -9,9 +9,9 @@ function withCustomerIOPlugin(
   config: ExpoConfig,
   props: CustomerIOPluginOptions
 ) {
-  if (props.ios) {
-    config = withCIOIos(config, props.ios);
-  }
+  // if (props.ios) {
+  //   config = withCIOIos(config, props.ios);
+  // }
 
   if (props.android) {
     config = withCIOAndroid(config, props.android);


### PR DESCRIPTION
This allows us to upgrade CIO RN SDK to 4.x along with its underlying Native CIO iOS SDK and avoid compilation issues.

This however breaks the push notifications feature but this will be fixed in later tickets.