### PR TITLE
chore: Add Gituhb action job to run plugin tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,4 @@ jobs:
 
       - name: Run plugin tests
         run: npm run test-plugin
+        

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,22 @@ jobs:
 
       - name: Publish test
         run: npm publish --dry-run
+
+  test-plugin:
+    name: Test unit tests for plguin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install plugin dependencies
+        working-directory: plugin
+        run: npm ci
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Run plugin tests
+        run: npm run test-plugin


### PR DESCRIPTION
This PR adds a new job that runs unit tests for the Expo plugin when changes are pushed to branches and on PRs.

The new job will run all unit tests under the `__tests__` directory in this repository.