### PR TITLE
chore: Build basic test app basic functionality

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,52 @@ jobs:
 
       - name: Run plugin tests
         run: npm run test-plugin
-        
+  
+  build-android-app:
+    name: Build and compile Android app to ensure correctness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Install plugin dependencies
+        working-directory: plugin
+        run: npm ci
+
+      - name: Setup test project
+        run: npm run setup-tests
+
+      - name: Build Android app
+        working-directory: test-app/android
+        run: ./gradlew assembleDebug
+
+  build-ios-app:
+    name: Build and compile iOS app to ensure correctness
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install XCode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "15.3"
+
+      - name: Install plugin dependencies
+        working-directory: plugin
+        run: npm ci
+
+      - name: Setup test project
+        run: npm run setup-tests
+
+      - name: Build iOS app
+        working-directory: test-app/ios
+        run: xcodebuild -workspace ExpoTestApp.xcworkspace -scheme ExpoTestApp -sdk iphonesimulator -configuration Debug build

--- a/__tests__/android/__snapshots__/app-gradle-build.test.js.snap
+++ b/__tests__/android/__snapshots__/app-gradle-build.test.js.snap
@@ -90,9 +90,9 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
     compileSdk rootProject.ext.compileSdkVersion
 
-    namespace 'com.anonymous.testapp'
+    namespace 'io.customer.ami'
     defaultConfig {
-        applicationId 'com.anonymous.testapp'
+        applicationId 'io.customer.ami'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/__tests__/android/__snapshots__/app-manifest.test.js.snap
+++ b/__tests__/android/__snapshots__/app-manifest.test.js.snap
@@ -32,7 +32,7 @@ exports[`Plugin injects CustomerIOFirebaseMessagingService in the app manifest 1
         <action android:name="android.intent.action.VIEW"/>
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
-        <data android:scheme="com.anonymous.testapp"/>
+        <data android:scheme="io.customer.ami"/>
       </intent-filter>
     </activity>
   </application>

--- a/__tests__/ios/AppDelegate-header.test.js
+++ b/__tests__/ios/AppDelegate-header.test.js
@@ -3,7 +3,7 @@ const path = require("path");
 
 const testProjectPath = path.join(__dirname, "../../test-app");
 const iosPath = path.join(testProjectPath, "ios");
-const appDelegateHeaderPath = path.join(iosPath, "testapp/AppDelegate.h");
+const appDelegateHeaderPath = path.join(iosPath, "ExpoTestApp/AppDelegate.h");
 
 test("Plugin injects CIO imports and calls into AppDelegate.h", async () => {
   const content = await fs.readFile(appDelegateHeaderPath, "utf8");

--- a/__tests__/ios/AppDelegate-impl.test.js
+++ b/__tests__/ios/AppDelegate-impl.test.js
@@ -3,7 +3,7 @@ const path = require("path");
 
 const testProjectPath = path.join(__dirname, "../../test-app");
 const iosPath = path.join(testProjectPath, "ios");
-const appDelegateImplPath = path.join(iosPath, "testapp/AppDelegate.mm");
+const appDelegateImplPath = path.join(iosPath, "ExpoTestApp/AppDelegate.mm");
 
 test("Plugin injects CIO imports and calls into AppDelegate.mm", async () => {
   const content = await fs.readFile(appDelegateImplPath, "utf8");

--- a/__tests__/ios/PushService-swift.test.js
+++ b/__tests__/ios/PushService-swift.test.js
@@ -3,7 +3,7 @@ const path = require("path");
 
 const testProjectPath = path.join(__dirname, "../../test-app");
 const iosPath = path.join(testProjectPath, "ios");
-const pushServicePath = path.join(iosPath, "testapp/PushService.swift");
+const pushServicePath = path.join(iosPath, "ExpoTestApp/PushService.swift");
 
 test("Plugin creates expected PushService.swift", async () => {
   const content = await fs.readFile(pushServicePath, "utf8");

--- a/__tests__/ios/__snapshots__/AppDelegate-impl.test.js.snap
+++ b/__tests__/ios/__snapshots__/AppDelegate-impl.test.js.snap
@@ -9,7 +9,7 @@ exports[`Plugin injects CIO imports and calls into AppDelegate.mm 1`] = `
 
 // Add swift bridge imports
 #import <ExpoModulesCore-Swift.h>
-#import <testapp-Swift.h>
+#import <ExpoTestApp-Swift.h>
   
 #import "AppDelegate.h"
 

--- a/__tests__/ios/__snapshots__/PodFile.test.js.snap
+++ b/__tests__/ios/__snapshots__/PodFile.test.js.snap
@@ -16,7 +16,7 @@ install! 'cocoapods',
 
 prepare_react_native_project!
 
-target 'testapp' do
+target 'ExpoTestApp' do
   use_expo_modules!
 
   if ENV['EXPO_USE_COMMUNITY_AUTOLINKING'] == '1'

--- a/test-app/App.js
+++ b/test-app/App.js
@@ -1,20 +1,11 @@
-import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import React, { useEffect } from "react";
+import DashboardScreen from "./screens/Dashboard";
+import { initializeCioSdk } from "./helpers/SdkInit";
 
 export default function App() {
-  return (
-    <View style={styles.container}>
-      <Text>Open up App.js to start working on your app!</Text>
-      <StatusBar style="auto" />
-    </View>
-  );
-}
+  useEffect(() => {
+    initializeCioSdk();
+  }, []);
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});
+  return <DashboardScreen />;
+}

--- a/test-app/app.json
+++ b/test-app/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "test-app",
-    "slug": "test-app",
+    "name": "Expo Test App",
+    "slug": "expo-test-app",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -14,14 +14,14 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.anonymous.test-app"
+      "bundleIdentifier": "io.customer.ami"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "com.anonymous.testapp"
+      "package": "io.customer.ami"
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/test-app/files/google-services.json
+++ b/test-app/files/google-services.json
@@ -1,0 +1,46 @@
+{
+    "project_info": {
+      "project_number": "93259709906",
+      "project_id": "amiapp-reactnative",
+      "storage_bucket": "amiapp-reactnative.appspot.com"
+    },
+    "client": [
+      {
+        "client_info": {
+          "mobilesdk_app_id": "1:93259709906:android:8e70e0f3b341eb8027dc0b",
+          "android_client_info": {
+            "package_name": "io.customer.ami"
+          }
+        },
+        "oauth_client": [
+          {
+            "client_id": "93259709906-l7aijbcib0l7nr3ho89rek720alc1s9o.apps.googleusercontent.com",
+            "client_type": 3
+          }
+        ],
+        "api_key": [
+          {
+            "current_key": "AIzaSyBj5yABJbp_zAuuWj7Mnz7Yae4fld9togw"
+          }
+        ],
+        "services": {
+          "appinvite_service": {
+            "other_platform_oauth_client": [
+              {
+                "client_id": "93259709906-l7aijbcib0l7nr3ho89rek720alc1s9o.apps.googleusercontent.com",
+                "client_type": 3
+              },
+              {
+                "client_id": "93259709906-8pn1fj1si34773vg0eqc5i63kmtfctos.apps.googleusercontent.com",
+                "client_type": 2,
+                "ios_info": {
+                  "bundle_id": "io.customer.ami"
+                }
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "configuration_version": "1"
+  }

--- a/test-app/helpers/RequestPushPermission.js
+++ b/test-app/helpers/RequestPushPermission.js
@@ -1,0 +1,25 @@
+import { CustomerIO, CioPushPermissionStatus } from "customerio-reactnative";
+
+export function requestPermissionForPush() {
+  let options = { ios: { sound: true, badge: true } };
+  CustomerIO.pushMessaging
+    .showPromptForPushNotifications(options)
+    .then((status) => {
+      switch (status) {
+        case CioPushPermissionStatus.Granted:
+          alert(`Push notifications are now enabled on this device`);
+          break;
+
+        case CioPushPermissionStatus.Denied:
+        case CioPushPermissionStatus.NotDetermined:
+          alert(
+            `Push notifications are denied on this device. Please allow notification permission from settings to receive push on this device`
+          );
+          break;
+      }
+    })
+    .catch((error) => {
+      alert(`Unable to request permission. Check console for error`);
+      console.error(error);
+    });
+}

--- a/test-app/helpers/SdkInit.js
+++ b/test-app/helpers/SdkInit.js
@@ -1,0 +1,25 @@
+import {
+  CioLogLevel,
+  CioRegion,
+  CustomerIO,
+  PushClickBehaviorAndroid,
+} from "customerio-reactnative";
+
+export function initializeCioSdk() {
+  const config = {
+    cdpApiKey: "YourApiKey",
+    region: CioRegion.US,
+    logLevel: CioLogLevel.Debug,
+    trackApplicationLifecycleEvents: true,
+    inApp: {
+      siteId: "YourSiteId",
+    },
+    push: {
+      android: {
+        pushClickBehavior: PushClickBehaviorAndroid.ResetTaskStack,
+      },
+    },
+  };
+
+  CustomerIO.initialize(config);
+}

--- a/test-app/screens/Dashboard.js
+++ b/test-app/screens/Dashboard.js
@@ -1,0 +1,104 @@
+import React, { useState } from "react";
+import { View, TextInput, Button, StyleSheet } from "react-native";
+import { CustomerIO } from "customerio-reactnative";
+import { requestPermissionForPush } from "../helpers/RequestPushPermission";
+
+export default function DashboardScreen() {
+  const [email, setEmail] = useState("");
+  const [eventName, setEventName] = useState("");
+
+  const handleLoginButtonPressed = () => {
+    const trimmedEmail = email.trim();
+    if (trimmedEmail === "") {
+      CustomerIO.clearIdentify();
+      alert(`Logged out!`);
+    } else {
+      CustomerIO.identify({
+        userId: trimmedEmail,
+        traits: {
+          first_name: trimmedEmail,
+          email: trimmedEmail,
+        },
+      });
+      alert(`Identified ${trimmedEmail}`);
+    }
+  };
+
+  const handleSendEventButtonPressed = () => {
+    CustomerIO.track(eventName, { product: "shoes", price: "29.99" });
+    alert(`Tracked event: ${eventName}`);
+  };
+
+  const handleRequestPushPermissionButtonPressed = () => {
+    requestPermissionForPush();
+  };
+
+  return (
+    <View style={styles.container}>
+      {/* First Section */}
+      <View style={styles.section}>
+        <TextInput
+          style={styles.input}
+          placeholder="Email"
+          keyboardType="email-address"
+          autoCapitalize="none"
+          value={email}
+          onChangeText={setEmail}
+        />
+        <Button title="Login" onPress={handleLoginButtonPressed} />
+      </View>
+
+      {/* Divider */}
+      <View style={styles.divider} />
+
+      {/* Second Section */}
+      <View style={styles.section}>
+        <TextInput
+          style={styles.input}
+          placeholder="Event name"
+          autoCapitalize="none"
+          value={eventName}
+          onChangeText={setEventName}
+        />
+        <Button title="Send event" onPress={handleSendEventButtonPressed} />
+      </View>
+
+      {/* Divider */}
+      <View style={styles.divider} />
+
+      {/* Third Button */}
+      <Button
+        title="Request push permission"
+        onPress={handleRequestPushPermissionButtonPressed}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 20,
+  },
+  section: {
+    marginBottom: 20,
+    width: "100%",
+    alignItems: "center",
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: "#ccc",
+    padding: 10,
+    marginBottom: 10,
+    borderRadius: 5,
+    width: "80%",
+  },
+  divider: {
+    height: 1,
+    backgroundColor: "#ccc",
+    width: "100%",
+    marginVertical: 10,
+  },
+});


### PR DESCRIPTION
This PR starts to build basic functionality for the Expo test app so we can verify E2E integration is working.

This is no way a complete or final version of the app, this is only to unblock testing and basic verification of Expo SDK functionality.

The test app with its current state should allow you to:
- Identify a user
- Clear user identification
- Send an event
- Request push permission to allow you to test push notifications

<img width="345" alt="Screenshot 2024-12-10 at 3 48 29 PM" src="https://github.com/user-attachments/assets/dd4dfbed-dbb3-4266-8c41-ec73b2ee455b">


I've tested the following scenarios with the test app and the [Expo workspace](https://fly.customer.io/workspaces/94996/journeys/dashboard) and they working:
- ✅ Anonymous user tracking 
- ✅ Identify a user
- ✅  Clear user identification
- ✅  Send push messages (Push setup has to be done locally)
- ✅  Send in-app message


There are 3 main things that are still missing and will be added in following PRs:
- Push setup (download certificates)
- Inject API key and Site ID through CI secrets
- Add more functionality to configure and test more SDK features