### PR TITLE
chore: Create Github Action job that builds native apps (Android, iOS)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,27 @@ jobs:
 
       - name: Run plugin tests
         run: npm run test-plugin
-        
+  
+  build-android-app:
+    name: Build and compile Android app to ensure correctness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Install plugin dependencies
+        working-directory: plugin
+        run: npm ci
+
+      - name: Setup test project
+        run: npm run setup-tests
+
+      - name: Build Android app
+        working-directory: test-app/android
+        run: ./gradlew assembleDebug

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,3 +66,28 @@ jobs:
       - name: Build Android app
         working-directory: test-app/android
         run: ./gradlew assembleDebug
+
+  build-ios-app:
+    name: Build and compile iOS app to ensure correctness
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install XCode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "15.3"
+
+      - name: Install plugin dependencies
+        working-directory: plugin
+        run: npm ci
+
+      - name: Setup test project
+        run: npm run setup-tests
+
+      - name: Build iOS app
+        working-directory: test-app/ios
+        run: xcodebuild -workspace ExpoTestApp.xcworkspace -scheme ExpoTestApp -sdk iphonesimulator -configuration Debug build


### PR DESCRIPTION
The PR closes the last step of testing mentioned in [this proposal](https://www.notion.so/custio/Tech-Proposal-Reliable-Expo-plugin-1454302f4c2b800fb7d3c30cd76ffbfd?pvs=4#1454302f4c2b8010845cd8598444b77d). To ensure that the generated code for Android and iOS compiles successfully after applying the CIO Expo plugin.

This PR adds two new jobs to the `Test` action:
- `build-android-app`: Builds and compiles the native Android app
- `build-ios-app`: Builds and compiles the native iOS app