### PR TITLE
chore: Minor tweaks to test app to enable regression

### DIFF
--- a/test-app/helpers/SdkInit.js
+++ b/test-app/helpers/SdkInit.js
@@ -2,12 +2,11 @@ import {
   CioLogLevel,
   CioRegion,
   CustomerIO,
-  PushClickBehaviorAndroid,
 } from "customerio-reactnative";
 import Constants from "expo-constants";
 
 export function initializeCioSdk() {
-  console.log("Extras config: " + Constants.expoConfig);
+  console.log("Expo config: " + Constants.expoConfig);
   const cdpApiKey = Constants.expoConfig?.extra?.cdpApiKey || "Failed to load!";
   const siteId = Constants.expoConfig?.extra?.siteId || "Failed to load!";
 
@@ -15,14 +14,9 @@ export function initializeCioSdk() {
     cdpApiKey: cdpApiKey,
     region: CioRegion.US,
     logLevel: CioLogLevel.Debug,
-    trackApplicationLifecycleEvents: true,
+    migrationSiteId: siteId,
     inApp: {
       siteId: siteId,
-    },
-    push: {
-      android: {
-        pushClickBehavior: PushClickBehaviorAndroid.ResetTaskStack,
-      },
     },
   };
 

--- a/test-app/screens/Dashboard.js
+++ b/test-app/screens/Dashboard.js
@@ -1,35 +1,43 @@
-import React, { useState, useCallback } from "react";
-import { View, Button, StyleSheet, Text } from "react-native";
-import { requestPermissionForPush } from "../helpers/RequestPushPermission";
+import React, { useState, useCallback } from 'react';
+import { View, Button, StyleSheet, Text } from 'react-native';
+import { requestPermissionForPush } from '../helpers/RequestPushPermission';
 import { useFocusEffect } from '@react-navigation/native';
-import Constants from "expo-constants";
+import Constants from 'expo-constants';
 
-import LoginModal from "./LoginModal";
-import SendEventModal from "./SendEventModal";
-import DeviceAttributeModal from "./DeviceAttributesModal";
-import { CustomerIO } from "customerio-reactnative";
+import LoginModal from './LoginModal';
+import SendEventModal from './SendEventModal';
+import DeviceAttributeModal from './DeviceAttributesModal';
+import ProfileAttributeModal from './ProfileAttributeModal';
+import { CustomerIO } from 'customerio-reactnative';
 
 export default function DashboardScreen({ navigation }) {
   const [loginModalVisible, seLoginModalVisible] = useState(false);
   const [sendEventModalVisible, setSendEventModalVisible] = useState(false);
-  const [deviceAttributeModalVisible, setDeviceAttributeModalVisible] = useState(false);
+  const [deviceAttributeModalVisible, setDeviceAttributeModalVisible] =
+    useState(false);
+  const [profileAttributeModalVisible, setProfileAttributeModalVisible] =
+    useState(false);
 
-  const cdpApiKey = Constants.expoConfig?.extra?.cdpApiKey || "Failed to load!";
-  const siteId = Constants.expoConfig?.extra?.siteId || "Failed to load!";
-  const workspaceInfo = "CDP API Key: " + cdpApiKey + "\n" +
-      "Site ID: " + siteId;
+  const cdpApiKey = Constants.expoConfig?.extra?.cdpApiKey || 'Failed to load!';
+  const siteId = Constants.expoConfig?.extra?.siteId || 'Failed to load!';
+  const workspaceInfo =
+    'CDP API Key: ' + cdpApiKey + '\n' + 'Site ID: ' + siteId;
 
   const handleRequestPushPermissionButtonPressed = () => {
     requestPermissionForPush();
   };
 
   const handleNavigateToTestScreenButtonPressed = () => {
-    navigation.navigate('NavigationTest')
-  }
+    navigation.navigate('NavigationTest');
+  };
+
+  const handleLogoutButtonPressed = () => {
+    CustomerIO.clearIdentify();
+  };
 
   useFocusEffect(
     useCallback(() => {
-      CustomerIO.screen("Dashboard");
+      CustomerIO.screen('Dashboard');
 
       return () => {
         console.log('Leaving DashboardScreen');
@@ -44,22 +52,43 @@ export default function DashboardScreen({ navigation }) {
       </View>
 
       <View style={styles.section}>
-        <Button title="Send event" onPress={() => setSendEventModalVisible(true)} />
+        <Button
+          title="Send event"
+          onPress={() => setSendEventModalVisible(true)}
+        />
       </View>
 
       <View style={styles.section}>
-        <Button title="Device attribute" onPress={() => setDeviceAttributeModalVisible(true)} />
+        <Button
+          title="Profile Attribute"
+          onPress={() => setProfileAttributeModalVisible(true)}
+        />
       </View>
 
-      <Button
-        title="Request push permission"
-        onPress={handleRequestPushPermissionButtonPressed}
-      />
+      <View style={styles.section}>
+        <Button
+          title="Device attribute"
+          onPress={() => setDeviceAttributeModalVisible(true)}
+        />
+      </View>
 
-      <Button
-        title="Navigate to test screen"
-        onPress={handleNavigateToTestScreenButtonPressed}
-      />
+      <View style={styles.section}>
+        <Button
+          title="Request push permission"
+          onPress={handleRequestPushPermissionButtonPressed}
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Button
+          title="Navigate to test screen"
+          onPress={handleNavigateToTestScreenButtonPressed}
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Button title="Logout" onPress={handleLogoutButtonPressed} />
+      </View>
 
       <View style={styles.bottomLabelContainer}>
         <Text style={styles.bottomLabel}>{workspaceInfo}</Text>
@@ -73,6 +102,10 @@ export default function DashboardScreen({ navigation }) {
         visible={sendEventModalVisible}
         onClose={() => setSendEventModalVisible(false)}
       />
+      <ProfileAttributeModal
+        visible={profileAttributeModalVisible}
+        onClose={() => setProfileAttributeModalVisible(false)}
+      />
       <DeviceAttributeModal
         visible={deviceAttributeModalVisible}
         onClose={() => setDeviceAttributeModalVisible(false)}
@@ -84,22 +117,22 @@ export default function DashboardScreen({ navigation }) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
+    justifyContent: 'center',
+    alignItems: 'center',
     padding: 20,
   },
   section: {
     marginBottom: 20,
-    width: "100%",
-    alignItems: "center",
+    width: '100%',
+    alignItems: 'center',
   },
   input: {
     borderWidth: 1,
-    borderColor: "#ccc",
+    borderColor: '#ccc',
     padding: 10,
     marginBottom: 10,
     borderRadius: 5,
-    width: "80%",
+    width: '80%',
   },
   bottomLabelContainer: {
     position: 'absolute',

--- a/test-app/screens/ProfileAttributeModal.js
+++ b/test-app/screens/ProfileAttributeModal.js
@@ -1,0 +1,114 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  TouchableOpacity,
+  Modal,
+} from 'react-native';
+import { CustomerIO } from 'customerio-reactnative';
+
+export default function ProfileAttributeModal({ visible, onClose }) {
+  const [attributeName, setAttributeName] = useState('');
+  const [attributeValue, setAttributeValue] = useState('');
+
+  const handlePopupButtonPress = () => {
+    if (attributeName === '' || attributeValue === '') {
+      onClose();
+      return;
+    }
+
+    const profileAttributes = {
+      attributeName: attributeValue,
+    };
+    CustomerIO.setProfileAttributes(profileAttributes);
+
+    setAttributeName('');
+    setAttributeValue('');
+
+    onClose();
+  };
+
+  return (
+    <Modal
+      animationType="slide"
+      transparent={true}
+      visible={visible}
+      onRequestClose={onClose}
+    >
+      <View style={styles.modalOverlay}>
+        <View style={styles.modalContainer}>
+          <Text style={styles.modalTitle}>Profile Attribute</Text>
+
+          <TextInput
+            style={styles.input}
+            placeholder="Attribute Name"
+            autoCapitalize="none"
+            value={attributeName}
+            onChangeText={setAttributeName}
+          />
+          <TextInput
+            style={styles.input}
+            placeholder="Attribute Value"
+            autoCapitalize="none"
+            value={attributeValue}
+            onChangeText={setAttributeValue}
+          />
+
+          <TouchableOpacity
+            style={styles.modalButton}
+            onPress={handlePopupButtonPress}
+          >
+            <Text style={styles.modalButtonText}>Submit</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContainer: {
+    width: '80%',
+    padding: 20,
+    backgroundColor: 'white',
+    borderRadius: 10,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+  modalTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 15,
+  },
+  input: {
+    width: '100%',
+    height: 40,
+    borderColor: '#ccc',
+    borderWidth: 1,
+    borderRadius: 5,
+    marginBottom: 10,
+    paddingHorizontal: 10,
+  },
+  modalButton: {
+    marginTop: 10,
+    backgroundColor: '#28a745',
+    padding: 10,
+    borderRadius: 5,
+  },
+  modalButtonText: {
+    color: 'white',
+    fontSize: 16,
+  },
+});


### PR DESCRIPTION
In this PR I've added some minor tweaks to the test app to enable full regression for the Expo plugin.

Changes include:
- Adding a `migrationSiteId` to test SDK migrations
- Added modal to add profile attributes
- Added a button to logout