### PR TITLE
chore: Build and publish iOS test app to Firebase

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -44,7 +44,7 @@ jobs:
         working-directory: plugin
         run: npm ci
 
-      - name: Setup test projects
+      - name: Setup test project
         run: npm run setup-tests
 
       - name: Setup CIO workspace credentials in test apps config
@@ -60,3 +60,59 @@ jobs:
         env:
           FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64: ${{ secrets.FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64 }}
 
+  build-ios-app:
+    name: Build and publish iOS app
+    runs-on: macos-14
+    env:
+      GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64: ${{ secrets.GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64 }}
+      FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64: ${{ secrets.FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64 }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install XCode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "15.3"
+      
+      - name: Install tools from Gemfile (ruby language) used for building our apps with
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+          bundler-cache: true
+
+      - name: Install SD CLI
+        run: brew install sd
+
+      - name: Bundle install
+        working-directory: test-app
+        run: bundle install
+
+      - name: Install plugin dependencies
+        working-directory: plugin
+        run: npm ci
+
+      - name: Setup test project
+        run: npm run setup-tests
+
+      - name: Setup CIO workspace credentials in test apps config
+        run: |
+          sd '@CDP_API_KEY@' "${{ secrets.CUSTOMERIO_EXPO_WORKSPACE_CDP_API_KEY }}" test-app/app.json
+          sd '@SITE_ID@' "${{ secrets.CUSTOMERIO_EXPO_WORKSPACE_SITE_ID }}" test-app/app.json
+
+      - name: Copy GoogleService-Info.plist to ios project
+        run: |
+          cp test-app/files/GoogleService-Info.plist test-app/ios/GoogleService-Info.plist
+          gem install xcodeproj
+          ruby scripts/add-google-service-ios.rb
+
+      - name: Build iOS app with fastlane
+        uses: maierj/fastlane-action@v3.1.0
+        with:
+          lane: ios build_ios
+          subdirectory: test-app
+        env:
+          GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64: ${{ secrets.GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64 }}
+          FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64: ${{ secrets.FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64 }}

--- a/scripts/add-google-service-ios.rb
+++ b/scripts/add-google-service-ios.rb
@@ -1,0 +1,27 @@
+require 'xcodeproj'
+
+project_path = 'test-app/ios/ExpoTestApp.xcodeproj'
+google_service_plist_path = 'GoogleService-Info.plist'
+target_name = 'ExpoTestApp'
+
+# Open the Xcode project
+project = Xcodeproj::Project.open(project_path)
+
+# Find the main app target
+target = project.targets.find { |t| t.name == target_name }
+if target.nil?
+  abort("Target '#{target_name}' not found in the project!")
+end
+
+# Add the GoogleService-Info.plist file to the project
+file_ref = project.new_file(google_service_plist_path)
+
+resources_build_phase = target.resources_build_phase
+unless resources_build_phase.files_references.include?(file_ref)
+  resources_build_phase.add_file_reference(file_ref)
+  puts "Added #{google_service_plist_path} to the #{target_name} target."
+end
+
+# Save the changes to the Xcode project
+project.save
+puts "Successfully updated the Xcode project."

--- a/test-app/app.json
+++ b/test-app/app.json
@@ -14,7 +14,10 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "io.customer.ami"
+      "bundleIdentifier": "io.customer.ami",
+      "entitlements": {
+        "aps-environment": "development"
+      }
     },
     "android": {
       "adaptiveIcon": {

--- a/test-app/fastlane/Fastfile
+++ b/test-app/fastlane/Fastfile
@@ -55,3 +55,91 @@ platform :android do
     )
   end
 end
+
+
+platform :ios do
+  lane :build_ios do |arguments|
+
+    download_ci_code_signing_files_local
+
+    xcodeproj_path = "./ios/ExpoTestApp.xcodeproj"
+
+    ios_set_version(
+      xcodeproj: xcodeproj_path,
+      version: get_new_app_version()
+    )
+    ios_set_build_number(
+      xcodeproj: xcodeproj_path,
+      build_number: get_new_build_version()
+    )
+
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path: xcodeproj_path
+    )
+
+    update_project_provisioning(
+      xcodeproj: xcodeproj_path,
+      target_filter: "ExpoTestApp",
+      profile: "/Users/runner/Library/MobileDevice/Provisioning Profiles/ad21ce7c-1f32-40df-a2f4-919c0be79e44.mobileprovision"
+    )
+
+    update_project_provisioning(
+      xcodeproj: xcodeproj_path,
+      target_filter: "NotificationService",
+      profile: "/Users/runner/Library/MobileDevice/Provisioning Profiles/c1055dbd-7028-4b54-a22d-807211e19f05.mobileprovision"
+    )
+
+    update_project_team(
+      path: xcodeproj_path,
+      teamid: "2YC97BQN3N"
+    )
+
+    gym(
+      scheme: "ExpoTestApp",
+      workspace: "ios/ExpoTestApp.xcworkspace",
+      export_method: "ad-hoc",
+      configuration: "Release",
+      codesigning_identity: "Apple Distribution: Peaberry Software, Inc. (2YC97BQN3N)",
+      export_options: {
+        provisioningProfiles: {
+          "io.customer.ami" => "match AdHoc io.customer.ami",
+          "io.customer.ami.richpush" => "match AdHoc io.customer.ami.richpush"
+        },
+        signingStyle: "manual",
+        teamID: "2YC97BQN3N"
+      },
+      export_xcargs: "-allowProvisioningUpdates CODE_SIGN_IDENTITY='Apple Distribution: Peaberry Software, Inc. (2YC97BQN3N)'"
+    )
+
+    # function 'setup_google_bucket_access' is a re-usable function inside of apple-code-signing Fastfile that we imported.
+    # This allows you to create a temporary file from a GitHub secret for added convenience.
+    # When uploading the build to Firebase App Distribution, the CI server needs to authenticate with Firebase. This is done with a
+    # Google Cloud Service Account json creds file. The base64 encoded value of this service account file is stored as this secret.
+    service_credentials_file_path = setup_google_bucket_access(
+      environment_variable_key: "FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64"
+    )
+
+    firebase_app_distribution(
+      service_credentials_file: service_credentials_file_path,
+      groups: get_build_test_groups(),
+      release_notes: get_build_notes()
+    )
+  end
+
+  lane :download_ci_code_signing_files_local do |values|  
+    google_cloud_keys_file_path = setup_google_bucket_access(
+      environment_variable_key: "GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64"
+    )
+  
+    sync_code_signing(
+      type: "adhoc",
+      readonly: true,
+      team_id: "2YC97BQN3N",
+      storage_mode: "google_cloud",
+      google_cloud_bucket_name: "ios_code_signing_files",
+      google_cloud_project_id: "remote-habits",
+      google_cloud_keys_file: google_cloud_keys_file_path
+    )
+  end 
+end

--- a/test-app/fastlane/Gymfile
+++ b/test-app/fastlane/Gymfile
@@ -1,0 +1,8 @@
+# For more information about this configuration run `fastlane gym --help` or check
+# out the documentation at https://docs.fastlane.tools/actions/gym/#gymfile
+
+configuration("Release")
+export_method("ad-hoc")
+# scheme in XCode workspace of native iOS app
+scheme("ExpoTestApp")
+workspace("ios/ExpoTestApp.xcworkspace")

--- a/test-app/fastlane/Matchfile
+++ b/test-app/fastlane/Matchfile
@@ -1,0 +1,6 @@
+storage_mode "google_cloud"
+type "adhoc"
+readonly true
+# IMPORTANT: use the same gcloud bucket name for *all* iOS apps we use in the company. 
+# fastlane is smart enough to share certificates while creating separate provisioning profiles for each app. 
+google_cloud_bucket_name "remote-habits-ios-signing"

--- a/test-app/files/GoogleService-Info.plist
+++ b/test-app/files/GoogleService-Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>1001564516023-gm9hi3ec7pkkh9hi4b8aivrrddfpk6qm.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.1001564516023-gm9hi3ec7pkkh9hi4b8aivrrddfpk6qm</string>
+	<key>API_KEY</key>
+	<string>AIzaSyApOVYacWweX4ab6a3rf8CmjqI4PmUvnEI</string>
+	<key>GCM_SENDER_ID</key>
+	<string>1001564516023</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>io.customer.ami</string>
+	<key>PROJECT_ID</key>
+	<string>remote-habits</string>
+	<key>STORAGE_BUCKET</key>
+	<string>remote-habits.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:1001564516023:ios:026d87787b3965221a2732</string>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds a job to build and publish the Expo iOS test app to Firebase.

_I am pretty sure some parts of the flow are not optimal, but this should be good enough to unblock testing and we can optimize the scripts later on._