### PR TITLE
chore: Setup deeplinking and in-app messaging listeners for test app

### DIFF
--- a/__tests__/android/__snapshots__/app-manifest.test.js.snap
+++ b/__tests__/android/__snapshots__/app-manifest.test.js.snap
@@ -34,6 +34,12 @@ exports[`Plugin injects CustomerIOFirebaseMessagingService in the app manifest 1
         <category android:name="android.intent.category.BROWSABLE"/>
         <data android:scheme="io.customer.ami"/>
       </intent-filter>
+      <intent-filter data-generated="true">
+        <action android:name="android.intent.action.VIEW"/>
+        <data android:scheme="expo-test-app" android:host="nav-test"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+      </intent-filter>
     </activity>
   </application>
 </manifest>"

--- a/test-app/App.js
+++ b/test-app/App.js
@@ -18,8 +18,7 @@ export default function App() {
     prefixes: ['expo-test-app://'],
     config: {
       screens: {
-        Dashboard: '',
-        Label: 'NavigationTest',
+        NavigationTest: 'nav-test'
       },
     },
   };

--- a/test-app/app.json
+++ b/test-app/app.json
@@ -17,6 +17,13 @@
       "bundleIdentifier": "io.customer.ami",
       "entitlements": {
         "aps-environment": "development"
+      },
+      "infoPlist": {
+        "CFBundleURLTypes": [
+          {
+            "CFBundleURLSchemes": ["expo-test-app"]
+          }
+        ]
       }
     },
     "android": {
@@ -24,7 +31,22 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "io.customer.ami"
+      "package": "io.customer.ami",
+      "intentFilters": [
+        {
+          "action": "VIEW",
+          "data": [
+            {
+              "scheme": "expo-test-app",
+              "host": "nav-test"
+            }
+          ],
+          "category": [
+            "BROWSABLE",
+            "DEFAULT"
+          ]
+        }
+      ]
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/test-app/helpers/InAppMessagingListener.js
+++ b/test-app/helpers/InAppMessagingListener.js
@@ -1,0 +1,22 @@
+import { CustomerIO, InAppMessageEventType } from 'customerio-reactnative';
+
+export function registerInAppMessagingEventListener() {
+  CustomerIO.inAppMessaging.registerEventsListener((event) => {
+    switch (event.eventType) {
+      case InAppMessageEventType.messageShown:
+        console.log('EXPO-TEST: In App message shown');
+        break;
+      case InAppMessageEventType.messageDismissed:
+        console.log('EXPO-TEST: In App message dismissed');
+        break;
+      case InAppMessageEventType.errorWithMessage:
+        console.log('EXPO-TEST: In App error showing message');
+        break;
+      case InAppMessageEventType.messageActionTaken:
+        console.log(
+          'EXPO-TEST: Message action taken'
+        );
+        break;
+    }
+  });
+}

--- a/test-app/screens/Dashboard.js
+++ b/test-app/screens/Dashboard.js
@@ -1,8 +1,10 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { View, Button, StyleSheet, Text } from 'react-native';
 import { requestPermissionForPush } from '../helpers/RequestPushPermission';
 import { useFocusEffect } from '@react-navigation/native';
 import Constants from 'expo-constants';
+import { Linking } from 'react-native';
+import { registerInAppMessagingEventListener } from '../helpers/InAppMessagingListener';
 
 import LoginModal from './LoginModal';
 import SendEventModal from './SendEventModal';
@@ -11,6 +13,10 @@ import ProfileAttributeModal from './ProfileAttributeModal';
 import { CustomerIO } from 'customerio-reactnative';
 
 export default function DashboardScreen({ navigation }) {
+  useEffect(() => {
+    registerInAppMessagingEventListener();
+  }, []);
+
   const [loginModalVisible, seLoginModalVisible] = useState(false);
   const [sendEventModalVisible, setSendEventModalVisible] = useState(false);
   const [deviceAttributeModalVisible, setDeviceAttributeModalVisible] =
@@ -31,6 +37,16 @@ export default function DashboardScreen({ navigation }) {
     navigation.navigate('NavigationTest');
   };
 
+  const handleDeeplinkToTestScreenButtonPressed = () => {
+    Linking.openURL('expo-test-app://nav-test')
+      .then(() => {
+        console.log('EXPO-TEST: Deeplinking to test screen opened successfully');
+      })
+      .catch((err) => {
+        console.error('EXPO-TEST: Deeplinking to test screen failed!', err);
+      });
+  };
+
   const handleLogoutButtonPressed = () => {
     CustomerIO.clearIdentify();
   };
@@ -40,7 +56,7 @@ export default function DashboardScreen({ navigation }) {
       CustomerIO.screen('Dashboard');
 
       return () => {
-        console.log('Leaving DashboardScreen');
+        console.log('EXPO-TEST: Leaving DashboardScreen');
       };
     }, [])
   );
@@ -83,6 +99,13 @@ export default function DashboardScreen({ navigation }) {
         <Button
           title="Navigate to test screen"
           onPress={handleNavigateToTestScreenButtonPressed}
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Button
+          title="Deeplink to test screen"
+          onPress={handleDeeplinkToTestScreenButtonPressed}
         />
       </View>
 

--- a/test-app/screens/NavigationTest.js
+++ b/test-app/screens/NavigationTest.js
@@ -11,7 +11,7 @@ export default function NavigationTestScreen() {
 
       // Optional cleanup logic
       return () => {
-        console.log('Leaving LabelScreen');
+        console.log('EXPO-TEST: Leaving LabelScreen');
       };
     }, [])
   );


### PR DESCRIPTION
This PR setups us two things that can help with testing SDK functionality:

#### Deep linking
We setup a scheme `expo-test-app://` for out test app that works with `nav-test` page.

The links that can be used are as such: `expo-test-app://nav-test`

You can test by either:
- Using one of the deeplinks above with a push notification
- Added a button that deep links to the test page

#### In-App messaging listeners
Added in-app messaging event listeners to make sure they are working