### PR TITLE
chore: update test app to use tarball plugin dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         run: npm publish --dry-run
 
   test-plugin:
-    name: Test unit tests for plguin
+    name: Test unit tests for plugin
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 .nvm
 npm-debug.log
 yarn-error.log
+*.tgz
 
 # OS X
 .DS_Store

--- a/local-development-readme.md
+++ b/local-development-readme.md
@@ -33,6 +33,16 @@ npx expo run:android
 npx expo run:ios
 ```
 
+### Plugin Dependency Installation
+
+> Note: For Node.js 18 or newer, this typically runs automatically with `npm install`.
+
+We use tarball dependency to ensure our expo plugin is installed as if it was published, avoiding path issues and ensuring dependencies are resolved consistently. If you face errors, run following command before running `npm install`:
+
+```bash
+npm run preinstall
+``` 
+
 ## Convenience scripts
 
 Sometimes when you are making changes to the plugin, it's helpful to clear out dependencies or rebuild the plugin. There are a couple of convenience scripts that you can use.

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -9,7 +9,7 @@ print_blue "\nInstalling root dependencies for plugin and tests...\n"
 npm install
 
 print_blue "\nInstalling test-app dependencies...\n"
-(cd test-app && npm install)
+(cd test-app && npm run preinstall && npm install)
 
 print_blue "\nGenerating Android and iOS native projects...\n"
 (cd test-app && npx npx expo prebuild)

--- a/scripts/install-plugin-tarball.sh
+++ b/scripts/install-plugin-tarball.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Script that generates a tarball for the npm package.
+#
+# Designed to be run before installing dependencies in the app.
+#
+# Use script: npm run install (in test-app)
+# Ensures the tarball name is consistent to avoid unnecessary git diffs.
+
+set -e
+
+# Define constants
+PLUGIN_NAME="customerio-expo-plugin"
+PLUGIN_PATH_RELATIVE=${1:-..} # Default plugin path to `..` if no argument is provided
+TARBALL_NAME=$PLUGIN_NAME-latest.tgz
+TARBALL_PATTERN=$PLUGIN_NAME-*.tgz
+START_DIR=$(pwd) # Save the current directory (starting directory)
+
+echo "================================="
+echo "Running install-plugin-tarball.sh"
+echo "================================="
+echo "Starting in directory: $START_DIR with relative plugin path: $PLUGIN_PATH_RELATIVE"
+echo "Generating tarball for the plugin..."
+
+# Navigate to root plugin directory
+cd $PLUGIN_PATH_RELATIVE
+# Remove any existing matching tarball to avoid conflicts
+rm $TARBALL_PATTERN || true
+# Generate the tarball using npm pack
+# This creates a tarball named based on the `name` and `version` fields in the package.json
+npm pack --silent
+# Rename the tarball to a consistent name
+mv $TARBALL_PATTERN $TARBALL_NAME
+echo "Tarball created: $TARBALL_NAME" at $(pwd)
+
+# Return to the starting directory
+cd $START_DIR
+echo "Returned to directory: $START_DIR"
+
+echo "Uninstalling existing plugin and installing the tarball to ensure it's up-to-date..."
+npm uninstall $PLUGIN_NAME --no-save
+npm install "$PLUGIN_PATH_RELATIVE/$TARBALL_NAME" --silent
+
+echo "Plugin tarball installed successfully!"
+
+echo "==================================="
+echo "install-plugin-tarball.sh completed"
+echo "==================================="

--- a/scripts/install-plugin-tarball.sh
+++ b/scripts/install-plugin-tarball.sh
@@ -7,6 +7,8 @@
 # Use script: npm run install (in test-app)
 # Ensures the tarball name is consistent to avoid unnecessary git diffs.
 
+# Includes utils.sh script located in the same directory as this script
+source "$(dirname "$0")/utils.sh"
 set -e
 
 # Define constants
@@ -16,11 +18,10 @@ TARBALL_NAME=$PLUGIN_NAME-latest.tgz
 TARBALL_PATTERN=$PLUGIN_NAME-*.tgz
 START_DIR=$(pwd) # Save the current directory (starting directory)
 
-echo "================================="
-echo "Running install-plugin-tarball.sh"
-echo "================================="
-echo "Starting in directory: $START_DIR with relative plugin path: $PLUGIN_PATH_RELATIVE"
-echo "Generating tarball for the plugin..."
+print_heading "Running install-plugin-tarball.sh script..."
+
+print_blue "Starting in directory: '$START_DIR' with relative plugin path: '$PLUGIN_PATH_RELATIVE'"
+print_blue "Generating tarball for expo plugin...\n"
 
 # Navigate to root plugin directory
 cd $PLUGIN_PATH_RELATIVE
@@ -31,18 +32,14 @@ rm $TARBALL_PATTERN || true
 npm pack --silent
 # Rename the tarball to a consistent name
 mv $TARBALL_PATTERN $TARBALL_NAME
-echo "Tarball created: $TARBALL_NAME" at $(pwd)
+print_blue "\nTarball created successfully: '$TARBALL_NAME' at '$(pwd)'"
 
 # Return to the starting directory
 cd $START_DIR
-echo "Returned to directory: $START_DIR"
+print_blue "Returned to directory: '$(pwd)'"
 
-echo "Uninstalling existing plugin and installing the tarball to ensure it's up-to-date..."
+print_blue "Uninstalling existing expo plugin and installing tarball dependency to ensure it is up-to-date..."
 npm uninstall $PLUGIN_NAME --no-save
 npm install "$PLUGIN_PATH_RELATIVE/$TARBALL_NAME" --silent
 
-echo "Plugin tarball installed successfully!"
-
-echo "==================================="
-echo "install-plugin-tarball.sh completed"
-echo "==================================="
+print_success "✅ $TARBALL_NAME dependency installed successfully!"

--- a/scripts/setup-test.sh
+++ b/scripts/setup-test.sh
@@ -7,6 +7,7 @@ echo "Setting up the test project..."
 cd test-app
 
 echo "Installing dependencies..."
+npm run preinstall
 npm install
 
 echo "Running expo prebuild..."

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -7,11 +7,12 @@
     "": {
       "name": "test-app",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@react-native-community/masked-view": "^0.1.11",
         "@react-navigation/native": "^7.0.14",
         "@react-navigation/stack": "^7.1.0",
-        "customerio-expo-plugin": "file:..",
+        "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
         "customerio-reactnative": "^4.1.1",
         "expo": "~52.0.11",
         "expo-status-bar": "~2.0.0",
@@ -25,37 +26,6 @@
       },
       "devDependencies": {
         "@babel/core": "^7.20.0"
-      }
-    },
-    "..": {
-      "version": "1.0.0-beta.17",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-package-json": "^1.2.0",
-        "fs-extra": "^11.2.0"
-      },
-      "devDependencies": {
-        "@expo/config-plugins": "^4.1.4",
-        "@expo/config-types": "^44.0.0",
-        "@types/jest": "^29.5.14",
-        "@typescript-eslint/eslint-plugin": "^5.21.0",
-        "@typescript-eslint/parser": "^5.21.0",
-        "eslint": "^8.14.0",
-        "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-prettier": "^4.0.0",
-        "expo-build-properties": "^0.2.0",
-        "expo-module-scripts": "^2.0.0",
-        "jest": "^29.7.0",
-        "jest-environment-jsdom": "^29.7.0",
-        "prettier": "^2.6.2",
-        "react-native-builder-bob": "^0.18.3",
-        "ts-jest": "^29.2.5",
-        "typescript": "^4.6.4",
-        "xcode": "^3.0.1"
-      },
-      "peerDependencies": {
-        "customerio-reactnative": ">=3.4.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -5204,8 +5174,53 @@
       }
     },
     "node_modules/customerio-expo-plugin": {
-      "resolved": "..",
-      "link": true
+      "version": "1.0.0-beta.17",
+      "resolved": "file:../customerio-expo-plugin-latest.tgz",
+      "integrity": "sha512-nCDP4Ofk4cZ7HMM3Jo5b+foen2cQHuqu4jJtjOg3MkKlQtNs7BgbwoHZz751T6TFszg/puhBb3U7fvefru6dDA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-package-json": "^1.2.0",
+        "fs-extra": "^11.2.0"
+      },
+      "peerDependencies": {
+        "customerio-reactnative": ">=3.4.0"
+      }
+    },
+    "node_modules/customerio-expo-plugin/node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/customerio-expo-plugin/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/customerio-expo-plugin/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/customerio-reactnative": {
       "version": "4.1.1",
@@ -5986,6 +6001,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/find-package-json": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-package-json/-/find-package-json-1.2.0.tgz",
+      "integrity": "sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "install-plugin": "bash ../scripts/install-plugin-tarball.sh ..",
+    "preinstall": "npm run install-plugin",
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
@@ -12,7 +14,7 @@
     "@react-native-community/masked-view": "^0.1.11",
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/stack": "^7.1.0",
-    "customerio-expo-plugin": "file:..",
+    "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
     "customerio-reactnative": "^4.1.1",
     "expo": "~52.0.11",
     "expo-status-bar": "~2.0.0",


### PR DESCRIPTION
part of [MBL-541](https://linear.app/customerio/issue/MBL-541/expo-user-agent)

### Background

Currently, the plugin is added as relative path dependency, causing path resolution issues in post-install scripts. These scripts rely on locating our React Native package in `node_modules`, but relative path setup fails to meet this expectation. This made testing iOS user agent changes a bit challenging. So I switched to tarball dependency, matching what we already do in our React Native apps. It resolves this issue by packaging the plugin as a final version that works fine with existing scripts without changing anything in plugin.

### Changes

- Added script to install and update the plugin dependency as a tarball for test app
- Updated README and package files to simplify running new scripts