### PR TITLE
chore: Bumping SDK version to 2.0.0-beta.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-expo-plugin",
-  "version": "1.0.0-beta.17",
+  "version": "2.0.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-expo-plugin",
-      "version": "1.0.0-beta.17",
+      "version": "2.0.0-beta.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "customerio-expo-plugin",
-  "version": "1.0.0-beta.19",
+  "version": "2.0.0-beta.0",
   "description": "Expo config plugin for the Customer IO React Native SDK",
   "main": "plugin/lib/commonjs/index",
   "module": "plugin/lib/module/index",


### PR DESCRIPTION
 Bumping SDK version to 2.0.0-beta.0