### PR TITLE
chore: update sample app name

### DIFF
--- a/__tests__/ios/AppDelegate-header.test.js
+++ b/__tests__/ios/AppDelegate-header.test.js
@@ -3,7 +3,7 @@ const path = require("path");
 
 const testProjectPath = path.join(__dirname, "../../test-app");
 const iosPath = path.join(testProjectPath, "ios");
-const appDelegateHeaderPath = path.join(iosPath, "ExpoTestApp/AppDelegate.h");
+const appDelegateHeaderPath = path.join(iosPath, "ExpoTestbed/AppDelegate.h");
 
 test("Plugin injects CIO imports and calls into AppDelegate.h", async () => {
   const content = await fs.readFile(appDelegateHeaderPath, "utf8");

--- a/__tests__/ios/AppDelegate-impl.test.js
+++ b/__tests__/ios/AppDelegate-impl.test.js
@@ -3,7 +3,7 @@ const path = require("path");
 
 const testProjectPath = path.join(__dirname, "../../test-app");
 const iosPath = path.join(testProjectPath, "ios");
-const appDelegateImplPath = path.join(iosPath, "ExpoTestApp/AppDelegate.mm");
+const appDelegateImplPath = path.join(iosPath, "ExpoTestbed/AppDelegate.mm");
 
 test("Plugin injects CIO imports and calls into AppDelegate.mm", async () => {
   const content = await fs.readFile(appDelegateImplPath, "utf8");

--- a/__tests__/ios/PushService-swift.test.js
+++ b/__tests__/ios/PushService-swift.test.js
@@ -3,7 +3,7 @@ const path = require("path");
 
 const testProjectPath = path.join(__dirname, "../../test-app");
 const iosPath = path.join(testProjectPath, "ios");
-const pushServicePath = path.join(iosPath, "ExpoTestApp/PushService.swift");
+const pushServicePath = path.join(iosPath, "ExpoTestbed/PushService.swift");
 
 test("Plugin creates expected PushService.swift", async () => {
   const content = await fs.readFile(pushServicePath, "utf8");

--- a/__tests__/ios/__snapshots__/AppDelegate-impl.test.js.snap
+++ b/__tests__/ios/__snapshots__/AppDelegate-impl.test.js.snap
@@ -9,7 +9,7 @@ exports[`Plugin injects CIO imports and calls into AppDelegate.mm 1`] = `
 
 // Add swift bridge imports
 #import <ExpoModulesCore-Swift.h>
-#import <ExpoTestApp-Swift.h>
+#import <ExpoTestbed-Swift.h>
   
 #import "AppDelegate.h"
 

--- a/__tests__/ios/__snapshots__/PodFile.test.js.snap
+++ b/__tests__/ios/__snapshots__/PodFile.test.js.snap
@@ -16,7 +16,7 @@ install! 'cocoapods',
 
 prepare_react_native_project!
 
-target 'ExpoTestApp' do
+target 'ExpoTestbed' do
   use_expo_modules!
 
   if ENV['EXPO_USE_COMMUNITY_AUTOLINKING'] == '1'

--- a/scripts/add-google-service-ios.rb
+++ b/scripts/add-google-service-ios.rb
@@ -1,8 +1,8 @@
 require 'xcodeproj'
 
-project_path = 'test-app/ios/ExpoTestApp.xcodeproj'
+project_path = 'test-app/ios/ExpoTestbed.xcodeproj'
 google_service_plist_path = 'GoogleService-Info.plist'
-target_name = 'ExpoTestApp'
+target_name = 'ExpoTestbed'
 
 # Open the Xcode project
 project = Xcodeproj::Project.open(project_path)

--- a/test-app/app.json
+++ b/test-app/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "Expo Test App",
+    "name": "Expo Testbed",
     "slug": "expo-test-app",
     "version": "1.0.0",
     "orientation": "portrait",

--- a/test-app/fastlane/Fastfile
+++ b/test-app/fastlane/Fastfile
@@ -53,7 +53,7 @@ platform :ios do
 
     download_ci_code_signing_files_local
 
-    xcodeproj_path = "./ios/ExpoTestApp.xcodeproj"
+    xcodeproj_path = "./ios/ExpoTestbed.xcodeproj"
 
     update_code_signing_settings(
       use_automatic_signing: false,
@@ -62,14 +62,14 @@ platform :ios do
 
     update_project_provisioning(
       xcodeproj: xcodeproj_path,
-      target_filter: "ExpoTestApp",
-      profile: "/Users/runner/Library/MobileDevice/Provisioning Profiles/ad21ce7c-1f32-40df-a2f4-919c0be79e44.mobileprovision"
+      target_filter: "ExpoTestbed",
+      profile: "/Users/runner/Library/MobileDevice/Provisioning Profiles/d3cc77cc-5db1-407e-8d0c-1be8adcfe21f.mobileprovision"
     )
 
     update_project_provisioning(
       xcodeproj: xcodeproj_path,
       target_filter: "NotificationService",
-      profile: "/Users/runner/Library/MobileDevice/Provisioning Profiles/c1055dbd-7028-4b54-a22d-807211e19f05.mobileprovision"
+      profile: "/Users/runner/Library/MobileDevice/Provisioning Profiles/58de181b-adc5-4ac2-ae96-13139f8c72db.mobileprovision"
     )
 
     update_project_team(
@@ -78,8 +78,8 @@ platform :ios do
     )
 
     gym(
-      scheme: "ExpoTestApp",
-      workspace: "ios/ExpoTestApp.xcworkspace",
+      scheme: "ExpoTestbed",
+      workspace: "ios/ExpoTestbed.xcworkspace",
       export_method: "ad-hoc",
       configuration: "Release",
       codesigning_identity: "Apple Distribution: Peaberry Software, Inc. (2YC97BQN3N)",

--- a/test-app/fastlane/Gymfile
+++ b/test-app/fastlane/Gymfile
@@ -4,5 +4,5 @@
 configuration("Release")
 export_method("ad-hoc")
 # scheme in XCode workspace of native iOS app
-scheme("ExpoTestApp")
-workspace("ios/ExpoTestApp.xcworkspace")
+scheme("ExpoTestbed")
+workspace("ios/ExpoTestbed.xcworkspace")

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -5174,9 +5174,9 @@
       }
     },
     "node_modules/customerio-expo-plugin": {
-      "version": "1.0.0-beta.17",
+      "version": "2.0.0-beta.1",
       "resolved": "file:../customerio-expo-plugin-latest.tgz",
-      "integrity": "sha512-nCDP4Ofk4cZ7HMM3Jo5b+foen2cQHuqu4jJtjOg3MkKlQtNs7BgbwoHZz751T6TFszg/puhBb3U7fvefru6dDA==",
+      "integrity": "sha512-Rj7YYUEkzHSXxK4wKonyko2kEwcmr7TyI9MLEpD9UTpA19/hpfQ0DENRwo1F+T38YaLXeEX9IY1y/BJEY/cABA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
part of: [MBL-742](https://linear.app/customerio/issue/MBL-742/has-easy-to-understand-app-name)

### Changes

- Renamed app from `Expo Test App` to `Expo`
- Lock file updates

Please refer to linked ticket for more details about these changes.

### Screenshots  

**Launcher**

_iOS_

![Simulator Screenshot - iPhone 16 - 2025-01-07 at 20 13 07-crop](https://github.com/user-attachments/assets/7dec135d-00db-444e-a3d4-2db3a755215b)

_Android_

![Screenshot_20250107_202443-crop](https://github.com/user-attachments/assets/3b51a2bd-1eb2-41f5-8a55-5206481b20ea)
