### PR TITLE
chore: update sample app groups

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -27,6 +27,26 @@ jobs:
           distribution: "temurin"
           java-version: "17"
       
+      - name: Set Default Firebase Distribution Groups
+        run: |
+          # Define all the possible distribution groups
+          ALL_BUILDS_GROUP="all-builds"
+          FEATURE_BUILDS_GROUP="feature-branch"
+          STABLE_BUILDS_GROUP="next"
+          
+          # Initialize with the default distribution group
+          distribution_groups=("$ALL_BUILDS_GROUP")
+          
+          # Determine current app type and Git context
+          current_branch="${GITHUB_REF}"
+          
+          # Append distribution groups based on branch and context
+          [[ "$current_branch" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
+          [[ "$current_branch" == "refs/heads/main" ]] && distribution_groups+=("$STABLE_BUILDS_GROUP")
+          
+          # Export the groups as an environment variable
+          echo "firebase_distribution_groups=$(IFS=','; echo "${distribution_groups[*]}")" >> $GITHUB_ENV
+
       - name: Install tools from Gemfile (ruby language) used for building our apps with
         uses: ruby/setup-ruby@v1
         with:
@@ -63,6 +83,7 @@ jobs:
         with:
           lane: android build
           subdirectory: test-app
+          options: '{"distribution_groups": "${{ env.firebase_distribution_groups }}"}'
         env:
           FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64: ${{ secrets.FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64 }}
 
@@ -125,6 +146,7 @@ jobs:
         with:
           lane: ios build_ios
           subdirectory: test-app
+          options: '{"distribution_groups": "${{ env.firebase_distribution_groups }}"}'
         env:
           GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64: ${{ secrets.GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64 }}
           FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64: ${{ secrets.FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64 }}

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -28,22 +28,24 @@ jobs:
           java-version: "17"
       
       - name: Set Default Firebase Distribution Groups
+        shell: bash
+        env:
+          # Distribution group constants
+          ALL_BUILDS_GROUP: all-builds
+          FEATURE_BUILDS_GROUP: feature-branch
+          NEXT_BUILDS_GROUP: next
+          PUBLIC_BUILDS_GROUP: public
+          # Input variables
+          CURRENT_BRANCH: ${{ github.ref }}
         run: |
-          # Define all the possible distribution groups
-          ALL_BUILDS_GROUP="all-builds"
-          FEATURE_BUILDS_GROUP="feature-branch"
-          STABLE_BUILDS_GROUP="next"
-          
           # Initialize with the default distribution group
           distribution_groups=("$ALL_BUILDS_GROUP")
-          
-          # Determine current app type and Git context
-          current_branch="${GITHUB_REF}"
-          
-          # Append distribution groups based on branch and context
-          [[ "$current_branch" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
-          [[ "$current_branch" == "refs/heads/main" ]] && distribution_groups+=("$STABLE_BUILDS_GROUP")
-          
+
+          # Determine current app type and git context
+          [[ "$CURRENT_BRANCH" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
+          [[ "$CURRENT_BRANCH" == "refs/heads/main" ]] && distribution_groups+=("$NEXT_BUILDS_GROUP")
+          [[ "$CURRENT_BRANCH" == "refs/heads/main" ]] && distribution_groups+=("$PUBLIC_BUILDS_GROUP")
+
           # Export the groups as an environment variable
           echo "firebase_distribution_groups=$(IFS=','; echo "${distribution_groups[*]}")" >> $GITHUB_ENV
 

--- a/test-app/fastlane/Fastfile
+++ b/test-app/fastlane/Fastfile
@@ -41,7 +41,7 @@ platform :android do
       apk_path: distribution_apk_path,
       app: firebase_app_id,
       service_credentials_file: service_credentials_file_path,
-      groups: get_build_test_groups(),
+      groups: get_build_test_groups(distribution_groups: values[:distribution_groups]),
       release_notes: get_build_notes()
     )
   end
@@ -101,7 +101,7 @@ platform :ios do
 
     firebase_app_distribution(
       service_credentials_file: service_credentials_file_path,
-      groups: get_build_test_groups(),
+      groups: get_build_test_groups(distribution_groups: arguments[:distribution_groups]),
       release_notes: get_build_notes()
     )
   end


### PR DESCRIPTION
part of: [MBL-710](https://linear.app/customerio/issue/MBL-710/single-app-per-platform-distributed-to-firebase)

### Changes

- Updated `Build Sample Apps` action to push sample app to relevant channels
- Modified `get_build_test_groups` lane to decouple from GitHub and accept arguments for passing Firebase distribution groups when distributing sample apps

Please refer to linked ticket for detailed expectations regarding channel distribution.