### PR TITLE
chore: fix test sample app ui for ios

### DIFF
--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -66,7 +66,6 @@ jobs:
         run: |
           touch "test-app/local.env"
           echo "sdkVersion=${{ steps.latest-sdk-version-step.outputs.LATEST_TAG }}" >> "test-app/local.env"
-          
 
       - name: Install tools from Gemfile (ruby language) used for building our apps with
         uses: ruby/setup-ruby@v1
@@ -205,9 +204,20 @@ jobs:
         run: npm run setup-test-app
 
       - name: Setup CIO workspace credentials in test apps config
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          COMMIT_HASH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
-          sd '@CDP_API_KEY@' "${{ secrets.CUSTOMERIO_EXPO_WORKSPACE_CDP_API_KEY }}" test-app/app.json
-          sd '@SITE_ID@' "${{ secrets.CUSTOMERIO_EXPO_WORKSPACE_SITE_ID }}" test-app/app.json
+          APP_JSON_FILE="test-app/app.json"
+          sd "\"buildTimestamp\": .*" "\"buildTimestamp\": $(date +%s)," "$APP_JSON_FILE"
+          sd "\"cdpApiKey\".*" "\"cdpApiKey\": \"${{ secrets.CUSTOMERIO_EXPO_WORKSPACE_CDP_API_KEY }}\"," "$APP_JSON_FILE"
+          sd "\"siteId\".*" "\"siteId\": \"${{ secrets.CUSTOMERIO_EXPO_WORKSPACE_SITE_ID }}\"," "$APP_JSON_FILE"
+          sd "\"workspaceName\".*" "\"workspaceName\": \"Mobile: Expo\"," "$APP_JSON_FILE"
+          sd "\"branchName\".*" "\"branchName\": \"$BRANCH_NAME\"," "$APP_JSON_FILE"
+          sd "\"commitHash\".*" "\"commitHash\": \"${COMMIT_HASH:0:7}\"," "$APP_JSON_FILE"
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "untagged")
+          COMMITS_AHEAD=$(git rev-list $LAST_TAG..HEAD --count 2>/dev/null || echo "untracked")
+          sd "\"commitsAheadCount\".*" "\"commitsAheadCount\": \"$COMMITS_AHEAD\"," "$APP_JSON_FILE"
 
       - name: Copy GoogleService-Info.plist to ios project
         run: |

--- a/test-app/helpers/BuildMetadata.js
+++ b/test-app/helpers/BuildMetadata.js
@@ -22,13 +22,16 @@ const BuildMetadata = {
     const siteId = resolveValidOrElse(extras.siteId, () => 'Failed to load!');
 
     return `
-      CDP API Key: ${cdpApiKey} \tSite ID: ${siteId}
+      CDP API Key: ${cdpApiKey}
+      Site ID: ${siteId}
       Plugin Version: ${this.pluginVersion}
-      SDK Version: ${this.sdkVersion} \tApp Version: ${this.appVersion}
+      RN SDK Version: ${this.sdkVersion}
+      App Version: ${this.appVersion}
       Build Date: ${this.buildDate}
       Branch: ${this.gitMetadata}
       Default Workspace: ${this.defaultWorkspace}
-      Language: ${this.language} \tUI Framework: ${this.uiFramework}
+      Language: ${this.language}
+      UI Framework: ${this.uiFramework}
       SDK Integration: ${this.sdkIntegration}
     `;
   },

--- a/test-app/screens/Dashboard.js
+++ b/test-app/screens/Dashboard.js
@@ -1,17 +1,15 @@
-import React, { useState, useCallback, useEffect } from 'react';
-import { View, Button, StyleSheet, Text } from 'react-native';
-import { requestPermissionForPush } from '../helpers/RequestPushPermission';
 import { useFocusEffect } from '@react-navigation/native';
-import Constants from 'expo-constants';
-import { Linking } from 'react-native';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Button, Linking, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { registerInAppMessagingEventListener } from '../helpers/InAppMessagingListener';
+import { requestPermissionForPush } from '../helpers/RequestPushPermission';
 
-import LoginModal from './LoginModal';
-import SendEventModal from './SendEventModal';
-import DeviceAttributeModal from './DeviceAttributesModal';
-import ProfileAttributeModal from './ProfileAttributeModal';
 import { CustomerIO } from 'customerio-reactnative';
 import { BuildMetadata } from '../helpers/BuildMetadata';
+import DeviceAttributeModal from './DeviceAttributesModal';
+import LoginModal from './LoginModal';
+import ProfileAttributeModal from './ProfileAttributeModal';
+import SendEventModal from './SendEventModal';
 
 export default function DashboardScreen({ navigation }) {
   useEffect(() => {
@@ -61,59 +59,63 @@ export default function DashboardScreen({ navigation }) {
 
   return (
     <View style={styles.container}>
-      <View style={styles.section}>
-        <Button title="Login" onPress={() => seLoginModalVisible(true)} />
-      </View>
+      <ScrollView contentContainerStyle={styles.content}>
+        <View style={styles.section}>
+          <Button title="Login" onPress={() => seLoginModalVisible(true)} />
+        </View>
 
-      <View style={styles.section}>
-        <Button
-          title="Send event"
-          onPress={() => setSendEventModalVisible(true)}
-        />
-      </View>
+        <View style={styles.section}>
+          <Button
+            title="Send event"
+            onPress={() => setSendEventModalVisible(true)}
+          />
+        </View>
 
-      <View style={styles.section}>
-        <Button
-          title="Profile Attribute"
-          onPress={() => setProfileAttributeModalVisible(true)}
-        />
-      </View>
+        <View style={styles.section}>
+          <Button
+            title="Profile Attribute"
+            onPress={() => setProfileAttributeModalVisible(true)}
+          />
+        </View>
 
-      <View style={styles.section}>
-        <Button
-          title="Device attribute"
-          onPress={() => setDeviceAttributeModalVisible(true)}
-        />
-      </View>
+        <View style={styles.section}>
+          <Button
+            title="Device attribute"
+            onPress={() => setDeviceAttributeModalVisible(true)}
+          />
+        </View>
 
-      <View style={styles.section}>
-        <Button
-          title="Request push permission"
-          onPress={handleRequestPushPermissionButtonPressed}
-        />
-      </View>
+        <View style={styles.section}>
+          <Button
+            title="Request push permission"
+            onPress={handleRequestPushPermissionButtonPressed}
+          />
+        </View>
 
-      <View style={styles.section}>
-        <Button
-          title="Navigate to test screen"
-          onPress={handleNavigateToTestScreenButtonPressed}
-        />
-      </View>
+        <View style={styles.section}>
+          <Button
+            title="Navigate to test screen"
+            onPress={handleNavigateToTestScreenButtonPressed}
+          />
+        </View>
 
-      <View style={styles.section}>
-        <Button
-          title="Deeplink to test screen"
-          onPress={handleDeeplinkToTestScreenButtonPressed}
-        />
-      </View>
+        <View style={styles.section}>
+          <Button
+            title="Deeplink to test screen"
+            onPress={handleDeeplinkToTestScreenButtonPressed}
+          />
+        </View>
 
-      <View style={styles.section}>
-        <Button title="Logout" onPress={handleLogoutButtonPressed} />
-      </View>
+        <View style={styles.section}>
+          <Button title="Logout" onPress={handleLogoutButtonPressed} />
+        </View>
 
-      <View style={styles.bottomLabelContainer}>
-        <Text style={styles.bottomLabel}>{workspaceInfo}</Text>
-      </View>
+        <View style={styles.spacer} />
+
+        <View style={styles.bottomLabelContainer}>
+          <Text style={styles.bottomLabel}>{workspaceInfo}</Text>
+        </View>
+      </ScrollView>
 
       <LoginModal
         visible={loginModalVisible}
@@ -138,9 +140,17 @@ export default function DashboardScreen({ navigation }) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'flex-start',
+    justifyContent: 'center',
     alignItems: 'center',
-    padding: 20,
+  },
+  content: {
+    flexGrow: 1,
+    paddingVertical: 20,
+    paddingHorizontal: 10,
+    alignItems: 'center',
+  },
+  spacer: {
+    flexGrow: 1,
   },
   section: {
     marginBottom: 20,
@@ -156,8 +166,7 @@ const styles = StyleSheet.create({
     width: '80%',
   },
   bottomLabelContainer: {
-    position: 'absolute',
-    bottom: 20, // Distance from the bottom of the screen
+    marginTop: 20,
     alignItems: 'center',
     width: '100%',
   },


### PR DESCRIPTION
closes: [MBL-929](https://linear.app/customerio/issue/MBL-929/bug-expo-testbed-not-all-build-info-is-showing-properly)

### Changes

- Fixed missing `app.json` updates in iOS sample app workflow
- Updated build info formatting to display one item per line, preventing UI breaks
- Added scroll support to `Dashboard` screen to ensure UI adapts properly to different screen sizes

### Screenshots

| Before | After (with scroll) |
| - | - |
| ![Screenshot 2025-02-17 at 1 21 15 PM](https://github.com/user-attachments/assets/1b50cc05-f22e-4e8d-915c-4b3e7dc99c2a) | ![Screenshot 2025-02-17 at 2 09 07 PM](https://github.com/user-attachments/assets/a0b6f491-1b6b-4b5b-8593-832d741c6a6a) |