### PR TITLE
chore: Build iOS sample app for FCM and APN

### DIFF
--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -139,6 +139,9 @@ jobs:
   build-ios-app:
     name: Build and publish iOS app
     runs-on: macos-14
+    strategy:
+      matrix:
+        push_provider: [fcm, apn]
     env:
       GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64: ${{ secrets.GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64 }}
       FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64: ${{ secrets.FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64 }}
@@ -185,10 +188,13 @@ jobs:
           echo "firebase_distribution_groups=$(IFS=','; echo "${distribution_groups[*]}")" >> $GITHUB_ENV
 
       - name: Setup local.env file for sample app
-        if: ${{ inputs.use_latest_sdk_version == true }}
+        shell: bash
         run: |
           touch "test-app/local.env"
-          echo "sdkVersion=${{ env.LATEST_TAG }}" >> "test-app/local.env"
+          if [ "${{ inputs.use_latest_sdk_version }}" == "true" ]; then
+            echo "sdkVersion=${{ env.LATEST_TAG }}" >> "test-app/local.env"
+          fi
+          echo "pushProvider=${{ matrix.push_provider }}" >> "test-app/local.env"
 
       - name: Install XCode
         uses: maxim-lobanov/setup-xcode@v1
@@ -229,14 +235,20 @@ jobs:
         run: |
           APP_JSON_FILE="test-app/app.json"
           sd "\"buildTimestamp\": .*" "\"buildTimestamp\": $(date +%s)," "$APP_JSON_FILE"
-          sd "\"cdpApiKey\".*" "\"cdpApiKey\": \"${{ secrets.CUSTOMERIO_EXPO_WORKSPACE_CDP_API_KEY }}\"," "$APP_JSON_FILE"
-          sd "\"siteId\".*" "\"siteId\": \"${{ secrets.CUSTOMERIO_EXPO_WORKSPACE_SITE_ID }}\"," "$APP_JSON_FILE"
           sd "\"workspaceName\".*" "\"workspaceName\": \"Mobile: Expo\"," "$APP_JSON_FILE"
           sd "\"branchName\".*" "\"branchName\": \"${{ env.BRANCH_NAME }}\"," "$APP_JSON_FILE"
           sd "\"commitHash\".*" "\"commitHash\": \"${{ env.COMMIT_HASH }}\"," "$APP_JSON_FILE"
           LAST_TAG="${LATEST_TAG:-untagged}"
           COMMITS_AHEAD=$(git rev-list $LAST_TAG..HEAD --count 2>/dev/null || echo "untracked")
           sd "\"commitsAheadCount\".*" "\"commitsAheadCount\": \"$COMMITS_AHEAD\"," "$APP_JSON_FILE"
+
+          if [ "${{ matrix.push_provider }}" == "fcm" ]; then
+            sd "\"cdpApiKey\".*" "\"cdpApiKey\": \"${{ secrets.TMP_CUSTOMERIO_EXPO_FCM_WORKSPACE_CDP_API_KEY }}\"," "$APP_JSON_FILE"
+            sd "\"siteId\".*" "\"siteId\": \"${{ secrets.TMP_CUSTOMERIO_EXPO_FCM_WORKSPACE_SITE_ID }}\"," "$APP_JSON_FILE"
+          else
+            sd "\"cdpApiKey\".*" "\"cdpApiKey\": \"${{ secrets.CUSTOMERIO_EXPO_WORKSPACE_CDP_API_KEY }}\"," "$APP_JSON_FILE"
+            sd "\"siteId\".*" "\"siteId\": \"${{ secrets.CUSTOMERIO_EXPO_WORKSPACE_SITE_ID }}\"," "$APP_JSON_FILE"
+          fi
 
       - name: Copy GoogleService-Info.plist to ios project
         run: |

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -262,7 +262,7 @@ jobs:
         with:
           lane: ios build_ios
           subdirectory: test-app
-          options: '{"distribution_groups": "${{ env.firebase_distribution_groups }}"}'
+          options: '{"distribution_groups": "${{ env.firebase_distribution_groups }}", "push_provider": "${{ matrix.push_provider }}"}'
         env:
           GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64: ${{ secrets.GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64 }}
           FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64: ${{ secrets.FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64 }}

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -243,8 +243,8 @@ jobs:
           sd "\"commitsAheadCount\".*" "\"commitsAheadCount\": \"$COMMITS_AHEAD\"," "$APP_JSON_FILE"
 
           if [ "${{ matrix.push_provider }}" == "fcm" ]; then
-            sd "\"cdpApiKey\".*" "\"cdpApiKey\": \"${{ secrets.TMP_CUSTOMERIO_EXPO_FCM_WORKSPACE_CDP_API_KEY }}\"," "$APP_JSON_FILE"
-            sd "\"siteId\".*" "\"siteId\": \"${{ secrets.TMP_CUSTOMERIO_EXPO_FCM_WORKSPACE_SITE_ID }}\"," "$APP_JSON_FILE"
+            sd "\"cdpApiKey\".*" "\"cdpApiKey\": \"${{ secrets.CUSTOMERIO_RN_FCM_WORKSPACE_CDP_API_KEY }}\"," "$APP_JSON_FILE"
+            sd "\"siteId\".*" "\"siteId\": \"${{ secrets.CUSTOMERIO_RN_FCM_WORKSPACE_SITE_ID }}\"," "$APP_JSON_FILE"
           else
             sd "\"cdpApiKey\".*" "\"cdpApiKey\": \"${{ secrets.CUSTOMERIO_EXPO_WORKSPACE_CDP_API_KEY }}\"," "$APP_JSON_FILE"
             sd "\"siteId\".*" "\"siteId\": \"${{ secrets.CUSTOMERIO_EXPO_WORKSPACE_SITE_ID }}\"," "$APP_JSON_FILE"

--- a/scripts/applyLocalEnvValues.js
+++ b/scripts/applyLocalEnvValues.js
@@ -58,7 +58,6 @@ function updatePushProvider() {
     return;
   }
 
-  const testAppPath = '../test-app';
   const appJsonPath = `${testAppPath}/app.json`;
   const appJson = JSON.parse(fs.readFileSync(appJsonPath, 'utf8'));
 
@@ -76,7 +75,7 @@ function updatePushProvider() {
         // Update the provider value to "fcm"
         pluginConfig.ios.pushNotification.provider = 'fcm';
         pluginConfig.ios.pushNotification.googleServicesFile =
-          './files/google-services.json';
+          './files/GoogleService-Info.plist';
         console.log("Successfully updated provider to 'fcm'");
       } else {
         pluginConfig.ios.pushNotification.provider = 'apn';

--- a/scripts/applyLocalEnvValues.js
+++ b/scripts/applyLocalEnvValues.js
@@ -17,6 +17,85 @@ function installPluginTarball() {
   }
 }
 
+function updateSdkVersion() {
+  // Read the version from local.env
+  const expoPluginVersion = process.env.sdkVersion;
+  const cioExpoPackageName = 'customerio-expo-plugin';
+
+  const packageJsonPath = `${testAppPath}/package.json`;
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+  if (expoPluginVersion) {
+    if (
+      packageJson.dependencies &&
+      packageJson.dependencies[cioExpoPackageName]
+    ) {
+      packageJson.dependencies[cioExpoPackageName] = expoPluginVersion;
+      console.log(
+        `Updated ${cioExpoPackageName} to version ${expoPluginVersion}`
+      );
+    }
+  } else {
+    console.log(
+      'No Expo plugin version found in local.env. Using local tarball...'
+    );
+    installPluginTarball();
+  }
+
+  // Write the updated package.json back
+  fs.writeFileSync(
+    packageJsonPath,
+    JSON.stringify(packageJson, null, 2) + '\n'
+  );
+
+  console.log(`Updated ${packageJsonPath} with local.env values!`);
+}
+
+function updatePushProvider() {
+  const pushProvider = process.env.pushProvider;
+
+  if (!pushProvider) {
+    return;
+  }
+
+  const testAppPath = '../test-app';
+  const appJsonPath = `${testAppPath}/app.json`;
+  const appJson = JSON.parse(fs.readFileSync(appJsonPath, 'utf8'));
+
+  // Find the "customerio-expo-plugin" in plugins array
+  const plugins = appJson.expo.plugins || [];
+  const customerioPlugin = plugins.find(
+    (plugin) => Array.isArray(plugin) && plugin[0] === 'customerio-expo-plugin'
+  );
+
+  if (customerioPlugin) {
+    const pluginConfig = customerioPlugin[1];
+
+    if (pluginConfig.ios && pluginConfig.ios.pushNotification) {
+      if (pushProvider === 'fcm') {
+        // Update the provider value to "fcm"
+        pluginConfig.ios.pushNotification.provider = 'fcm';
+        pluginConfig.ios.pushNotification.googleServicesFile =
+          './files/google-services.json';
+        console.log("Successfully updated provider to 'fcm'");
+      } else {
+        pluginConfig.ios.pushNotification.provider = 'apn';
+        console.log("Successfully updated provider to 'apn'");
+      }
+    } else {
+      console.error("'pushNotification' key not found in iOS config.");
+    }
+  } else {
+    console.error(
+      "'customerio-expo-plugin' not found in app.json, cannot update push provider config!"
+    );
+  }
+
+  // Save the updated app.json
+  fs.writeFileSync(appJsonPath, JSON.stringify(appJson, null, 2) + '\n');
+  console.log('Updated app.json successfully.');
+}
+
 const testAppPath = '../test-app';
 
 // Load the local.env file
@@ -30,31 +109,5 @@ if (envConfig.error) {
   process.exit(0); // Exit without error
 }
 
-// Read the version from local.env
-const expoPluginVersion = process.env.sdkVersion;
-const cioExpoPackageName = 'customerio-expo-plugin';
-
-const packageJsonPath = `${testAppPath}/package.json`;
-const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-
-if (expoPluginVersion) {
-  if (
-    packageJson.dependencies &&
-    packageJson.dependencies[cioExpoPackageName]
-  ) {
-    packageJson.dependencies[cioExpoPackageName] = expoPluginVersion;
-    console.log(
-      `Updated ${cioExpoPackageName} to version ${expoPluginVersion}`
-    );
-  }
-} else {
-  console.log(
-    'No Expo plugin version found in local.env. Using local tarball...'
-  );
-  installPluginTarball();
-}
-
-// Write the updated package.json back
-fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
-
-console.log(`Updated ${packageJsonPath} with local.env values!`);
+updatePushProvider();
+updateSdkVersion();

--- a/test-app/fastlane/Fastfile
+++ b/test-app/fastlane/Fastfile
@@ -102,7 +102,8 @@ platform :ios do
     firebase_app_distribution(
       service_credentials_file: service_credentials_file_path,
       groups: get_build_test_groups(distribution_groups: arguments[:distribution_groups]),
-      release_notes: get_build_notes()
+      release_notes: get_build_notes(),
+      release_notes: "Push provider: #{arguments[:push_provider]}"
     )
   end
 

--- a/test-app/fastlane/Fastfile
+++ b/test-app/fastlane/Fastfile
@@ -102,8 +102,7 @@ platform :ios do
     firebase_app_distribution(
       service_credentials_file: service_credentials_file_path,
       groups: get_build_test_groups(distribution_groups: arguments[:distribution_groups]),
-      release_notes: get_build_notes(),
-      release_notes: "Push provider: #{arguments[:push_provider]}"
+      release_notes: get_build_notes() + "\nPush provider: #{arguments[:push_provider]}"
     )
   end
 


### PR DESCRIPTION
This PR is a quality of life improvement for mobile developers and internal testers by publishing two iOS versions from CI one for APN and FCM, so developers don't have to manually change the config to test both variants.

This PR builds on the approach we used to inject SDK version through `local.env`. An additional property is added to `local.env` for `pushProvider`. This approach could work locally as well, if you create `local.env` locally and populate it with values it will make the correct configuration for you.