### PR TITLE
chore: Prevent Firebase init call if it's already initialized

### DIFF
--- a/plugin/src/helpers/native-files/ios/fcm/PushService.swift
+++ b/plugin/src/helpers/native-files/ios/fcm/PushService.swift
@@ -14,7 +14,9 @@ public class CIOAppPushNotificationsHandler : NSObject {
 
   @objc(initializeCioSdk)
   public func initializeCioSdk() {
-    FirebaseApp.configure()
+    if (FirebaseApp.app() == nil) {
+      FirebaseApp.configure()
+    }
     Messaging.messaging().delegate = self
     UIApplication.shared.registerForRemoteNotifications()
     


### PR DESCRIPTION
This PR ensures a smooth integration for our customers when using `@react-native-firebase` and configuring CIO push to work with FCM as provider.

Firebase crashes when the call `FirebaseApp.configure()` is done multiple times. Since we cannot be sure if our call will be first, hence adding a check to make sure that `FirebaseApp` is not already configured.