### PR TITLE
chore: Prevent GoogleService-info.plist from being double copied

### DIFF
--- a/__tests__/ios/fcm/GoogleService-InfoCopied.test.js
+++ b/__tests__/ios/fcm/GoogleService-InfoCopied.test.js
@@ -5,7 +5,7 @@ const testProjectPath = path.join(__dirname, "../../../test-app");
 const iosPath = path.join(testProjectPath, "ios");
 const googleServicesFile = path.join(iosPath, "GoogleService-Info.plist");
 
-test("Plugin injects expected customerio-reactnative/apn and customerio-reactnative-richpush/apn in Podfile", async () => {
+test("GoogleService-Info.plist is copied at the expected location in the iOS project", async () => {
   const googleServicesFileExists = fs.existsSync(googleServicesFile);
 
   expect(googleServicesFileExists).toBe(true);

--- a/__tests__/ios/fcm/GoogleService-InfoCopied.test.js
+++ b/__tests__/ios/fcm/GoogleService-InfoCopied.test.js
@@ -1,0 +1,12 @@
+const fs = require("fs-extra");
+const path = require("path");
+
+const testProjectPath = path.join(__dirname, "../../../test-app");
+const iosPath = path.join(testProjectPath, "ios");
+const googleServicesFile = path.join(iosPath, "GoogleService-Info.plist");
+
+test("Plugin injects expected customerio-reactnative/apn and customerio-reactnative-richpush/apn in Podfile", async () => {
+  const googleServicesFileExists = fs.existsSync(googleServicesFile);
+
+  expect(googleServicesFileExists).toBe(true);
+});

--- a/plugin/src/ios/withGoogleServicesJsonFile.ts
+++ b/plugin/src/ios/withGoogleServicesJsonFile.ts
@@ -1,68 +1,85 @@
-import { withXcodeProject, IOSConfig, ConfigPlugin } from '@expo/config-plugins';
+import {
+  withXcodeProject,
+  IOSConfig,
+  ConfigPlugin,
+} from '@expo/config-plugins';
 
 import { FileManagement } from './../helpers/utils/fileManagement';
 import type { CustomerIOPluginOptionsIOS } from '../types/cio-types';
+import { isFcmPushProvider } from './utils';
 
-export const withGoogleServicesJsonFile: ConfigPlugin<CustomerIOPluginOptionsIOS> = (
-  config,
-  cioProps
-) => {
+export const withGoogleServicesJsonFile: ConfigPlugin<
+  CustomerIOPluginOptionsIOS
+> = (config, cioProps) => {
   return withXcodeProject(config, async (props) => {
-    
-    const pushProvider = cioProps.pushNotification?.provider ?? 'apn';
-    const useFcm = pushProvider === 'fcm';
+    const useFcm = isFcmPushProvider(cioProps);
     if (!useFcm) {
-        // Nothing to do, for providers other than FCM, the Google services JSON file isn't needed
-        return props;
+      // Nothing to do, for providers other than FCM, the Google services JSON file isn't needed
+      return props;
     }
 
     // googleServicesFile
     const iosPath = props.modRequest.platformProjectRoot;
     const googleServicesFile = cioProps.pushNotification?.googleServicesFile;
-    if (!FileManagement.exists(`${iosPath}/GoogleService-Info.plist`)) {
-          if (googleServicesFile && FileManagement.exists(googleServicesFile)) {
-            try {
-              FileManagement.copyFile(
-                googleServicesFile,
-                `${iosPath}/GoogleService-Info.plist`
-              );
+    const appName = props.modRequest.projectName;
 
-              addFileToXcodeProject(props.modResults, "GoogleService-Info.plist");
-            } catch (e) {
-              console.error(
-                `There was an error copying your GoogleService-Info.plist file. You can copy it manually into ${iosPath}/GoogleService-Info.plist`
-              );
-            }
-          } else {
-            console.error(
-              `The Google Services file provided in ${googleServicesFile} doesn't seem to exist. You can copy it manually into ${iosPath}/GoogleService-Info.plist`
-            );
-          }
-        } else {
-          console.log(
-            `File already exists: ${iosPath}/GoogleService-Info.plist. Skipping...`
-          );
-        }
-    
+    if (FileManagement.exists(`${iosPath}/GoogleService-Info.plist`)) {
+      console.log(
+        `File already exists: ${iosPath}/GoogleService-Info.plist. Skipping...`
+      );
+      return props;
+    }
+
+    if (
+      FileManagement.exists(`${iosPath}/${appName}/GoogleService-Info.plist`)
+    ) {
+      // This is where RN Firebase potentially copies GoogleService-Info.plist
+      // Do not copy if it's already done by Firebase to avoid conflict in Resources
+      console.log(
+        `File already exists: ${iosPath}/${appName}/GoogleService-Info.plist. Skipping...`
+      );
+      return props;
+    }
+
+    if (googleServicesFile && FileManagement.exists(googleServicesFile)) {
+      try {
+        FileManagement.copyFile(
+          googleServicesFile,
+          `${iosPath}/GoogleService-Info.plist`
+        );
+
+        addFileToXcodeProject(props.modResults, 'GoogleService-Info.plist');
+      } catch (e) {
+        console.error(
+          `There was an error copying your GoogleService-Info.plist file. You can copy it manually into ${iosPath}/GoogleService-Info.plist`
+        );
+      }
+    } else {
+      console.error(
+        `The Google Services file provided in ${googleServicesFile} doesn't seem to exist. You can copy it manually into ${iosPath}/GoogleService-Info.plist`
+      );
+    }
 
     return props;
   });
 };
 
 function addFileToXcodeProject(project: any, fileName: string) {
-    const groupName = "Resources";
-    const filepath = fileName;
-  
-    if (!IOSConfig.XcodeUtils.ensureGroupRecursively(project, groupName)) {
-      console.error(`Error copying GoogleService-Info.plist. Failed to find or create '${groupName}' group in Xcode.`);
-      return;
-    }
-  
-    // Add GoogleService-Info.plist to the Xcode project
-    IOSConfig.XcodeUtils.addResourceFileToGroup({
-      project,
-      filepath,
-      groupName,
-      isBuildFile: true,
-    });
+  const groupName = 'Resources';
+  const filepath = fileName;
+
+  if (!IOSConfig.XcodeUtils.ensureGroupRecursively(project, groupName)) {
+    console.error(
+      `Error copying GoogleService-Info.plist. Failed to find or create '${groupName}' group in Xcode.`
+    );
+    return;
   }
+
+  // Add GoogleService-Info.plist to the Xcode project
+  IOSConfig.XcodeUtils.addResourceFileToGroup({
+    project,
+    filepath,
+    groupName,
+    isBuildFile: true,
+  });
+}

--- a/plugin/src/ios/withGoogleServicesJsonFile.ts
+++ b/plugin/src/ios/withGoogleServicesJsonFile.ts
@@ -18,6 +18,11 @@ export const withGoogleServicesJsonFile: ConfigPlugin<
       return props;
     }
 
+    console.log(
+      'Only specify Customer IO ios.pushNotification.googleServicesFile config if you are not already including' +
+        ' GoogleService-Info.plist as part of Firebase integration'
+    );
+
     // googleServicesFile
     const iosPath = props.modRequest.platformProjectRoot;
     const googleServicesFile = cioProps.pushNotification?.googleServicesFile;
@@ -42,6 +47,13 @@ export const withGoogleServicesJsonFile: ConfigPlugin<
     }
 
     if (googleServicesFile && FileManagement.exists(googleServicesFile)) {
+      if (config.ios?.googleServicesFile) {
+        console.warn(
+          'Specifying both Expo ios.googleServicesFile and Customer IO ios.pushNotification.googleServicesFile can cause a conflict' +
+            ' duplicating GoogleService-Info.plist in the iOS project resources. Please remove Customer IO ios.pushNotification.googleServicesFile'
+        );
+      }
+
       try {
         FileManagement.copyFile(
           googleServicesFile,

--- a/plugin/src/ios/withGoogleServicesJsonFile.ts
+++ b/plugin/src/ios/withGoogleServicesJsonFile.ts
@@ -19,7 +19,7 @@ export const withGoogleServicesJsonFile: ConfigPlugin<
     }
 
     console.log(
-      'Only specify Customer IO ios.pushNotification.googleServicesFile config if you are not already including' +
+      'Only specify Customer.io ios.pushNotification.googleServicesFile config if you are not already including' +
         ' GoogleService-Info.plist as part of Firebase integration'
     );
 
@@ -49,8 +49,8 @@ export const withGoogleServicesJsonFile: ConfigPlugin<
     if (googleServicesFile && FileManagement.exists(googleServicesFile)) {
       if (config.ios?.googleServicesFile) {
         console.warn(
-          'Specifying both Expo ios.googleServicesFile and Customer IO ios.pushNotification.googleServicesFile can cause a conflict' +
-            ' duplicating GoogleService-Info.plist in the iOS project resources. Please remove Customer IO ios.pushNotification.googleServicesFile'
+          'Specifying both Expo ios.googleServicesFile and Customer.io ios.pushNotification.googleServicesFile can cause a conflict' +
+            ' duplicating GoogleService-Info.plist in the iOS project resources. Please remove Customer.io ios.pushNotification.googleServicesFile'
         );
       }
 


### PR DESCRIPTION
The [ReactNative Firebase dependency](https://rnfirebase.io/) requires `GoogleService-info.plist` to be added to the iOS project.

RN Firebase [doesn't check if the file already exists](https://github.com/invertase/react-native-firebase/blob/d9b7175983f0e7b86747c88fcb522295bedf203b/packages/app/plugin/src/ios/googleServicesPlist.ts#L39) before adding it to the project. Since we cannot depend on customers having ReactNative Firebase to copy the file. Our plugin copies the file.

This PR adds a check at the path where ReactNative Firebase copies the file first before copying it.