### PR TITLE
chore: handle conflict from firebase 

### DIFF
--- a/__tests__/ios/fcm/GoogleService-InfoCopied.test.js
+++ b/__tests__/ios/fcm/GoogleService-InfoCopied.test.js
@@ -3,10 +3,46 @@ const path = require("path");
 
 const testProjectPath = path.join(__dirname, "../../../test-app");
 const iosPath = path.join(testProjectPath, "ios");
-const googleServicesFile = path.join(iosPath, "GoogleService-Info.plist");
+const appName = "ExpoTestbed"; // Replace with your app name if different
+// Define all possible locations where GoogleService-Info.plist might exist
+const possibleLocations = [
+  path.join(iosPath, "GoogleService-Info.plist"),                    // Our plugin's default location
+  path.join(iosPath, appName, "GoogleService-Info.plist"),           // Where React Native Firebase typically adds it
+  path.join(iosPath, "Pods", "GoogleService-Info.plist"),            // Sometimes found in Pods
+  path.join(iosPath, appName, "Resources", "GoogleService-Info.plist"), // Alternative location in app resources
+  path.join(iosPath, "Supporting", "GoogleService-Info.plist")       // Another possible location
+];
 
-test("Plugin injects expected customerio-reactnative/apn and customerio-reactnative-richpush/apn in Podfile", async () => {
-  const googleServicesFileExists = fs.existsSync(googleServicesFile);
-
-  expect(googleServicesFileExists).toBe(true);
+describe("GoogleService-Info.plist File", () => {
+  test("GoogleService-Info.plist exists in at least one expected location", () => {
+    // Check all possible locations
+    const existsInAnyLocation = possibleLocations.some(location => fs.existsSync(location));
+    
+    // Log all locations where the file exists
+    const existingLocations = possibleLocations.filter(location => fs.existsSync(location));
+    if (existingLocations.length > 0) {
+      console.log("GoogleService-Info.plist found in these locations:");
+      existingLocations.forEach(location => console.log(`- ${location}`));
+    } else {
+      console.log("GoogleService-Info.plist not found in any expected location");
+    }
+    
+    expect(existsInAnyLocation).toBe(true);
+  });
+  
+  test("GoogleService-Info.plist file is not duplicated", () => {
+    // Count how many locations have the file
+    const existingLocations = possibleLocations.filter(location => fs.existsSync(location));
+    
+    // If more than one location has the file, log a warning
+    if (existingLocations.length > 1) {
+      console.warn("WARNING: GoogleService-Info.plist found in multiple locations:");
+      existingLocations.forEach(location => console.log(`- ${location}`));
+    }
+    
+    // We expect the file to be in at most one location
+    // This test will pass if the file exists in exactly one location
+    // and will fail if it's duplicated
+    expect(existingLocations.length).toBeLessThanOrEqual(1);
+  });
 });

--- a/plugin/src/ios/withGoogleServicesJsonFile.ts
+++ b/plugin/src/ios/withGoogleServicesJsonFile.ts
@@ -8,6 +8,170 @@ import { FileManagement } from './../helpers/utils/fileManagement';
 import type { CustomerIOPluginOptionsIOS } from '../types/cio-types';
 import { isFcmPushProvider } from './utils';
 
+/**
+ * Checks if a file is already referenced in the Xcode project
+ * 
+ * @param project The Xcode project
+ * @param fileName The file name to check
+ * @returns True if the file is already referenced in the project
+ */
+function isFileReferencedInXcodeProject(project: any, fileName: string): boolean {
+  try {
+    // Get all file references
+    const fileReferences = project.pbxFileReferenceSection();
+    
+    // Check if any file reference matches our fileName
+    for (const key in fileReferences) {
+      const fileReference = fileReferences[key];
+      if (typeof fileReference === 'object' && fileReference.name === fileName) {
+        return true;
+      }
+      
+      // Some file references might use path instead of name
+      if (typeof fileReference === 'object' && fileReference.path === fileName) {
+        return true;
+      }
+    }
+    
+    // Check in resources build phase as well
+    const buildPhases = project.pbxResourcesBuildPhaseSection();
+    for (const key in buildPhases) {
+      const buildPhase = buildPhases[key];
+      
+      if (typeof buildPhase === 'object' && buildPhase.files) {
+        for (const fileKey of buildPhase.files) {
+          const buildFile = project.pbxBuildFileSection()[fileKey.value];
+          if (buildFile && buildFile.fileRef) {
+            const fileRef = project.pbxFileReferenceSection()[buildFile.fileRef];
+            if (fileRef && (fileRef.name === fileName || fileRef.path === fileName)) {
+              return true;
+            }
+          }
+        }
+      }
+    }
+    
+    return false;
+  } catch (error) {
+    console.warn(`Error checking if ${fileName} is referenced in Xcode project: ${error}`);
+    // In case of error, assume it's not referenced to be safe
+    return false;
+  }
+}
+
+/**
+ * Adds a file to the Xcode project
+ * 
+ * @param project The Xcode project
+ * @param fileName The file name to add
+ * @returns boolean indicating success
+ */
+function addFileToXcodeProject(project: any, fileName: string): boolean {
+  const groupName = 'Resources';
+  const filepath = fileName;
+
+  if (!IOSConfig.XcodeUtils.ensureGroupRecursively(project, groupName)) {
+    console.error(
+      `Error copying GoogleService-Info.plist. Failed to find or create '${groupName}' group in Xcode.`
+    );
+    return false;
+  }
+
+  try {
+    // Add GoogleService-Info.plist to the Xcode project
+    IOSConfig.XcodeUtils.addResourceFileToGroup({
+      project,
+      filepath,
+      groupName,
+      isBuildFile: true,
+    });
+    return true;
+  } catch (error) {
+    // Handle potential errors like file already added
+    if (String(error).includes('already exists')) {
+      console.log(`File ${fileName} is already in the Xcode project. Skipping addition.`);
+      return true;
+    } else {
+      console.error(`Error adding ${fileName} to Xcode project: ${error}`);
+      return false;
+    }
+  }
+}
+
+/**
+ * Find an existing GoogleService-Info.plist file in common locations
+ * 
+ * @param iosPath iOS project root path
+ * @param appName iOS app name
+ * @returns Path to existing file or null if not found
+ */
+function findExistingGoogleServicesFile(iosPath: string, appName: string): string | null {
+  // Define all possible locations where GoogleService-Info.plist might exist
+  const possibleLocations = [
+    `${iosPath}/GoogleService-Info.plist`,                    // Our plugin's default location
+    `${iosPath}/${appName}/GoogleService-Info.plist`,         // Where React Native Firebase typically adds it
+    `${iosPath}/Pods/GoogleService-Info.plist`,               // Sometimes found in Pods
+    `${iosPath}/${appName}/Resources/GoogleService-Info.plist`, // Alternative location in app resources
+    `${iosPath}/Supporting/GoogleService-Info.plist`          // Another possible location
+  ];
+  
+  for (const location of possibleLocations) {
+    if (FileManagement.exists(location)) {
+      console.log(`Found existing GoogleService-Info.plist at ${location}`);
+      return location;
+    }
+  }
+  
+  return null;
+}
+
+/**
+ * Checks for configuration conflicts between Expo and CustomerIO
+ * 
+ * @param config Expo config
+ * @param googleServicesFile Customer IO googleServicesFile path
+ */
+function checkConfigConflicts(config: any, googleServicesFile: string | undefined): void {
+  if (config.ios?.googleServicesFile && googleServicesFile) {
+    console.warn(
+      'CONFLICT DETECTED: Specifying both Expo ios.googleServicesFile and Customer IO ios.pushNotification.googleServicesFile' +
+      ' will cause a conflict by duplicating GoogleService-Info.plist in the iOS project resources.' +
+      '\nRECOMMENDATION: Please remove Customer IO ios.pushNotification.googleServicesFile from your configuration.'
+    );
+  }
+}
+
+/**
+ * Copy GoogleService-Info.plist from source to destination and add to Xcode project
+ * 
+ * @param sourceFile Source file path
+ * @param destinationPath Destination path
+ * @param project Xcode project
+ * @returns boolean indicating success
+ */
+function copyAndAddGoogleServicesFile(
+  sourceFile: string, 
+  destinationPath: string, 
+  project: any
+): boolean {
+  try {
+    console.log(`Copying GoogleService-Info.plist from ${sourceFile} to ${destinationPath}`);
+    FileManagement.copyFile(sourceFile, destinationPath);
+
+    const success = addFileToXcodeProject(project, 'GoogleService-Info.plist');
+    if (success) {
+      console.log('Successfully added GoogleService-Info.plist to Xcode project');
+    }
+    return success;
+  } catch (e) {
+    console.error(
+      `ERROR: There was an error copying your GoogleService-Info.plist file: ${e}` +
+      `\nYou can copy it manually into ${destinationPath} and add it to your Xcode project`
+    );
+    return false;
+  }
+}
+
 export const withGoogleServicesJsonFile: ConfigPlugin<
   CustomerIOPluginOptionsIOS
 > = (config, cioProps) => {
@@ -23,75 +187,48 @@ export const withGoogleServicesJsonFile: ConfigPlugin<
         ' GoogleService-Info.plist as part of Firebase integration'
     );
 
-    // googleServicesFile
     const iosPath = props.modRequest.platformProjectRoot;
-    const googleServicesFile = cioProps.pushNotification?.googleServicesFile;
     const appName = props.modRequest.projectName;
+    const googleServicesFile = cioProps.pushNotification?.googleServicesFile;
+    const fileName = 'GoogleService-Info.plist';
+    const destinationPath = `${iosPath}/${fileName}`;
 
-    if (FileManagement.exists(`${iosPath}/GoogleService-Info.plist`)) {
-      console.log(
-        `File already exists: ${iosPath}/GoogleService-Info.plist. Skipping...`
-      );
+    // Check if file already exists in common locations
+    const existingFilePath = findExistingGoogleServicesFile(iosPath, appName);
+    
+    if (existingFilePath) {
+      console.log(`File already exists: ${existingFilePath}. Skipping copy...`);
+      
+      // If the file is in the main iOS directory, check if it's in the Xcode project
+      if (existingFilePath === destinationPath && !isFileReferencedInXcodeProject(props.modResults, fileName)) {
+        console.log('Adding existing GoogleService-Info.plist to Xcode project...');
+        addFileToXcodeProject(props.modResults, fileName);
+      } else {
+        console.log('GoogleService-Info.plist is already referenced or in a location handled by other tools. No action needed.');
+      }
+      
       return props;
     }
 
-    if (
-      FileManagement.exists(`${iosPath}/${appName}/GoogleService-Info.plist`)
-    ) {
-      // This is where RN Firebase potentially copies GoogleService-Info.plist
-      // Do not copy if it's already done by Firebase to avoid conflict in Resources
-      console.log(
-        `File already exists: ${iosPath}/${appName}/GoogleService-Info.plist. Skipping...`
-      );
-      return props;
-    }
+    // Check for config conflicts
+    checkConfigConflicts(config, googleServicesFile);
 
+    // Only copy if the file wasn't found anywhere and a source file was provided
     if (googleServicesFile && FileManagement.exists(googleServicesFile)) {
-      if (config.ios?.googleServicesFile) {
-        console.warn(
-          'Specifying both Expo ios.googleServicesFile and Customer IO ios.pushNotification.googleServicesFile can cause a conflict' +
-            ' duplicating GoogleService-Info.plist in the iOS project resources. Please remove Customer IO ios.pushNotification.googleServicesFile'
-        );
-      }
-
-      try {
-        FileManagement.copyFile(
-          googleServicesFile,
-          `${iosPath}/GoogleService-Info.plist`
-        );
-
-        addFileToXcodeProject(props.modResults, 'GoogleService-Info.plist');
-      } catch (e) {
-        console.error(
-          `There was an error copying your GoogleService-Info.plist file. You can copy it manually into ${iosPath}/GoogleService-Info.plist`
-        );
-      }
-    } else {
+      copyAndAddGoogleServicesFile(googleServicesFile, destinationPath, props.modResults);
+    } else if (googleServicesFile) {
       console.error(
-        `The Google Services file provided in ${googleServicesFile} doesn't seem to exist. You can copy it manually into ${iosPath}/GoogleService-Info.plist`
+        `ERROR: The Google Services file specified at "${googleServicesFile}" does not exist.` +
+        `\nPlease check the path and make sure the file exists, or copy it manually into ${destinationPath}`
+      );
+    } else {
+      console.warn(
+        `WARNING: No GoogleService-Info.plist source file was provided in the configuration.` +
+        `\nIf you're using FCM for push notifications, you need to provide the file.` +
+        `\nPlease add it manually to ${destinationPath} or configure it through Customer IO ios.pushNotification.googleServicesFile`
       );
     }
 
     return props;
   });
 };
-
-function addFileToXcodeProject(project: any, fileName: string) {
-  const groupName = 'Resources';
-  const filepath = fileName;
-
-  if (!IOSConfig.XcodeUtils.ensureGroupRecursively(project, groupName)) {
-    console.error(
-      `Error copying GoogleService-Info.plist. Failed to find or create '${groupName}' group in Xcode.`
-    );
-    return;
-  }
-
-  // Add GoogleService-Info.plist to the Xcode project
-  IOSConfig.XcodeUtils.addResourceFileToGroup({
-    project,
-    filepath,
-    groupName,
-    isBuildFile: true,
-  });
-}


### PR DESCRIPTION
summary:
- Refactors `withGoogleServicesJsonFile.ts` to detect and handle `GoogleService-Info.plist` files across multiple locations
- Prevents duplicate file additions by checking Xcode `project references`
- Improves error handling and logging

changes:
- Systematically checks multiple locations where GoogleService-Info.plist might exist Prioritizes existing files added by React Native Firebase

This PR attempts to resolve build errors caused by both our plugin and React Native Firebase trying to add the same GoogleService-Info.plist file.