### PR TITLE
chore: Publish testbed app to public channel only for APN and not FCM

### DIFF
--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -182,7 +182,10 @@ jobs:
           # Determine current app type and git context
           [[ "$CURRENT_BRANCH" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
           [[ "$CURRENT_BRANCH" == "refs/heads/main" || "$CURRENT_BRANCH" == "refs/heads/beta" ]] && distribution_groups+=("$NEXT_BUILDS_GROUP")
-          [[ "$USE_LATEST_SDK_VERSION" == "true" ]] && distribution_groups+=("$PUBLIC_BUILDS_GROUP")
+          
+          if [[ ${{ matrix.push_provider }} == "apn" && "$USE_LATEST_SDK_VERSION" == "true" ]]; then
+            distribution_groups+=("$PUBLIC_BUILDS_GROUP")
+          fi
 
           # Export the groups as an environment variable
           echo "firebase_distribution_groups=$(IFS=','; echo "${distribution_groups[*]}")" >> $GITHUB_ENV


### PR DESCRIPTION
### Context
When we added support for FCM, we have made the iOS app get published twice, once with APN config and once with FCM config

### Change
This PR prevents publishing FCM iOS app to public channel to avoid confusing internal stakeholders.