### PR TITLE
chore: add workflow for compatibility testing

### DIFF
--- a/.github/workflows/validate-plugin-compatibility.yml
+++ b/.github/workflows/validate-plugin-compatibility.yml
@@ -1,0 +1,111 @@
+name: Validate Plugin Compatibility
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main, beta, feature/*]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: "20"
+  JAVA_VERSION: "17"
+  XCODE_VERSION: "15.3"
+  APP_DIR: ci-test-apps
+  APP_NAME_PREFIX: ExpoPluginTestApp
+
+jobs:
+  validate:
+    name: Expo ${{ matrix.expo-version }} - ${{ matrix.platform }}${{ matrix.ios-push-provider && format(' ({0})', matrix.ios-push-provider) }}
+    runs-on: macos-14
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - expo-version: 51
+            platform: android
+          - expo-version: 51
+            platform: ios
+            ios-push-provider: apn
+            ios-deployment-target: "15.1"
+          - expo-version: 51
+            platform: ios
+            ios-push-provider: fcm
+            ios-deployment-target: "15.1"
+
+          - expo-version: 52
+            platform: android
+          - expo-version: 52
+            platform: ios
+            ios-push-provider: apn
+          - expo-version: 52
+            platform: ios
+            ios-push-provider: fcm
+
+          # Running on latest version helps to catch issues early for new versions not listed above
+          - expo-version: latest
+            platform: android
+          - expo-version: latest
+            platform: ios
+            ios-push-provider: apn
+          - expo-version: latest
+            platform: ios
+            ios-push-provider: fcm
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Set APP_NAME and APP_PATH
+        run: |
+          echo "APP_NAME=${{ env.APP_NAME_PREFIX }}_${{ matrix.expo-version }}" >> $GITHUB_ENV
+          echo "APP_PATH=${{ env.APP_DIR }}/${{ env.APP_NAME_PREFIX }}_${{ matrix.expo-version }}" >> $GITHUB_ENV
+
+      - name: Create Test App
+        run: |
+          npm run compatibility:create-test-app -- \
+            --expo-version=${{ matrix.expo-version }} \
+            --app-name=${{ env.APP_NAME }} \
+            --dir-name=${{ env.APP_DIR }}
+
+      - name: Setup Test App
+        run: |
+          npm run compatibility:setup-test-app -- \
+            --app-path=${{ env.APP_PATH }}
+
+      - name: Configure Plugin with Default Config
+        run: |
+          npm run compatibility:configure-plugin -- \
+            --app-path=${{ env.APP_PATH }} \
+            --add-default-config \
+            ${{ matrix.ios-deployment-target && format('--expo-build-props.ios.deploymentTarget={0}', matrix.ios-deployment-target) }}
+
+      - name: Validate Plugin
+        run: |
+          npm run compatibility:validate-plugin -- \
+            --app-path=${{ env.APP_PATH }} \
+            --platforms=${{ matrix.platform }}\
+            ${{ matrix.ios-push-provider && format(' --ios-push-providers={0}', matrix.ios-push-provider) }}

--- a/.github/workflows/validate-plugin-compatibility.yml
+++ b/.github/workflows/validate-plugin-compatibility.yml
@@ -101,7 +101,6 @@ jobs:
           npm run compatibility:configure-plugin -- \
             --app-path=${{ env.APP_PATH }} \
             --add-default-config \
-            --ios-use-frameworks="static" \
             ${{ matrix.ios-deployment-target && format('--expo-build-props.ios.deploymentTarget={0}', matrix.ios-deployment-target) }}
 
       - name: Validate Plugin
@@ -109,4 +108,5 @@ jobs:
           npm run compatibility:validate-plugin -- \
             --app-path=${{ env.APP_PATH }} \
             --platforms=${{ matrix.platform }}\
+            --ios-use-frameworks="static" \
             ${{ matrix.ios-push-provider && format(' --ios-push-providers={0}', matrix.ios-push-provider) }}

--- a/.github/workflows/validate-plugin-compatibility.yml
+++ b/.github/workflows/validate-plugin-compatibility.yml
@@ -101,6 +101,7 @@ jobs:
           npm run compatibility:configure-plugin -- \
             --app-path=${{ env.APP_PATH }} \
             --add-default-config \
+            --ios-use-frameworks="static" \
             ${{ matrix.ios-deployment-target && format('--expo-build-props.ios.deploymentTarget={0}', matrix.ios-deployment-target) }}
 
       - name: Validate Plugin

--- a/scripts/compatibility/configure-plugin.js
+++ b/scripts/compatibility/configure-plugin.js
@@ -38,7 +38,7 @@ function getPluginConfigFromCliPrefix(pluginName) {
     process.exit(1);
   }
 
-  const fullPrefix = `${prefix}.`; // e.g. "cio." or "bp."
+  const fullPrefix = `${prefix}.`; // e.g. "cio-plugin.", etc.
   const keyValues = parseArgsAsObject();
 
   const configEntries = Object.entries(keyValues)

--- a/scripts/compatibility/run-compatibility-tests.js
+++ b/scripts/compatibility/run-compatibility-tests.js
@@ -1,37 +1,54 @@
 const path = require("path");
-const { getArgValue, isFlagEnabled, logMessage, runCommand } = require("../utils/cli");
+const { getArgValue, logMessage, runCommand, runScriptWithArgs } = require("../utils/cli");
 
 const EXPO_VERSION = getArgValue("--expo-version", { default: "latest" });
-const APP_NAME = getArgValue("--app-name", { default: `ExpoTest_V${EXPO_VERSION}`.replace(/\./g, "") });
+const APP_NAME = getArgValue("--app-name", {
+  default: `ExpoTest_V${EXPO_VERSION}`.replace(/\./g, ""),
+});
 const APP_DIR = getArgValue("--dir-name", { default: "ci-test-apps" });
-const CLEAN_FLAG = isFlagEnabled("--clean");
 const APP_PATH = path.resolve(__dirname, "../..", APP_DIR, APP_NAME);
 
 logMessage(`🚀 Starting local validation for Expo plugin (Expo ${EXPO_VERSION})...`);
+const EXCLUDED_FORWARD_ARGS = ["expo-version", "app-name", "dir-name", "app-path"];
 
 // Step 1: Create Test App
 logMessage(`\n🔹 Creating Test App: ${APP_NAME} (Expo ${EXPO_VERSION})...`);
-let createAppCommand = `npm run compatibility:create-test-app -- \
-  --expo-version=${EXPO_VERSION} \
-  --app-name=${APP_NAME} \
-  --dir-name=${APP_DIR}`;
-
-if (CLEAN_FLAG) {
-  createAppCommand += " --clean";
-}
-
-runCommand(createAppCommand);
+runScriptWithArgs("compatibility:create-test-app", {
+  args: {
+    "expo-version": EXPO_VERSION,
+    "app-name": APP_NAME,
+    "dir-name": APP_DIR,
+  },
+  exclude: EXCLUDED_FORWARD_ARGS,
+});
 
 // Step 2: Set Up Test App
 logMessage("\n🔹 Setting up Test App...");
-runCommand(`npm run compatibility:setup-test-app -- --app-path=${APP_PATH}`);
+runScriptWithArgs("compatibility:setup-test-app", {
+  args: {
+    "app-path": APP_PATH,
+  },
+  exclude: EXCLUDED_FORWARD_ARGS,
+});
 
 // Step 3: Configure Plugin
 logMessage("\n🔹 Configuring Plugin...");
-runCommand(`npm run compatibility:configure-plugin -- --app-path=${APP_PATH} --add-default-config`);
+runScriptWithArgs("compatibility:configure-plugin", {
+  args: {
+    "app-path": APP_PATH,
+    "add-default-config": true,
+    "ios-use-frameworks": "static",
+  },
+  exclude: EXCLUDED_FORWARD_ARGS,
+});
 
 // Step 4: Validate Plugin
 logMessage("\n🔹 Validating Plugin...");
-runCommand(`npm run compatibility:validate-plugin -- --app-path=${APP_PATH}`);
+runScriptWithArgs("compatibility:validate-plugin", {
+  args: {
+    "app-path": APP_PATH,
+  },
+  exclude: EXCLUDED_FORWARD_ARGS,
+});
 
 logMessage(`\n🎉 Expo plugin validation completed successfully! (Expo ${EXPO_VERSION})\n`, "success");

--- a/scripts/utils/constants.js
+++ b/scripts/utils/constants.js
@@ -1,7 +1,9 @@
 const CUSTOMER_IO_EXPO_PLUGIN_NAME = "customerio-expo-plugin";
 const CUSTOMER_IO_REACT_NATIVE_SDK_NAME = "customerio-reactnative";
+const EXPO_BUILD_PROPERTIES_PLUGIN = "expo-build-properties";
 
 module.exports = {
   CUSTOMER_IO_EXPO_PLUGIN_NAME,
   CUSTOMER_IO_REACT_NATIVE_SDK_NAME,
+  EXPO_BUILD_PROPERTIES_PLUGIN,
 };


### PR DESCRIPTION
part of: [MBL-967](https://linear.app/customerio/issue/MBL-967/automate-expo-compatibility-checks-on-ci)

### Changes

- Added workflow to run compatibility tests for our plugin against Expo 51, 52, and latest version to catch future release issues
- Updated compatibility scripts to forward all arguments for improved local testing experience