### PR TITLE
fix: Disable Code Climate Velocity Deployment

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -72,13 +72,13 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
-      - name: Send Velocity Deployment
-        uses: codeclimate/velocity-deploy-action@1b4a22f0db113bf8d85c14fd726cf0ec6d17cd13 # v1.0.0
-        if: steps.semantic-release.outputs.new_release_published == 'true' # only run if a git tag was made.
-        with:
-          token: ${{ secrets.VELOCITY_DEPLOYMENT_TOKEN }}
-          version: ${{ steps.semantic-release.outputs.new_release_version }}
-          environment: production
+      # - name: Send Velocity Deployment
+      #   uses: codeclimate/velocity-deploy-action@1b4a22f0db113bf8d85c14fd726cf0ec6d17cd13 # v1.0.0
+      #   if: steps.semantic-release.outputs.new_release_published == 'true' # only run if a git tag was made.
+      #   with:
+      #     token: ${{ secrets.VELOCITY_DEPLOYMENT_TOKEN }}
+      #     version: ${{ steps.semantic-release.outputs.new_release_version }}
+      #     environment: production
 
       - name: Notify team of failure
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## [2.0.2](https://github.com/customerio/customerio-expo-plugin/compare/2.0.1...2.0.2) (2025-04-10)
-
-### Bug Fixes
-
-* CustomerIOPluginOptionsIOS structure revised for clarity ([#249](https://github.com/customerio/customerio-expo-plugin/issues/249)) ([711aa07](https://github.com/customerio/customerio-expo-plugin/commit/711aa07b7d902d5b81a9061903125ccb79558c7b))
-
 ## [2.0.1](https://github.com/customerio/customerio-expo-plugin/compare/2.0.0...2.0.1) (2025-04-03)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "customerio-expo-plugin",
-  "version": "2.0.2",
+  "version": "2.0.1",
   "description": "Expo config plugin for the Customer IO React Native SDK",
   "main": "plugin/lib/commonjs/index",
   "module": "plugin/lib/module/index",


### PR DESCRIPTION
`codeclimate/velocity-deploy-action` Github action started [failing](https://github.com/customerio/customerio-expo-plugin/actions/runs/14379532878/job/40319773344), which is blocking SDK release, we are temporarily disabling it to enables releasing

