### PR TITLE
chore: Trigger sample apps public builds after npm deployment is successful

### DIFF
--- a/.github/workflows/build-sample-app-for-sdk-release.yml
+++ b/.github/workflows/build-sample-app-for-sdk-release.yml
@@ -2,6 +2,7 @@ name: Publish test apps for SDK release
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build-sample-apps:

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -203,3 +203,10 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+  publish-sample-apps-public-builds:
+    needs: deploy-npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sample apps public builds
+        uses: ./.github/workflows/build-sample-app-for-sdk-release.yml


### PR DESCRIPTION
Closes: [MBL-1053](https://linear.app/customerio/issue/MBL-1053/auto-create-testbed-releases-for-every-sdk-release)

This PR triggers a sample apps public release build after the SDK has been deployed successfully to NPM so that internal stakeholders always have up to date versions to test with.