### PR TITLE
chore: Fix Github workflow job triggering public sample app build for SDK releases

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -206,7 +206,6 @@ jobs:
 
   publish-sample-apps-public-builds:
     needs: deploy-npm
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger sample apps public builds
-        uses: ./.github/workflows/build-sample-app-for-sdk-release.yml
+    uses: ./.github/workflows/build-sample-app-for-sdk-release.yml
+    secrets: inherit
+    


### PR DESCRIPTION
Closes: [MBL-1053](https://linear.app/customerio/issue/MBL-1053/auto-create-testbed-releases-for-every-sdk-release)

I've made a mistake in the previous PR #253, reusable workflows should be called at the job level and not on the step level. Steps can only call custom action and not reusable workflows.