### PR TITLE
chore: Expo 53 support minor improvements

### DIFF
--- a/__tests__/ios/apn/__snapshots__/AppDelegate-swift.test.js.snap
+++ b/__tests__/ios/apn/__snapshots__/AppDelegate-swift.test.js.snap
@@ -7,7 +7,7 @@ import ReactAppDependencyProvider
 
 @UIApplicationMain
 public class AppDelegate: ExpoAppDelegate {
-    let cioSdkHandler = CioSdkAppDelegateHandler()
+  let cioSdkHandler = CioSdkAppDelegateHandler()
 
   var window: UIWindow?
 
@@ -34,7 +34,7 @@ public class AppDelegate: ExpoAppDelegate {
       launchOptions: launchOptions)
 #endif
 
-        cioSdkHandler.application(application, didFinishLaunchingWithOptions: launchOptions)
+      cioSdkHandler.application(application, didFinishLaunchingWithOptions: launchOptions)
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/__tests__/ios/fcm/__snapshots__/AppDelegate-swift.test.js.snap
+++ b/__tests__/ios/fcm/__snapshots__/AppDelegate-swift.test.js.snap
@@ -7,7 +7,7 @@ import ReactAppDependencyProvider
 
 @UIApplicationMain
 public class AppDelegate: ExpoAppDelegate {
-    let cioSdkHandler = CioSdkAppDelegateHandler()
+  let cioSdkHandler = CioSdkAppDelegateHandler()
 
   var window: UIWindow?
 
@@ -34,7 +34,7 @@ public class AppDelegate: ExpoAppDelegate {
       launchOptions: launchOptions)
 #endif
 
-        cioSdkHandler.application(application, didFinishLaunchingWithOptions: launchOptions)
+      cioSdkHandler.application(application, didFinishLaunchingWithOptions: launchOptions)
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const semver = require('semver');
 
 function testAppPath() {
   const appPath = process.env.TEST_APP_PATH;

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -1,15 +1,15 @@
-const path = require("path");
+const path = require('path');
 
 function testAppPath() {
-    const appPath = process.env.TEST_APP_PATH
-    if (appPath) {
-        return path.join(appPath)
-    }
-    return path.join(__dirname, "../test-app")
+  const appPath = process.env.TEST_APP_PATH;
+  if (appPath) {
+    return path.join(appPath);
+  }
+  return path.join(__dirname, '../test-app');
 }
 
 function testAppName() {
-    return process.env.TEST_APP_NAME || "ExpoTestbed"
+  return process.env.TEST_APP_NAME || 'ExpoTestbed';
 }
 
 /**
@@ -17,7 +17,7 @@ function testAppName() {
  * @returns {string} The Expo version
  */
 function getExpoVersion() {
-    return process.env.EXPO_VERSION || "53.0.0"; // Default to 53
+  return process.env.EXPO_VERSION || '53.0.0'; // Default to 53
 }
 
 /**
@@ -25,14 +25,21 @@ function getExpoVersion() {
  * @returns {boolean} True if Expo version is 53 or higher
  */
 function isExpoVersion53OrHigher() {
-    const version = getExpoVersion();
-    const majorVersion = parseInt(version.split('.')[0], 10);
-    return !isNaN(majorVersion) && majorVersion >= 53;
+  const sdkVersion = getExpoVersion();
+
+  // If sdkVersion is not a valid semver, coerce it to a valid one if possible
+  const validVersion = semver.valid(sdkVersion) || semver.coerce(sdkVersion);
+
+  // If we couldn't get a valid version, return false
+  if (!validVersion) return false;
+
+  // Check if the version is greater than or equal to 53.0.0
+  return semver.gte(validVersion, '53.0.0');
 }
 
 module.exports = {
-    testAppPath,
-    testAppName,
-    getExpoVersion,
-    isExpoVersion53OrHigher
+  testAppPath,
+  testAppName,
+  getExpoVersion,
+  isExpoVersion53OrHigher,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,11 @@
       "license": "MIT",
       "dependencies": {
         "find-package-json": "^1.2.0",
-        "fs-extra": "^11.2.0"
+        "fs-extra": "^11.2.0",
+        "semver": "^7.7.2"
       },
       "devDependencies": {
-        "@expo/config-plugins": "~10.0.0",
+        "@expo/config-plugins": "^10.0.0",
         "@expo/config-types": "^53.0.0",
         "@types/jest": "^29.5.14",
         "@typescript-eslint/eslint-plugin": "^5.21.0",
@@ -22,7 +23,7 @@
         "eslint": "^8.14.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.0.0",
-        "expo-build-properties": "~0.14.6",
+        "expo-build-properties": "^0.14.6",
         "expo-module-scripts": "^3.0.2",
         "gradle-to-js": "^2.0.1",
         "jest": "^29.2.1",
@@ -30,7 +31,7 @@
         "prettier": "^2.6.2",
         "react-native-builder-bob": "^0.18.3",
         "ts-jest": "^29.2.5",
-        "typescript": "~5.8.3",
+        "typescript": "^5.8.3",
         "xcode": "^3.0.1"
       },
       "peerDependencies": {
@@ -149,30 +150,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.2.tgz",
-      "integrity": "sha512-TUtMJYRPyUb/9aU8f3K0mjmjf6M9N5Woshn2CS6nqJSeJtTtQcpLUXjGt9vbF8ZGff0El99sWkLgzwW3VXnxZQ==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.3.tgz",
+      "integrity": "sha512-V42wFfx1ymFte+ecf6iXghnnP8kWTO+ZLXIyZq+1LAXHHvTZdVxicn4yiVYdYMGaCO3tmqub11AorKkv+iodqw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
-      "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.3.tgz",
+      "integrity": "sha512-hyrN8ivxfvJ4i0fIJuV4EOlV0WDMz5Ui4StRTgVaAvWeiRCilXgwVvxJKtFQ3TKtHgJscB2YiXKGNJuVwhQMtA==",
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.1",
-        "@babel/helper-compilation-targets": "^7.27.1",
-        "@babel/helper-module-transforms": "^7.27.1",
-        "@babel/helpers": "^7.27.1",
-        "@babel/parser": "^7.27.1",
-        "@babel/template": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1",
+        "@babel/generator": "^7.27.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.27.3",
+        "@babel/helpers": "^7.27.3",
+        "@babel/parser": "^7.27.3",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.27.3",
+        "@babel/types": "^7.27.3",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -211,13 +212,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.1.tgz",
-      "integrity": "sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.3.tgz",
+      "integrity": "sha512-xnlJYj5zepml8NXtjkG0WquFUv8RskFqyFcVgTBp5k+NaA/8uw/K+OSVf8AMGw5e9HKP2ETd5xpK5MLZQD6b4Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.1",
-        "@babel/types": "^7.27.1",
+        "@babel/parser": "^7.27.3",
+        "@babel/types": "^7.27.3",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -227,13 +228,13 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.1.tgz",
-      "integrity": "sha512-WnuuDILl9oOBbKnb4L+DyODx7iC47XfzmNCpTttFsSp6hTG7XZxu60+4IO+2/hPfcGOoKbFiwoI/+zwARbNQow==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.1"
+        "@babel/types": "^7.27.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -382,14 +383,14 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.1.tgz",
-      "integrity": "sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
+      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/traverse": "^7.27.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -513,13 +514,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.1.tgz",
-      "integrity": "sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.3.tgz",
+      "integrity": "sha512-h/eKy9agOya1IGuLaZ9tEUgz+uIRXcbtOhRtUyyMf8JFmn1iT13vnl/IGVWSkdOCG/pC57U4S1jnAabAavTMwg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -620,12 +621,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.2.tgz",
-      "integrity": "sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.3.tgz",
+      "integrity": "sha512-xyYxRj6+tLNDTWi0KCBcZ9V7yg3/lwL9DWh9Uwh/RIVlIfFidggcgxKX3GCXwCiswwcGRawBKbEg2LG/Y8eJhw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.1"
+        "@babel/types": "^7.27.3"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1302,9 +1303,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.1.tgz",
-      "integrity": "sha512-QEcFlMl9nGTgh1rn2nIeU5bkfb9BAjaQcWbiP4LvKxUot52ABcTkpcyJ7f2Q2U2RuQ84BNLgts3jRme2dTx6Fw==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.3.tgz",
+      "integrity": "sha512-+F8CnfhuLhwUACIJMLWnjz6zvzYM2r0yeIHKlbgfw7ml8rOMJsXNXV/hyRcb3nb493gRs4WvYpQAndWj/qQmkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1400,9 +1401,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.27.1.tgz",
-      "integrity": "sha512-ttDCqhfvpE9emVkXbPD8vyxxh4TWYACVybGkDj+oReOGwnp066ITEivDlLwe0b1R0+evJ13IXQuLNB5w1fhC5Q==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.27.3.tgz",
+      "integrity": "sha512-s4Jrok82JpiaIprtY2nHsYmrThKvvwgHwjgd7UMiYhZaN0asdXNLr0y+NjTfkA7SyQE5i2Fb7eawUOZmLvyqOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1765,15 +1766,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.27.2.tgz",
-      "integrity": "sha512-AIUHD7xJ1mCrj3uPozvtngY3s0xpv7Nu7DoUSnzNY6Xam1Cy4rUznR//pvMHOhQ4AvbCexhbqXCtpxGHOGOO6g==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.27.3.tgz",
+      "integrity": "sha512-7ZZtznF9g4l2JCImCo5LNKFHB5eXnN39lLtLY5Tg+VkR0jwOt7TBciMckuiQIOIW7L5tkQOCh3bVGYeXgMx52Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/plugin-transform-destructuring": "^7.27.1",
+        "@babel/plugin-transform-destructuring": "^7.27.3",
         "@babel/plugin-transform-parameters": "^7.27.1"
       },
       "engines": {
@@ -2051,9 +2052,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.27.1.tgz",
-      "integrity": "sha512-TqGF3desVsTcp3WrJGj4HfKokfCXCLcHpt4PJF0D8/iT6LPd9RS82Upw3KPeyr6B22Lfd3DO8MVrmp0oRkUDdw==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.27.3.tgz",
+      "integrity": "sha512-bA9ZL5PW90YwNgGfjg6U+7Qh/k3zCEQJ06BFgAGRp/yMjw9hP9UGbGPtx3KSOkHGljEPCCxaE+PH4fUR2h1sDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2438,9 +2439,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
-      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.3.tgz",
+      "integrity": "sha512-7EYtGezsdiDMyY80+65EzwiGmcJqpmcZCojSXaRgdrBaGtWTgDZKq69cPIVped6MkIM78cTQ2GOiEYjwOlG4xw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2475,16 +2476,16 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.1.tgz",
-      "integrity": "sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.3.tgz",
+      "integrity": "sha512-lId/IfN/Ye1CIu8xG7oKBHXd2iNb2aW1ilPszzGcJug6M8RCKfVNcYhpI5+bMvFYjK7lXIM0R+a+6r8xhHp2FQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.1",
-        "@babel/parser": "^7.27.1",
-        "@babel/template": "^7.27.1",
-        "@babel/types": "^7.27.1",
+        "@babel/generator": "^7.27.3",
+        "@babel/parser": "^7.27.3",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.3",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -2494,17 +2495,17 @@
     },
     "node_modules/@babel/traverse--for-generate-function-map": {
       "name": "@babel/traverse",
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.1.tgz",
-      "integrity": "sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.3.tgz",
+      "integrity": "sha512-lId/IfN/Ye1CIu8xG7oKBHXd2iNb2aW1ilPszzGcJug6M8RCKfVNcYhpI5+bMvFYjK7lXIM0R+a+6r8xhHp2FQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.1",
-        "@babel/parser": "^7.27.1",
-        "@babel/template": "^7.27.1",
-        "@babel/types": "^7.27.1",
+        "@babel/generator": "^7.27.3",
+        "@babel/parser": "^7.27.3",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.3",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -2561,9 +2562,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
-      "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.3.tgz",
+      "integrity": "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -4303,9 +4304,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
-      "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
+      "version": "22.15.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.23.tgz",
+      "integrity": "sha512-7Ec1zaFPF4RJ0eXu1YT/xgiebqwqoJz8rYPDi/O2BcZ++Wpt0Kq9cl0eg6NN6bYbPnR67ZLo7St5Q3UK0SnARw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4319,9 +4320,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.5.tgz",
-      "integrity": "sha512-piErsCVVbpMMT2r7wbawdZsq4xMvIAhQuac2gedQHysu1TZYEigE6pnFfgZT+/jQnrRuF5r+SHzuehFjfRjr4g==",
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
+      "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -6710,9 +6711,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.157",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.157.tgz",
-      "integrity": "sha512-/0ybgsQd1muo8QlnuTpKwtl0oX5YMlUGbm8xyqgDU00motRkKFFbUJySAQBWcY79rVqNLWIWa87BGVGClwAB2w==",
+      "version": "1.5.159",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.159.tgz",
+      "integrity": "sha512-CEvHptWAMV5p6GJ0Lq8aheyvVbfzVrv5mmidu1D3pidoVNkB3tTBsTMVtPJ+rzRK5oV229mCLz9Zj/hNvU8GBA==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -16113,9 +16114,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.39.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.2.tgz",
-      "integrity": "sha512-yEPUmWve+VA78bI71BW70Dh0TuV4HHd+I5SHOAfS1+QBOmvmCiiffgjR8ryyEd3KIfvPGFqoADt8LdQ6XpXIvg==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.40.0.tgz",
+      "integrity": "sha512-cfeKl/jjwSR5ar7d0FGmave9hFGJT8obyo0z+CrQOylLDbk7X81nPU6vq9VORa5jU30SkDnT2FXjLbR8HLP+xA==",
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
@@ -17300,9 +17301,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.28",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.28.tgz",
-      "integrity": "sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q==",
+      "version": "3.25.32",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.32.tgz",
+      "integrity": "sha512-OSm2xTIRfW8CV5/QKgngwmQW/8aPfGdaQFlrGoErlgg/Epm7cjb6K6VEyExfe65a3VybUOnu381edLb0dfJl0g==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -56,15 +56,15 @@
     "customerio-reactnative": "4.2.7"
   },
   "devDependencies": {
+    "@expo/config-plugins": "^10.0.0",
     "@expo/config-types": "^53.0.0",
-    "@expo/config-plugins": "~10.0.0",
     "@types/jest": "^29.5.14",
     "@typescript-eslint/eslint-plugin": "^5.21.0",
     "@typescript-eslint/parser": "^5.21.0",
     "eslint": "^8.14.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "expo-build-properties": "~0.14.6",
+    "expo-build-properties": "^0.14.6",
     "expo-module-scripts": "^3.0.2",
     "gradle-to-js": "^2.0.1",
     "jest": "^29.2.1",
@@ -72,7 +72,7 @@
     "prettier": "^2.6.2",
     "react-native-builder-bob": "^0.18.3",
     "ts-jest": "^29.2.5",
-    "typescript": "~5.8.3",
+    "typescript": "^5.8.3",
     "xcode": "^3.0.1"
   },
   "commitlint": {

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
   },
   "dependencies": {
     "find-package-json": "^1.2.0",
-    "fs-extra": "^11.2.0"
+    "fs-extra": "^11.2.0",
+    "semver": "^7.7.2"
   }
 }

--- a/plugin/src/android/withAndroidManifestUpdates.ts
+++ b/plugin/src/android/withAndroidManifestUpdates.ts
@@ -1,4 +1,5 @@
-import { ConfigPlugin, withAndroidManifest } from '@expo/config-plugins';
+import type { ConfigPlugin } from '@expo/config-plugins';
+import { withAndroidManifest } from '@expo/config-plugins';
 import type { ManifestApplication } from '@expo/config-plugins/build/android/Manifest';
 
 import type { CustomerIOPluginOptionsAndroid } from '../types/cio-types';

--- a/plugin/src/android/withAppGoogleServices.ts
+++ b/plugin/src/android/withAppGoogleServices.ts
@@ -1,4 +1,5 @@
-import { ConfigPlugin, withAppBuildGradle } from '@expo/config-plugins';
+import type { ConfigPlugin } from '@expo/config-plugins';
+import { withAppBuildGradle } from '@expo/config-plugins';
 
 import {
   CIO_APP_APPLY_REGEX,

--- a/plugin/src/android/withGistMavenRepository.ts
+++ b/plugin/src/android/withGistMavenRepository.ts
@@ -1,4 +1,5 @@
-import { withProjectBuildGradle, ConfigPlugin } from '@expo/config-plugins';
+import { withProjectBuildGradle } from '@expo/config-plugins';
+import type { ConfigPlugin } from '@expo/config-plugins';
 
 import {
   CIO_GIST_MAVEN_REGEX,

--- a/plugin/src/android/withGoogleServicesJSON.ts
+++ b/plugin/src/android/withGoogleServicesJSON.ts
@@ -1,4 +1,5 @@
-import { withProjectBuildGradle, ConfigPlugin } from '@expo/config-plugins';
+import { withProjectBuildGradle } from '@expo/config-plugins';
+import type { ConfigPlugin } from '@expo/config-plugins';
 
 import { FileManagement } from './../helpers/utils/fileManagement';
 import type { CustomerIOPluginOptionsAndroid } from './../types/cio-types';

--- a/plugin/src/android/withProjectGoogleServices.ts
+++ b/plugin/src/android/withProjectGoogleServices.ts
@@ -1,4 +1,5 @@
-import { ConfigPlugin, withProjectBuildGradle } from '@expo/config-plugins';
+import type { ConfigPlugin } from '@expo/config-plugins';
+import { withProjectBuildGradle } from '@expo/config-plugins';
 
 import {
   CIO_PROJECT_BUILDSCRIPTS_REGEX,

--- a/plugin/src/android/withProjectStrings.ts
+++ b/plugin/src/android/withProjectStrings.ts
@@ -1,4 +1,5 @@
-import { ConfigPlugin, withStringsXml } from '@expo/config-plugins';
+import type { ConfigPlugin } from '@expo/config-plugins';
+import { withStringsXml } from '@expo/config-plugins';
 import { getPluginVersion } from '../helpers/utils/pluginUtils';
 
 /**

--- a/plugin/src/helpers/native-files/ios/apn/CioSdkAppDelegateHandler.swift
+++ b/plugin/src/helpers/native-files/ios/apn/CioSdkAppDelegateHandler.swift
@@ -35,7 +35,7 @@ public class CioSdkAppDelegateHandler: NSObject {
     // Note: Initialize the native iOS SDK and setup SDK push click handling before running this code.
     #if canImport(EXNotifications)
       // Getting the singleton reference from Expo
-      if let notificationCenterDelegate = EXModuleRegistryProvider.getSingletonModule(forClass: EXNotificationCenterDelegate.self) as? UNUserNotificationCenterDelegate {
+    if let notificationCenterDelegate = ModuleRegistryProvider.getSingletonModule(for: NotificationCenterManager.self) as? UNUserNotificationCenterDelegate {
         let center = UNUserNotificationCenter.current()
         center.delegate = notificationCenterDelegate
       }

--- a/plugin/src/helpers/native-files/ios/apn/CioSdkAppDelegateHandler.swift
+++ b/plugin/src/helpers/native-files/ios/apn/CioSdkAppDelegateHandler.swift
@@ -2,6 +2,10 @@ import Foundation
 import UIKit
 import UserNotifications
 import CioMessagingPushAPN
+#if canImport(EXNotifications)
+import EXNotifications
+import ExpoModulesCore
+#endif
 
 public class CioSdkAppDelegateHandler: NSObject {
     
@@ -16,6 +20,26 @@ public class CioSdkAppDelegateHandler: NSObject {
         .autoTrackPushEvents({{AUTO_TRACK_PUSH_EVENTS}})
         .build()
     )
+    
+    // Code to make the CIO SDK compatible with expo-notifications package.
+    //
+    // The CIO SDK and expo-notifications both need to handle when a push gets clicked. However, iOS only allows one click handler to be set per app.
+    // To get around this limitation, we set the CIO SDK as the click handler. The CIO SDK sets itself up so that when another SDK or host iOS app
+    // sets itself as the click handler, the CIO SDK will still be able to handle when the push gets clicked, even though it's not the designated
+    // click handler in iOS at runtime.
+    //
+    // This should work for most SDKs. However, expo-notifications is unique in its implementation. It will not setup push click handling if it detects
+    // that another SDK or host iOS app has already set itself as the click handler.
+    // To get around this, we must manually set it as the click handler after the CIO SDK. That's what this code block does.
+    //
+    // Note: Initialize the native iOS SDK and setup SDK push click handling before running this code.
+    #if canImport(EXNotifications)
+      // Getting the singleton reference from Expo
+      if let notificationCenterDelegate = EXModuleRegistryProvider.getSingletonModule(forClass: EXNotificationCenterDelegate.self) as? UNUserNotificationCenterDelegate {
+        let center = UNUserNotificationCenter.current()
+        center.delegate = notificationCenterDelegate
+      }
+    #endif
   }
 
   public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {

--- a/plugin/src/helpers/native-files/ios/fcm/CioSdkAppDelegateHandler.swift
+++ b/plugin/src/helpers/native-files/ios/fcm/CioSdkAppDelegateHandler.swift
@@ -43,7 +43,7 @@ public class CioSdkAppDelegateHandler: NSObject {
     // Note: Initialize the native iOS SDK and setup SDK push click handling before running this code.
     #if canImport(EXNotifications)
       // Getting the singleton reference from Expo
-      if let notificationCenterDelegate = EXModuleRegistryProvider.getSingletonModule(forClass: EXNotificationCenterDelegate.self) as? UNUserNotificationCenterDelegate {
+    if let notificationCenterDelegate = ModuleRegistryProvider.getSingletonModule(for: NotificationCenterManager.self) as? UNUserNotificationCenterDelegate {
         let center = UNUserNotificationCenter.current()
         center.delegate = notificationCenterDelegate
       }

--- a/plugin/src/helpers/native-files/ios/fcm/CioSdkAppDelegateHandler.swift
+++ b/plugin/src/helpers/native-files/ios/fcm/CioSdkAppDelegateHandler.swift
@@ -4,6 +4,10 @@ import FirebaseCore
 import FirebaseMessaging
 import UserNotifications
 import UIKit
+#if canImport(EXNotifications)
+import EXNotifications
+import ExpoModulesCore
+#endif
 
 public class CioSdkAppDelegateHandler: NSObject {
     
@@ -24,6 +28,26 @@ public class CioSdkAppDelegateHandler: NSObject {
         .autoTrackPushEvents({{AUTO_TRACK_PUSH_EVENTS}})
         .build()
     )
+    
+    // Code to make the CIO SDK compatible with expo-notifications package.
+    //
+    // The CIO SDK and expo-notifications both need to handle when a push gets clicked. However, iOS only allows one click handler to be set per app.
+    // To get around this limitation, we set the CIO SDK as the click handler. The CIO SDK sets itself up so that when another SDK or host iOS app
+    // sets itself as the click handler, the CIO SDK will still be able to handle when the push gets clicked, even though it's not the designated
+    // click handler in iOS at runtime.
+    //
+    // This should work for most SDKs. However, expo-notifications is unique in its implementation. It will not setup push click handling if it detects
+    // that another SDK or host iOS app has already set itself as the click handler.
+    // To get around this, we must manually set it as the click handler after the CIO SDK. That's what this code block does.
+    //
+    // Note: Initialize the native iOS SDK and setup SDK push click handling before running this code.
+    #if canImport(EXNotifications)
+      // Getting the singleton reference from Expo
+      if let notificationCenterDelegate = EXModuleRegistryProvider.getSingletonModule(forClass: EXNotificationCenterDelegate.self) as? UNUserNotificationCenterDelegate {
+        let center = UNUserNotificationCenter.current()
+        center.delegate = notificationCenterDelegate
+      }
+    #endif
   }
 
   public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {

--- a/plugin/src/helpers/utils/fileManagement.ts
+++ b/plugin/src/helpers/utils/fileManagement.ts
@@ -7,8 +7,8 @@ import {
   mkdirSync,
   writeFileSync,
   readFileSync,
-  MakeDirectoryOptions,
 } from 'fs';
+import type { MakeDirectoryOptions } from 'fs';
 
 export class FileManagement {
   static async read(path: string): Promise<string> {

--- a/plugin/src/ios/utils.ts
+++ b/plugin/src/ios/utils.ts
@@ -1,5 +1,6 @@
 import type { CustomerIOPluginOptionsIOS } from '../types/cio-types';
 import type { ExpoConfig } from '@expo/config-types';
+import * as semver from 'semver';
 
 /**
  * Returns t
@@ -14,9 +15,13 @@ export const isFcmPushProvider = (
 
 export const isExpoVersion53OrHigher = (config: ExpoConfig): boolean => {
   const sdkVersion = config.sdkVersion || '';
-  const parsedMajorVersion = parseInt(sdkVersion.split('.')[0], 10);
-
-  if (isNaN(parsedMajorVersion)) return false;
-
-  return parsedMajorVersion >= 53;
+  
+  // If sdkVersion is not a valid semver, coerce it to a valid one if possible
+  const validVersion = semver.valid(sdkVersion) || semver.coerce(sdkVersion);
+  
+  // If we couldn't get a valid version, return false
+  if (!validVersion) return false;
+  
+  // Check if the version is greater than or equal to 53.0.0
+  return semver.gte(validVersion, '53.0.0');
 };

--- a/plugin/src/ios/withAppDelegateModifications.ts
+++ b/plugin/src/ios/withAppDelegateModifications.ts
@@ -1,4 +1,5 @@
-import { ConfigPlugin, withAppDelegate } from '@expo/config-plugins';
+import type { ConfigPlugin } from '@expo/config-plugins';
+import { withAppDelegate } from '@expo/config-plugins';
 import { getAppDelegateHeaderFilePath } from '@expo/config-plugins/build/ios/Paths';
 
 import {

--- a/plugin/src/ios/withCIOIos.ts
+++ b/plugin/src/ios/withCIOIos.ts
@@ -16,14 +16,12 @@ export function withCIOIos(
   props: CustomerIOPluginOptionsIOS
 ) {
   const cioProps = mergeDeprecatedPropertiesAndLogWarnings(props);
-  const isSwiftProject = isExpoVersion53OrHigher(config)
+  const isSwiftProject = isExpoVersion53OrHigher(config);
 
   if (cioProps.pushNotification) {
     if (isSwiftProject) {
       config = withCIOIosSwift(config, cioProps);
-      console.log('Applying Swift AppDelegate modifications for Expo 53+');
     } else {
-      console.log('Applying Objective-C AppDelegate modifications for Expo 52 and lower');
       config = withAppDelegateModifications(config, cioProps);
     }
 

--- a/plugin/src/ios/withGoogleServicesJsonFile.ts
+++ b/plugin/src/ios/withGoogleServicesJsonFile.ts
@@ -1,8 +1,8 @@
 import {
   withXcodeProject,
   IOSConfig,
-  ConfigPlugin,
 } from '@expo/config-plugins';
+import type { ConfigPlugin } from '@expo/config-plugins';
 
 import { FileManagement } from './../helpers/utils/fileManagement';
 import type { CustomerIOPluginOptionsIOS } from '../types/cio-types';

--- a/plugin/src/ios/withNotificationsXcodeProject.ts
+++ b/plugin/src/ios/withNotificationsXcodeProject.ts
@@ -1,8 +1,5 @@
-import {
-  ConfigPlugin,
-  XcodeProject,
-  withXcodeProject,
-} from '@expo/config-plugins';
+import type { ConfigPlugin, XcodeProject } from '@expo/config-plugins';
+import { withXcodeProject } from '@expo/config-plugins';
 
 import {
   CIO_NOTIFICATION_TARGET_NAME,
@@ -27,6 +24,7 @@ const addNotificationServiceExtension = async (
   isExpoVersion53OrHigher: boolean
 ) => {
   try {
+    // PushService file is only needed for pre-Expo 53 code generation
     if (options.pushNotification && !isExpoVersion53OrHigher) {
       await addPushNotificationFile(options, xcodeProject);
     }

--- a/plugin/src/ios/withXcodeProject.ts
+++ b/plugin/src/ios/withXcodeProject.ts
@@ -1,4 +1,5 @@
-import { ConfigPlugin, withXcodeProject } from '@expo/config-plugins';
+import type { ConfigPlugin } from '@expo/config-plugins';
+import { withXcodeProject } from '@expo/config-plugins';
 
 import { isFcmPushProvider } from './utils';
 import { injectCIOPodfileCode } from '../helpers/utils/injectCIOPodfileCode';

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -72,30 +72,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.2.tgz",
-      "integrity": "sha512-TUtMJYRPyUb/9aU8f3K0mjmjf6M9N5Woshn2CS6nqJSeJtTtQcpLUXjGt9vbF8ZGff0El99sWkLgzwW3VXnxZQ==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.3.tgz",
+      "integrity": "sha512-V42wFfx1ymFte+ecf6iXghnnP8kWTO+ZLXIyZq+1LAXHHvTZdVxicn4yiVYdYMGaCO3tmqub11AorKkv+iodqw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
-      "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.3.tgz",
+      "integrity": "sha512-hyrN8ivxfvJ4i0fIJuV4EOlV0WDMz5Ui4StRTgVaAvWeiRCilXgwVvxJKtFQ3TKtHgJscB2YiXKGNJuVwhQMtA==",
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.1",
-        "@babel/helper-compilation-targets": "^7.27.1",
-        "@babel/helper-module-transforms": "^7.27.1",
-        "@babel/helpers": "^7.27.1",
-        "@babel/parser": "^7.27.1",
-        "@babel/template": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1",
+        "@babel/generator": "^7.27.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.27.3",
+        "@babel/helpers": "^7.27.3",
+        "@babel/parser": "^7.27.3",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.27.3",
+        "@babel/types": "^7.27.3",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -111,13 +111,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.1.tgz",
-      "integrity": "sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.3.tgz",
+      "integrity": "sha512-xnlJYj5zepml8NXtjkG0WquFUv8RskFqyFcVgTBp5k+NaA/8uw/K+OSVf8AMGw5e9HKP2ETd5xpK5MLZQD6b4Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.1",
-        "@babel/types": "^7.27.1",
+        "@babel/parser": "^7.27.3",
+        "@babel/types": "^7.27.3",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -127,12 +127,12 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.1.tgz",
-      "integrity": "sha512-WnuuDILl9oOBbKnb4L+DyODx7iC47XfzmNCpTttFsSp6hTG7XZxu60+4IO+2/hPfcGOoKbFiwoI/+zwARbNQow==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.1"
+        "@babel/types": "^7.27.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -235,14 +235,14 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.1.tgz",
-      "integrity": "sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
+      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/traverse": "^7.27.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -361,13 +361,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.1.tgz",
-      "integrity": "sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.3.tgz",
+      "integrity": "sha512-h/eKy9agOya1IGuLaZ9tEUgz+uIRXcbtOhRtUyyMf8JFmn1iT13vnl/IGVWSkdOCG/pC57U4S1jnAabAavTMwg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -460,12 +460,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.2.tgz",
-      "integrity": "sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.3.tgz",
+      "integrity": "sha512-xyYxRj6+tLNDTWi0KCBcZ9V7yg3/lwL9DWh9Uwh/RIVlIfFidggcgxKX3GCXwCiswwcGRawBKbEg2LG/Y8eJhw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.1"
+        "@babel/types": "^7.27.3"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -835,9 +835,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.1.tgz",
-      "integrity": "sha512-QEcFlMl9nGTgh1rn2nIeU5bkfb9BAjaQcWbiP4LvKxUot52ABcTkpcyJ7f2Q2U2RuQ84BNLgts3jRme2dTx6Fw==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.3.tgz",
+      "integrity": "sha512-+F8CnfhuLhwUACIJMLWnjz6zvzYM2r0yeIHKlbgfw7ml8rOMJsXNXV/hyRcb3nb493gRs4WvYpQAndWj/qQmkQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -902,9 +902,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.27.1.tgz",
-      "integrity": "sha512-ttDCqhfvpE9emVkXbPD8vyxxh4TWYACVybGkDj+oReOGwnp066ITEivDlLwe0b1R0+evJ13IXQuLNB5w1fhC5Q==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.27.3.tgz",
+      "integrity": "sha512-s4Jrok82JpiaIprtY2nHsYmrThKvvwgHwjgd7UMiYhZaN0asdXNLr0y+NjTfkA7SyQE5i2Fb7eawUOZmLvyqOA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1073,14 +1073,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.27.2.tgz",
-      "integrity": "sha512-AIUHD7xJ1mCrj3uPozvtngY3s0xpv7Nu7DoUSnzNY6Xam1Cy4rUznR//pvMHOhQ4AvbCexhbqXCtpxGHOGOO6g==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.27.3.tgz",
+      "integrity": "sha512-7ZZtznF9g4l2JCImCo5LNKFHB5eXnN39lLtLY5Tg+VkR0jwOt7TBciMckuiQIOIW7L5tkQOCh3bVGYeXgMx52Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/plugin-transform-destructuring": "^7.27.1",
+        "@babel/plugin-transform-destructuring": "^7.27.3",
         "@babel/plugin-transform-parameters": "^7.27.1"
       },
       "engines": {
@@ -1280,9 +1280,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.27.1.tgz",
-      "integrity": "sha512-TqGF3desVsTcp3WrJGj4HfKokfCXCLcHpt4PJF0D8/iT6LPd9RS82Upw3KPeyr6B22Lfd3DO8MVrmp0oRkUDdw==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.27.3.tgz",
+      "integrity": "sha512-bA9ZL5PW90YwNgGfjg6U+7Qh/k3zCEQJ06BFgAGRp/yMjw9hP9UGbGPtx3KSOkHGljEPCCxaE+PH4fUR2h1sDw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
@@ -1435,9 +1435,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
-      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.3.tgz",
+      "integrity": "sha512-7EYtGezsdiDMyY80+65EzwiGmcJqpmcZCojSXaRgdrBaGtWTgDZKq69cPIVped6MkIM78cTQ2GOiEYjwOlG4xw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1458,16 +1458,16 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.1.tgz",
-      "integrity": "sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.3.tgz",
+      "integrity": "sha512-lId/IfN/Ye1CIu8xG7oKBHXd2iNb2aW1ilPszzGcJug6M8RCKfVNcYhpI5+bMvFYjK7lXIM0R+a+6r8xhHp2FQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.1",
-        "@babel/parser": "^7.27.1",
-        "@babel/template": "^7.27.1",
-        "@babel/types": "^7.27.1",
+        "@babel/generator": "^7.27.3",
+        "@babel/parser": "^7.27.3",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.3",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -1477,16 +1477,16 @@
     },
     "node_modules/@babel/traverse--for-generate-function-map": {
       "name": "@babel/traverse",
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.1.tgz",
-      "integrity": "sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.3.tgz",
+      "integrity": "sha512-lId/IfN/Ye1CIu8xG7oKBHXd2iNb2aW1ilPszzGcJug6M8RCKfVNcYhpI5+bMvFYjK7lXIM0R+a+6r8xhHp2FQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.1",
-        "@babel/parser": "^7.27.1",
-        "@babel/template": "^7.27.1",
-        "@babel/types": "^7.27.1",
+        "@babel/generator": "^7.27.3",
+        "@babel/parser": "^7.27.3",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.3",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -1495,9 +1495,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
-      "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.3.tgz",
+      "integrity": "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -2823,9 +2823,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.15.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
-      "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
+      "version": "22.15.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.23.tgz",
+      "integrity": "sha512-7Ec1zaFPF4RJ0eXu1YT/xgiebqwqoJz8rYPDi/O2BcZ++Wpt0Kq9cl0eg6NN6bYbPnR67ZLo7St5Q3UK0SnARw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3873,15 +3873,28 @@
     "node_modules/customerio-expo-plugin": {
       "version": "2.0.3",
       "resolved": "file:../customerio-expo-plugin-latest.tgz",
-      "integrity": "sha512-PM428hQAoYAiLHDFcwSy5CrOWbOKGny+La/lke2mLtbKasvdtXSbBDirla+vb/Jn7bwMPTqf4t4b65qo8eLSqA==",
+      "integrity": "sha512-UJn7pA2zVucl8ZpFf2HShCjTpw8gSdrvJ1mJwafUzk+VHofM7t7+1f/t3YaCrfk6WAhrqackxSKSVZ6jHhT/Jg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "find-package-json": "^1.2.0",
-        "fs-extra": "^11.2.0"
+        "fs-extra": "^11.2.0",
+        "semver": "^7.7.2"
       },
       "peerDependencies": {
         "customerio-reactnative": "4.2.7"
+      }
+    },
+    "node_modules/customerio-expo-plugin/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/customerio-reactnative": {
@@ -4034,9 +4047,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.157",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.157.tgz",
-      "integrity": "sha512-/0ybgsQd1muo8QlnuTpKwtl0oX5YMlUGbm8xyqgDU00motRkKFFbUJySAQBWcY79rVqNLWIWa87BGVGClwAB2w==",
+      "version": "1.5.159",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.159.tgz",
+      "integrity": "sha512-CEvHptWAMV5p6GJ0Lq8aheyvVbfzVrv5mmidu1D3pidoVNkB3tTBsTMVtPJ+rzRK5oV229mCLz9Zj/hNvU8GBA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -7862,9 +7875,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.39.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.2.tgz",
-      "integrity": "sha512-yEPUmWve+VA78bI71BW70Dh0TuV4HHd+I5SHOAfS1+QBOmvmCiiffgjR8ryyEd3KIfvPGFqoADt8LdQ6XpXIvg==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.40.0.tgz",
+      "integrity": "sha512-cfeKl/jjwSR5ar7d0FGmave9hFGJT8obyo0z+CrQOylLDbk7X81nPU6vq9VORa5jU30SkDnT2FXjLbR8HLP+xA==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "esnext"
+    "target": "esnext",
+    "verbatimModuleSyntax": true
   }
 }


### PR DESCRIPTION
This PR does some minor cleaning and changes based on previous PR comments.

## Summary
- Enables `verbatimModuleSyntax` TS flag and adjusts imports in TS files to import types explicitly
-  Uses `semver` to check Expo version instead of manual parsing
- Adds snippet for expo-notifications compatibility

## Testing
- You can use Firebase builds from this branch
- I tested all basic functionality with APN/FCM
- I tested with plugin from this branch working with an Expo 52 app