### PR TITLE
feat: Use non-swizzling push support solution for iOS

### DIFF
--- a/__tests__/ios/apn/CioSdkAppDelegateHandler-swift.test.js
+++ b/__tests__/ios/apn/CioSdkAppDelegateHandler-swift.test.js
@@ -1,0 +1,16 @@
+const { testAppPath, testAppName, isExpoVersion53OrHigher } = require("../../utils");
+const fs = require("fs-extra");
+const path = require("path");
+
+const testProjectPath = testAppPath();
+const iosPath = path.join(testProjectPath, "ios");
+const appDelegateHandlerPath = path.join(iosPath, `${testAppName()}/CioSdkAppDelegateHandler.swift`);
+
+// CioSdkAppDelegateHandler.swift is only relevant for versions lower than Expo 53
+(isExpoVersion53OrHigher() ? describe : describe.skip)("Expo 53 CioSdkAppDelegateHandler tests", () => {
+  test("Plugin creates expected CioSdkAppDelegateHandler.swift", async () => {
+    const content = await fs.readFile(appDelegateHandlerPath, "utf8");
+
+    expect(content).toMatchSnapshot();
+  });
+});

--- a/__tests__/ios/apn/__snapshots__/CioSdkAppDelegateHandler-swift.test.js.snap
+++ b/__tests__/ios/apn/__snapshots__/CioSdkAppDelegateHandler-swift.test.js.snap
@@ -10,11 +10,11 @@ import EXNotifications
 import ExpoModulesCore
 #endif
 
-class DummyAppDelegate: NSObject, UIApplicationDelegate {}
+private class DummyAppDelegate: NSObject, UIApplicationDelegate {}
 
 public class CioSdkAppDelegateHandler: NSObject {
 
-  let cioAppDelegate = CioAppDelegateWrapper<DummyAppDelegate>()
+  private let cioAppDelegate = CioAppDelegateWrapper<DummyAppDelegate>()
     
   public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
 
@@ -27,14 +27,6 @@ public class CioSdkAppDelegateHandler: NSObject {
         }
       }
     }
-
-    MessagingPushAPN.initialize(
-      withConfig: MessagingPushConfigBuilder()
-        .autoFetchDeviceToken(true)
-        .showPushAppInForeground(true)
-        .autoTrackPushEvents(true)
-        .build()
-    )
     
     // Code to make the CIO SDK compatible with expo-notifications package.
     //
@@ -57,6 +49,14 @@ public class CioSdkAppDelegateHandler: NSObject {
     #endif
 
     _ = cioAppDelegate.application(application, didFinishLaunchingWithOptions: launchOptions)
+
+    MessagingPushAPN.initialize(
+      withConfig: MessagingPushConfigBuilder()
+        .autoFetchDeviceToken(true)
+        .showPushAppInForeground(true)
+        .autoTrackPushEvents(true)
+        .build()
+    )
   }
 
   public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {

--- a/__tests__/ios/apn/__snapshots__/CioSdkAppDelegateHandler-swift.test.js.snap
+++ b/__tests__/ios/apn/__snapshots__/CioSdkAppDelegateHandler-swift.test.js.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expo 53 CioSdkAppDelegateHandler tests Plugin creates expected CioSdkAppDelegateHandler.swift 1`] = `
+"import Foundation
+import UIKit
+import UserNotifications
+import CioMessagingPushAPN
+#if canImport(EXNotifications)
+import EXNotifications
+import ExpoModulesCore
+#endif
+
+class DummyAppDelegate: NSObject, UIApplicationDelegate {}
+
+public class CioSdkAppDelegateHandler: NSObject {
+
+  let cioAppDelegate = CioAppDelegateWrapper<DummyAppDelegate>()
+    
+  public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
+
+    
+    let center  = UNUserNotificationCenter.current()
+    center.requestAuthorization(options: [.sound, .alert, .badge]) { (granted, error) in
+      if error == nil{
+        DispatchQueue.main.async {
+          UIApplication.shared.registerForRemoteNotifications()
+        }
+      }
+    }
+
+    MessagingPushAPN.initialize(
+      withConfig: MessagingPushConfigBuilder()
+        .autoFetchDeviceToken(true)
+        .showPushAppInForeground(true)
+        .autoTrackPushEvents(true)
+        .build()
+    )
+    
+    // Code to make the CIO SDK compatible with expo-notifications package.
+    //
+    // The CIO SDK and expo-notifications both need to handle when a push gets clicked. However, iOS only allows one click handler to be set per app.
+    // To get around this limitation, we set the CIO SDK as the click handler. The CIO SDK sets itself up so that when another SDK or host iOS app
+    // sets itself as the click handler, the CIO SDK will still be able to handle when the push gets clicked, even though it's not the designated
+    // click handler in iOS at runtime.
+    //
+    // This should work for most SDKs. However, expo-notifications is unique in its implementation. It will not setup push click handling if it detects
+    // that another SDK or host iOS app has already set itself as the click handler.
+    // To get around this, we must manually set it as the click handler after the CIO SDK. That's what this code block does.
+    //
+    // Note: Initialize the native iOS SDK and setup SDK push click handling before running this code.
+    #if canImport(EXNotifications)
+      // Getting the singleton reference from Expo
+    if let notificationCenterDelegate = ModuleRegistryProvider.getSingletonModule(for: NotificationCenterManager.self) as? UNUserNotificationCenterDelegate {
+        let center = UNUserNotificationCenter.current()
+        center.delegate = notificationCenterDelegate
+      }
+    #endif
+
+    _ = cioAppDelegate.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+    cioAppDelegate.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+  }
+    
+  public func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+    cioAppDelegate.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+  }
+}
+"
+`;

--- a/__tests__/ios/fcm/CioSdkAppDelegateHandler-swift.test.js
+++ b/__tests__/ios/fcm/CioSdkAppDelegateHandler-swift.test.js
@@ -1,0 +1,16 @@
+const { testAppPath, testAppName, isExpoVersion53OrHigher } = require("../../utils");
+const fs = require("fs-extra");
+const path = require("path");
+
+const testProjectPath = testAppPath();
+const iosPath = path.join(testProjectPath, "ios");
+const appDelegateHandlerPath = path.join(iosPath, `${testAppName()}/CioSdkAppDelegateHandler.swift`);
+
+// CioSdkAppDelegateHandler.swift is only relevant for versions lower than Expo 53
+(isExpoVersion53OrHigher() ? describe : describe.skip)("Expo 53 FCM CioSdkAppDelegateHandler tests", () => {
+  test("Plugin creates expected CioSdkAppDelegateHandler.swift", async () => {
+    const content = await fs.readFile(appDelegateHandlerPath, "utf8");
+
+    expect(content).toMatchSnapshot();
+  });
+});

--- a/__tests__/ios/fcm/__snapshots__/CioSdkAppDelegateHandler-swift.test.js.snap
+++ b/__tests__/ios/fcm/__snapshots__/CioSdkAppDelegateHandler-swift.test.js.snap
@@ -12,11 +12,13 @@ import EXNotifications
 import ExpoModulesCore
 #endif
 
-class DummyAppDelegate: NSObject, UIApplicationDelegate {}
+private class DummyAppDelegate: NSObject, UIApplicationDelegate, MessagingDelegate {
+  func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {}
+}
 
 public class CioSdkAppDelegateHandler: NSObject {
 
-  let cioAppDelegate = CioAppDelegateWrapper<DummyAppDelegate>()
+  private let cioAppDelegate = CioAppDelegateWrapper<DummyAppDelegate>()
     
   public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
 
@@ -29,19 +31,6 @@ public class CioSdkAppDelegateHandler: NSObject {
         }
       }
     }
-
-    if (FirebaseApp.app() == nil) {
-      FirebaseApp.configure()
-    }
-    UIApplication.shared.registerForRemoteNotifications()
-    
-    MessagingPushFCM.initialize(
-      withConfig: MessagingPushConfigBuilder()
-        .autoFetchDeviceToken(true)
-        .showPushAppInForeground(true)
-        .autoTrackPushEvents(true)
-        .build()
-    )
     
     // Code to make the CIO SDK compatible with expo-notifications package.
     //
@@ -63,7 +52,19 @@ public class CioSdkAppDelegateHandler: NSObject {
       }
     #endif
 
+    if (FirebaseApp.app() == nil) {
+      FirebaseApp.configure()
+    }
     _ = cioAppDelegate.application(application, didFinishLaunchingWithOptions: launchOptions)
+    UIApplication.shared.registerForRemoteNotifications()
+
+    MessagingPushFCM.initialize(
+      withConfig: MessagingPushConfigBuilder()
+        .autoFetchDeviceToken(true)
+        .showPushAppInForeground(true)
+        .autoTrackPushEvents(true)
+        .build()
+    )
   }
 
   public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {

--- a/__tests__/ios/fcm/__snapshots__/CioSdkAppDelegateHandler-swift.test.js.snap
+++ b/__tests__/ios/fcm/__snapshots__/CioSdkAppDelegateHandler-swift.test.js.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expo 53 FCM CioSdkAppDelegateHandler tests Plugin creates expected CioSdkAppDelegateHandler.swift 1`] = `
+"import Foundation
+import CioMessagingPushFCM
+import FirebaseCore
+import FirebaseMessaging
+import UserNotifications
+import UIKit
+#if canImport(EXNotifications)
+import EXNotifications
+import ExpoModulesCore
+#endif
+
+class DummyAppDelegate: NSObject, UIApplicationDelegate {}
+
+public class CioSdkAppDelegateHandler: NSObject {
+
+  let cioAppDelegate = CioAppDelegateWrapper<DummyAppDelegate>()
+    
+  public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
+
+    
+    let center  = UNUserNotificationCenter.current()
+    center.requestAuthorization(options: [.sound, .alert, .badge]) { (granted, error) in
+      if error == nil{
+        DispatchQueue.main.async {
+          UIApplication.shared.registerForRemoteNotifications()
+        }
+      }
+    }
+
+    if (FirebaseApp.app() == nil) {
+      FirebaseApp.configure()
+    }
+    UIApplication.shared.registerForRemoteNotifications()
+    
+    MessagingPushFCM.initialize(
+      withConfig: MessagingPushConfigBuilder()
+        .autoFetchDeviceToken(true)
+        .showPushAppInForeground(true)
+        .autoTrackPushEvents(true)
+        .build()
+    )
+    
+    // Code to make the CIO SDK compatible with expo-notifications package.
+    //
+    // The CIO SDK and expo-notifications both need to handle when a push gets clicked. However, iOS only allows one click handler to be set per app.
+    // To get around this limitation, we set the CIO SDK as the click handler. The CIO SDK sets itself up so that when another SDK or host iOS app
+    // sets itself as the click handler, the CIO SDK will still be able to handle when the push gets clicked, even though it's not the designated
+    // click handler in iOS at runtime.
+    //
+    // This should work for most SDKs. However, expo-notifications is unique in its implementation. It will not setup push click handling if it detects
+    // that another SDK or host iOS app has already set itself as the click handler.
+    // To get around this, we must manually set it as the click handler after the CIO SDK. That's what this code block does.
+    //
+    // Note: Initialize the native iOS SDK and setup SDK push click handling before running this code.
+    #if canImport(EXNotifications)
+      // Getting the singleton reference from Expo
+    if let notificationCenterDelegate = ModuleRegistryProvider.getSingletonModule(for: NotificationCenterManager.self) as? UNUserNotificationCenterDelegate {
+        let center = UNUserNotificationCenter.current()
+        center.delegate = notificationCenterDelegate
+      }
+    #endif
+
+    _ = cioAppDelegate.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+    
+  }
+    
+  public func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+    
+  }
+}
+"
+`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-expo-plugin",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-expo-plugin",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -326,17 +326,17 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.4.tgz",
-      "integrity": "sha512-jljfR1rGnXXNWnmQg2K3+bvhkxB51Rl32QRaOTuwwjviGrHzIbSc8+x9CpraDtbT7mfyjXObULP4w/adunNwAw==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
+      "integrity": "sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.22.6",
-        "@babel/helper-plugin-utils": "^7.22.5",
-        "debug": "^4.1.1",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "debug": "^4.4.1",
         "lodash.debounce": "^4.0.8",
-        "resolve": "^1.14.2"
+        "resolve": "^1.22.10"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -5269,14 +5269,14 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz",
-      "integrity": "sha512-3sX/eOms8kd3q2KZ6DAhKPc0dgm525Gqq5NtWKZ7QYYZEv57OQ54KtblzJzH1lQF/eQxO8KjWGIK9IPUJNus5g==",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
+      "integrity": "sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.22.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.4",
+        "@babel/compat-data": "^7.27.7",
+        "@babel/helper-define-polyfill-provider": "^0.6.5",
         "semver": "^6.3.1"
       },
       "peerDependencies": {
@@ -5308,13 +5308,13 @@
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.4.tgz",
-      "integrity": "sha512-7gD3pRadPrbjhjLyxebmx/WrFYcuSjZ0XbdUujQMZ/fcE9oeewk2U/7PCvez84UeuK3oSjmPZ0Ch0dlupQvGzw==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
+      "integrity": "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.4"
+        "@babel/helper-define-polyfill-provider": "^0.6.5"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -14099,9 +14099,9 @@
       }
     },
     "node_modules/react-devtools-core": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.2.tgz",
-      "integrity": "sha512-ldFwzufLletzCikNJVYaxlxMLu7swJ3T2VrGfzXlMsVhZhPDKXA38DEROidaYZVgMAmQnIjymrmqto5pyfrwPA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.3.tgz",
+      "integrity": "sha512-4be9IVco12d/4D7NpZgNjffbYIo/MAk4f5eBJR8PpKyiR7tgwe29liQbxyqDov5Ybc2crGABZyYAmdeU6NowKg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {

--- a/plugin/src/helpers/native-files/ios/apn/CioSdkAppDelegateHandler.swift
+++ b/plugin/src/helpers/native-files/ios/apn/CioSdkAppDelegateHandler.swift
@@ -7,7 +7,11 @@ import EXNotifications
 import ExpoModulesCore
 #endif
 
+class DummyAppDelegate: NSObject, UIApplicationDelegate {}
+
 public class CioSdkAppDelegateHandler: NSObject {
+
+  let cioAppDelegate = CioAppDelegateWrapper<DummyAppDelegate>()
     
   public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
 
@@ -40,13 +44,15 @@ public class CioSdkAppDelegateHandler: NSObject {
         center.delegate = notificationCenterDelegate
       }
     #endif
+
+    _ = cioAppDelegate.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 
   public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-    MessagingPush.shared.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+    cioAppDelegate.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
   }
     
   public func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-    MessagingPush.shared.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+    cioAppDelegate.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
   }
 }

--- a/plugin/src/helpers/native-files/ios/apn/CioSdkAppDelegateHandler.swift
+++ b/plugin/src/helpers/native-files/ios/apn/CioSdkAppDelegateHandler.swift
@@ -7,11 +7,11 @@ import EXNotifications
 import ExpoModulesCore
 #endif
 
-class DummyAppDelegate: NSObject, UIApplicationDelegate {}
+private class DummyAppDelegate: NSObject, UIApplicationDelegate {}
 
 public class CioSdkAppDelegateHandler: NSObject {
 
-  let cioAppDelegate = CioAppDelegateWrapper<DummyAppDelegate>()
+  private let cioAppDelegate = CioAppDelegateWrapper<DummyAppDelegate>()
     
   public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
 

--- a/plugin/src/helpers/native-files/ios/apn/CioSdkAppDelegateHandler.swift
+++ b/plugin/src/helpers/native-files/ios/apn/CioSdkAppDelegateHandler.swift
@@ -16,14 +16,6 @@ public class CioSdkAppDelegateHandler: NSObject {
   public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
 
     {{REGISTER_SNIPPET}}
-
-    MessagingPushAPN.initialize(
-      withConfig: MessagingPushConfigBuilder()
-        .autoFetchDeviceToken({{AUTO_FETCH_DEVICE_TOKEN}})
-        .showPushAppInForeground({{SHOW_PUSH_APP_IN_FOREGROUND}})
-        .autoTrackPushEvents({{AUTO_TRACK_PUSH_EVENTS}})
-        .build()
-    )
     
     // Code to make the CIO SDK compatible with expo-notifications package.
     //
@@ -46,6 +38,14 @@ public class CioSdkAppDelegateHandler: NSObject {
     #endif
 
     _ = cioAppDelegate.application(application, didFinishLaunchingWithOptions: launchOptions)
+
+    MessagingPushAPN.initialize(
+      withConfig: MessagingPushConfigBuilder()
+        .autoFetchDeviceToken({{AUTO_FETCH_DEVICE_TOKEN}})
+        .showPushAppInForeground({{SHOW_PUSH_APP_IN_FOREGROUND}})
+        .autoTrackPushEvents({{AUTO_TRACK_PUSH_EVENTS}})
+        .build()
+    )
   }
 
   public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {

--- a/plugin/src/helpers/native-files/ios/fcm/CioSdkAppDelegateHandler.swift
+++ b/plugin/src/helpers/native-files/ios/fcm/CioSdkAppDelegateHandler.swift
@@ -9,20 +9,17 @@ import EXNotifications
 import ExpoModulesCore
 #endif
 
-class DummyAppDelegate: NSObject, UIApplicationDelegate {}
+private class DummyAppDelegate: NSObject, UIApplicationDelegate, MessagingDelegate {
+  func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {}
+}
 
 public class CioSdkAppDelegateHandler: NSObject {
 
-  let cioAppDelegate = CioAppDelegateWrapper<DummyAppDelegate>()
+  private let cioAppDelegate = CioAppDelegateWrapper<DummyAppDelegate>()
     
   public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
 
     {{REGISTER_SNIPPET}}
-
-    if (FirebaseApp.app() == nil) {
-      FirebaseApp.configure()
-    }
-    UIApplication.shared.registerForRemoteNotifications()
     
     // Code to make the CIO SDK compatible with expo-notifications package.
     //
@@ -44,13 +41,17 @@ public class CioSdkAppDelegateHandler: NSObject {
       }
     #endif
 
+    if (FirebaseApp.app() == nil) {
+      FirebaseApp.configure()
+    }
     _ = cioAppDelegate.application(application, didFinishLaunchingWithOptions: launchOptions)
+    UIApplication.shared.registerForRemoteNotifications()
 
     MessagingPushFCM.initialize(
       withConfig: MessagingPushConfigBuilder()
-        .autoFetchDeviceToken({{AUTO_FETCH_DEVICE_TOKEN}})
-        .showPushAppInForeground({{SHOW_PUSH_APP_IN_FOREGROUND}})
-        .autoTrackPushEvents({{AUTO_TRACK_PUSH_EVENTS}})
+        .autoFetchDeviceToken(true)
+        .showPushAppInForeground(true)
+        .autoTrackPushEvents(true)
         .build()
     )
   }

--- a/plugin/src/helpers/native-files/ios/fcm/CioSdkAppDelegateHandler.swift
+++ b/plugin/src/helpers/native-files/ios/fcm/CioSdkAppDelegateHandler.swift
@@ -49,9 +49,9 @@ public class CioSdkAppDelegateHandler: NSObject {
 
     MessagingPushFCM.initialize(
       withConfig: MessagingPushConfigBuilder()
-        .autoFetchDeviceToken(true)
-        .showPushAppInForeground(true)
-        .autoTrackPushEvents(true)
+        .autoFetchDeviceToken({{AUTO_FETCH_DEVICE_TOKEN}})
+        .showPushAppInForeground({{SHOW_PUSH_APP_IN_FOREGROUND}})
+        .autoTrackPushEvents({{AUTO_TRACK_PUSH_EVENTS}})
         .build()
     )
   }

--- a/plugin/src/helpers/native-files/ios/fcm/CioSdkAppDelegateHandler.swift
+++ b/plugin/src/helpers/native-files/ios/fcm/CioSdkAppDelegateHandler.swift
@@ -9,7 +9,11 @@ import EXNotifications
 import ExpoModulesCore
 #endif
 
+class DummyAppDelegate: NSObject, UIApplicationDelegate {}
+
 public class CioSdkAppDelegateHandler: NSObject {
+
+  let cioAppDelegate = CioAppDelegateWrapper<DummyAppDelegate>()
     
   public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
 
@@ -18,7 +22,6 @@ public class CioSdkAppDelegateHandler: NSObject {
     if (FirebaseApp.app() == nil) {
       FirebaseApp.configure()
     }
-    Messaging.messaging().delegate = self
     UIApplication.shared.registerForRemoteNotifications()
     
     MessagingPushFCM.initialize(
@@ -48,6 +51,8 @@ public class CioSdkAppDelegateHandler: NSObject {
         center.delegate = notificationCenterDelegate
       }
     #endif
+
+    _ = cioAppDelegate.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 
   public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
@@ -56,19 +61,5 @@ public class CioSdkAppDelegateHandler: NSObject {
     
   public func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
     
-  }
-}
-
-extension CioSdkAppDelegateHandler: MessagingDelegate {
-  public func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-    MessagingPush.shared.messaging(messaging, didReceiveRegistrationToken: fcmToken)
-  }
-
-  func userNotificationCenter(
-    _ center: UNUserNotificationCenter,
-    willPresent notification: UNNotification,
-    withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
-  ) {
-    completionHandler([.list, .banner, .badge, .sound])
   }
 }

--- a/plugin/src/helpers/native-files/ios/fcm/CioSdkAppDelegateHandler.swift
+++ b/plugin/src/helpers/native-files/ios/fcm/CioSdkAppDelegateHandler.swift
@@ -24,14 +24,6 @@ public class CioSdkAppDelegateHandler: NSObject {
     }
     UIApplication.shared.registerForRemoteNotifications()
     
-    MessagingPushFCM.initialize(
-      withConfig: MessagingPushConfigBuilder()
-        .autoFetchDeviceToken({{AUTO_FETCH_DEVICE_TOKEN}})
-        .showPushAppInForeground({{SHOW_PUSH_APP_IN_FOREGROUND}})
-        .autoTrackPushEvents({{AUTO_TRACK_PUSH_EVENTS}})
-        .build()
-    )
-    
     // Code to make the CIO SDK compatible with expo-notifications package.
     //
     // The CIO SDK and expo-notifications both need to handle when a push gets clicked. However, iOS only allows one click handler to be set per app.
@@ -53,6 +45,14 @@ public class CioSdkAppDelegateHandler: NSObject {
     #endif
 
     _ = cioAppDelegate.application(application, didFinishLaunchingWithOptions: launchOptions)
+
+    MessagingPushFCM.initialize(
+      withConfig: MessagingPushConfigBuilder()
+        .autoFetchDeviceToken({{AUTO_FETCH_DEVICE_TOKEN}})
+        .showPushAppInForeground({{SHOW_PUSH_APP_IN_FOREGROUND}})
+        .autoTrackPushEvents({{AUTO_TRACK_PUSH_EVENTS}})
+        .build()
+    )
   }
 
   public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {

--- a/test-app/app.json
+++ b/test-app/app.json
@@ -22,9 +22,7 @@
       "infoPlist": {
         "CFBundleURLTypes": [
           {
-            "CFBundleURLSchemes": [
-              "expo-test-app"
-            ]
+            "CFBundleURLSchemes": ["expo-test-app"]
           }
         ]
       }
@@ -45,10 +43,7 @@
               "host": "nav-test"
             }
           ],
-          "category": [
-            "BROWSABLE",
-            "DEFAULT"
-          ]
+          "category": ["BROWSABLE", "DEFAULT"]
         }
       ]
     },
@@ -75,13 +70,12 @@
           "ios": {
             "useFrameworks": "static",
             "pushNotification": {
-              "provider": "fcm",
+              "provider": "apn",
               "useRichPush": true,
               "env": {
                 "cdpApiKey": "@CDP_API_KEY@",
                 "region": "us"
-              },
-              "googleServicesFile": "./files/GoogleService-Info.plist"
+              }
             }
           }
         }

--- a/test-app/app.json
+++ b/test-app/app.json
@@ -22,7 +22,9 @@
       "infoPlist": {
         "CFBundleURLTypes": [
           {
-            "CFBundleURLSchemes": ["expo-test-app"]
+            "CFBundleURLSchemes": [
+              "expo-test-app"
+            ]
           }
         ]
       }
@@ -43,7 +45,10 @@
               "host": "nav-test"
             }
           ],
-          "category": ["BROWSABLE", "DEFAULT"]
+          "category": [
+            "BROWSABLE",
+            "DEFAULT"
+          ]
         }
       ]
     },
@@ -70,12 +75,13 @@
           "ios": {
             "useFrameworks": "static",
             "pushNotification": {
-              "provider": "apn",
+              "provider": "fcm",
               "useRichPush": true,
               "env": {
                 "cdpApiKey": "@CDP_API_KEY@",
                 "region": "us"
-              }
+              },
+              "googleServicesFile": "./files/GoogleService-Info.plist"
             }
           }
         }

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -193,16 +193,16 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.4.tgz",
-      "integrity": "sha512-jljfR1rGnXXNWnmQg2K3+bvhkxB51Rl32QRaOTuwwjviGrHzIbSc8+x9CpraDtbT7mfyjXObULP4w/adunNwAw==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
+      "integrity": "sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.22.6",
-        "@babel/helper-plugin-utils": "^7.22.5",
-        "debug": "^4.1.1",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "debug": "^4.4.1",
         "lodash.debounce": "^4.0.8",
-        "resolve": "^1.14.2"
+        "resolve": "^1.22.10"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -2322,9 +2322,9 @@
       }
     },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.8.tgz",
+      "integrity": "sha512-3EDAPd0B8X1gsQQgGHU8vyxSp2MB414z3roN67fY7nI0GV3GDthHfaWcbCfrC95tpAzA5xUvAuoO9Dxx/ywwRQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -3121,13 +3121,13 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz",
-      "integrity": "sha512-3sX/eOms8kd3q2KZ6DAhKPc0dgm525Gqq5NtWKZ7QYYZEv57OQ54KtblzJzH1lQF/eQxO8KjWGIK9IPUJNus5g==",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
+      "integrity": "sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.22.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.4",
+        "@babel/compat-data": "^7.27.7",
+        "@babel/helper-define-polyfill-provider": "^0.6.5",
         "semver": "^6.3.1"
       },
       "peerDependencies": {
@@ -3148,12 +3148,12 @@
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.4.tgz",
-      "integrity": "sha512-7gD3pRadPrbjhjLyxebmx/WrFYcuSjZ0XbdUujQMZ/fcE9oeewk2U/7PCvez84UeuK3oSjmPZ0Ch0dlupQvGzw==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
+      "integrity": "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.4"
+        "@babel/helper-define-polyfill-provider": "^0.6.5"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -3881,9 +3881,9 @@
       }
     },
     "node_modules/customerio-expo-plugin": {
-      "version": "2.1.0",
+      "version": "2.2.0",
       "resolved": "file:../customerio-expo-plugin-latest.tgz",
-      "integrity": "sha512-8tdubS0I20FLgugMcVa2UpcZWsMD3IXVFNzKuJrQpynzp9Atu1oKgvmDsuTYarHFyZ1Ic/RhWqTGeYZasRLHcg==",
+      "integrity": "sha512-ykchYmFBdJcGZ8BFtcm18dbywLcoWV8/R6cbkTOocUACaua7d1QGqwtOB5JGVBB7EsPXar7ygXYvpxefv5QBhQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -4021,9 +4021,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.0.tgz",
-      "integrity": "sha512-Omf1L8paOy2VJhILjyhrhqwLIdstqm1BvcDPKg4NGAlkwEu9ODyrFbvk8UymUOMCT+HXo31jg1lArIrVAAhuGA==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -6622,9 +6622,9 @@
       }
     },
     "node_modules/react-devtools-core": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.2.tgz",
-      "integrity": "sha512-ldFwzufLletzCikNJVYaxlxMLu7swJ3T2VrGfzXlMsVhZhPDKXA38DEROidaYZVgMAmQnIjymrmqto5pyfrwPA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.3.tgz",
+      "integrity": "sha512-4be9IVco12d/4D7NpZgNjffbYIo/MAk4f5eBJR8PpKyiR7tgwe29liQbxyqDov5Ybc2crGABZyYAmdeU6NowKg==",
       "license": "MIT",
       "dependencies": {
         "shell-quote": "^1.6.1",


### PR DESCRIPTION
Closes: [MBL-1210](https://linear.app/customerio/issue/MBL-1210/update-wrapper-sdk-with-no-swizzling-system-expo)

## Overview

This PR migrates the iOS push notification setup from using Swizzling to the non-swizzling approach that uses `App Delegate` wrappers.

## Considered approaches

#### Wrapping Expo iOS generated `AppDelegate` ❌ 

- We've initially considered the approach where we wrap Expo's iOS native project generated `AppDelegate` with our own `CioAppDelegateWrapper`
- This approach proved to be risky for two main reasons:
  - It could easily conflict with any other plugins trying to do the same
  - [Certain parts](https://github.com/expo/expo/blob/9887dd05d691756ee9b70e9b33948da001079655/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegate.swift#L26) of the Expo framework expects the main delegate to be of their own types, which is a fair assumption
  
#### Manually forwarding calls to our wrapper ✅ 

- This approach basically still uses our `CioAppDelegateWrapper` benefiting from all the logic that exists in it
- Since the main reason we enabled customers to set our `CioAppDelegateWrapper` as main delegate is convenience and minimizing boilerplate, it's okay if we just forward calls manually to the wrapper since that code is generated anyways

### Implementation notes

**SDK initialization order**
- It's important that we call `CioAppDelegateWrapper`'s `application didFinishLaunchingWithOptions:` before we initialize the CIO push messaging modules to ensure that the non-swizzling code path is the one executed
- Check the usage of [this flag](https://github.com/customerio/customerio-ios/blob/dc6270e37f2bd34e46776d1d81c8c729b05e2626/Sources/MessagingPush/Integration/CioProviderAgnosticAppDelegate.swift#L76) for more info

**Using a dummy delegate**
- Our `CioAppDelegateWrapper` expects to wrap so a type that is `NSObject & UIApplicationDelegate` and non-null, so we have to provide something to it
- Since we decided not to the wrap the real `AppDelegate`, we created a dummy empty delegate just to satisfy the compiler

**Dummy delegate must override Firebase messaging delegate method**
- Due to how we changed the wrapper's [implementation](https://github.com/customerio/customerio-ios/blob/main/Sources/MessagingPush/Integration/CioProviderAgnosticAppDelegate.swift#L182-L200) of `respondsTo()`, methods declared in sub-classes aren't picked up
- To overcome this behavior for the time being, adding `messaging didReceiveRegistrationToken` to the dummy delegate achieves the problematic behavior

## Testing

You can use the APN/FCM apps published to firebase, most important scenarios:
- New devices added to profiles
- Able to receive push on device
- Able to click and deep link from push

I've tested all these scenarios for APN and FCM as well as with toggling flags `showPushAppInForeground` and `handleDeeplinkInKilledState` ON and OFF