### PR TITLE
feat: Add ability to configure messaging channels for local notifications

### DIFF
--- a/__tests__/android/app-manifest.test.js
+++ b/__tests__/android/app-manifest.test.js
@@ -34,3 +34,41 @@ test("Plugin injects CustomerIOFirebaseMessagingService in the app manifest", as
     expect(hasExpectedAction).toBe(true);
   });
 });
+
+test("Plugin injects notification channel metadata in the app manifest", async () => {
+  // When pushNotification.channel config is set with id, name, and importance
+  // metadata tags should be added to the app Manifest file
+  const manifestContent = await fs.readFile(appManifestPath, "utf8");
+
+  parseString(manifestContent, (err, manifest) => {
+    if (err) throw err;
+
+    const application = manifest?.manifest?.application?.[0];
+    expect(application).toBeDefined();
+
+    const metadataList = application['meta-data'] || [];
+    
+    // Check for channel ID metadata
+    const channelIdMetadata = metadataList.find(
+      metadata => metadata['$']['android:name'] === 'io.customer.notification_channel_id'
+    );
+    expect(channelIdMetadata).toBeDefined();
+    
+    // Check for channel name metadata
+    const channelNameMetadata = metadataList.find(
+      metadata => metadata['$']['android:name'] === 'io.customer.notification_channel_name'
+    );
+    expect(channelNameMetadata).toBeDefined();
+    
+    // Check for channel importance metadata
+    const channelImportanceMetadata = metadataList.find(
+      metadata => metadata['$']['android:name'] === 'io.customer.notification_channel_importance'
+    );
+    expect(channelImportanceMetadata).toBeDefined();
+    
+    // Verify the values match what's configured in the test app (app.json)
+    expect(channelIdMetadata['$']['android:value']).toBe('cio-expo-id');
+    expect(channelNameMetadata['$']['android:value']).toBe('CIO Test');
+    expect(channelImportanceMetadata['$']['android:value']).toBe('4');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -5273,155 +5273,15 @@
       }
     },
     "node_modules/babel-plugin-react-compiler": {
-      "version": "0.0.0-experimental-592953e-20240517",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-0.0.0-experimental-592953e-20240517.tgz",
-      "integrity": "sha512-OjG1SVaeQZaJrqkMFJatg8W/MTow8Ak5rx2SI0ETQBO1XvOk/XZGMbltNCPdFJLKghBYoBjC+Y3Ap/Xr7B01mA==",
+      "version": "19.0.0-beta-ebf51a3-20250411",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-19.0.0-beta-ebf51a3-20250411.tgz",
+      "integrity": "sha512-q84bNR9JG1crykAlJUt5Ud0/5BUyMFuQww/mrwIQDFBaxsikqBDj3f/FNDsVd2iR26A1HvXKWPEIfgJDv8/V2g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
-        "@babel/generator": "7.2.0",
-        "@babel/types": "^7.19.0",
-        "chalk": "4",
-        "invariant": "^2.2.4",
-        "pretty-format": "^24",
-        "zod": "^3.22.4",
-        "zod-validation-error": "^2.1.0"
-      }
-    },
-    "node_modules/babel-plugin-react-compiler/node_modules/@babel/generator": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.2.0.tgz",
-      "integrity": "sha512-BA75MVfRlFQG2EZgFYIwyT1r6xSkwfP2bdkY/kLZusEYWiJs4xCowab/alaEaT0wSvmVuXGqiefeBlP+7V1yKg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.2.0",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.10",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
-      }
-    },
-    "node_modules/babel-plugin-react-compiler/node_modules/@jest/types": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^1.1.1",
-        "@types/yargs": "^13.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/babel-plugin-react-compiler/node_modules/@types/istanbul-reports": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*",
-        "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/babel-plugin-react-compiler/node_modules/@types/yargs": {
-      "version": "13.0.12",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
-      "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/babel-plugin-react-compiler/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/babel-plugin-react-compiler/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/babel-plugin-react-compiler/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/babel-plugin-react-compiler/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-plugin-react-compiler/node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/babel-plugin-react-compiler/node_modules/pretty-format": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^24.9.0",
-        "ansi-regex": "^4.0.0",
-        "ansi-styles": "^3.2.0",
-        "react-is": "^16.8.4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/babel-plugin-react-compiler/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-plugin-react-compiler/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
+        "@babel/types": "^7.26.0"
       }
     },
     "node_modules/babel-plugin-react-native-web": {
@@ -7809,6 +7669,20 @@
         "expo-module": "bin/expo-module.js"
       }
     },
+    "node_modules/expo-module-scripts/node_modules/@babel/generator": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.2.0.tgz",
+      "integrity": "sha512-BA75MVfRlFQG2EZgFYIwyT1r6xSkwfP2bdkY/kLZusEYWiJs4xCowab/alaEaT0wSvmVuXGqiefeBlP+7V1yKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.2.0",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.10",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      }
+    },
     "node_modules/expo-module-scripts/node_modules/@react-native/babel-plugin-codegen": {
       "version": "0.74.87",
       "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.74.87.tgz",
@@ -7900,6 +7774,27 @@
       },
       "peerDependencies": {
         "@babel/preset-env": "^7.1.6"
+      }
+    },
+    "node_modules/expo-module-scripts/node_modules/@types/istanbul-reports": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/expo-module-scripts/node_modules/@types/yargs": {
+      "version": "13.0.12",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+      "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
       }
     },
     "node_modules/expo-module-scripts/node_modules/@typescript-eslint/eslint-plugin": {
@@ -8116,6 +8011,45 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/expo-module-scripts/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expo-module-scripts/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/expo-module-scripts/node_modules/babel-plugin-react-compiler": {
+      "version": "0.0.0-experimental-592953e-20240517",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-0.0.0-experimental-592953e-20240517.tgz",
+      "integrity": "sha512-OjG1SVaeQZaJrqkMFJatg8W/MTow8Ak5rx2SI0ETQBO1XvOk/XZGMbltNCPdFJLKghBYoBjC+Y3Ap/Xr7B01mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/generator": "7.2.0",
+        "@babel/types": "^7.19.0",
+        "chalk": "4",
+        "invariant": "^2.2.4",
+        "pretty-format": "^24",
+        "zod": "^3.22.4",
+        "zod-validation-error": "^2.1.0"
+      }
+    },
     "node_modules/expo-module-scripts/node_modules/babel-preset-expo": {
       "version": "11.0.15",
       "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-11.0.15.tgz",
@@ -8144,6 +8078,23 @@
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
+    },
+    "node_modules/expo-module-scripts/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/expo-module-scripts/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/expo-module-scripts/node_modules/doctrine": {
       "version": "2.1.0",
@@ -8410,6 +8361,19 @@
         "hermes-estree": "0.19.1"
       }
     },
+    "node_modules/expo-module-scripts/node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/expo-module-scripts/node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -8438,6 +8402,54 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/expo-module-scripts/node_modules/pretty-format": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^24.9.0",
+        "ansi-regex": "^4.0.0",
+        "ansi-styles": "^3.2.0",
+        "react-is": "^16.8.4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/expo-module-scripts/node_modules/pretty-format/node_modules/@jest/types": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^13.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/expo-module-scripts/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/expo-module-scripts/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/expo-module-scripts/node_modules/ts-jest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-expo-plugin",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-expo-plugin",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2021,9 +2021,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.0.tgz",
-      "integrity": "sha512-LOAozRVbqxEVjSKfhGnuLoE4Kz4Oc5UJzuvFUhSsQzdCdaAQu06mG8zDv2GFSerM62nImUZ7K92vxnQcLSDlCQ==",
+      "version": "7.28.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.1.tgz",
+      "integrity": "sha512-P0QiV/taaa3kXpLY+sXla5zec4E+4t4Aqc9ggHlfZ7a2cp8/x/Gv08jfwEtn9gnnYIMvHx6aoOZ8XJL8eU71Dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2562,9 +2562,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.0.tgz",
-      "integrity": "sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==",
+      "version": "7.28.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
+      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -4327,9 +4327,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.12.tgz",
-      "integrity": "sha512-LtOrbvDf5ndC9Xi+4QZjVL0woFymF/xSTKZKPgrrl7H7XoeDvnD+E2IclKVDyaK9UM756W/3BXqSU+JEHopA9g==",
+      "version": "24.0.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
+      "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
@@ -5273,15 +5273,155 @@
       }
     },
     "node_modules/babel-plugin-react-compiler": {
-      "version": "19.0.0-beta-ebf51a3-20250411",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-19.0.0-beta-ebf51a3-20250411.tgz",
-      "integrity": "sha512-q84bNR9JG1crykAlJUt5Ud0/5BUyMFuQww/mrwIQDFBaxsikqBDj3f/FNDsVd2iR26A1HvXKWPEIfgJDv8/V2g==",
+      "version": "0.0.0-experimental-592953e-20240517",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-0.0.0-experimental-592953e-20240517.tgz",
+      "integrity": "sha512-OjG1SVaeQZaJrqkMFJatg8W/MTow8Ak5rx2SI0ETQBO1XvOk/XZGMbltNCPdFJLKghBYoBjC+Y3Ap/Xr7B01mA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@babel/types": "^7.26.0"
+        "@babel/generator": "7.2.0",
+        "@babel/types": "^7.19.0",
+        "chalk": "4",
+        "invariant": "^2.2.4",
+        "pretty-format": "^24",
+        "zod": "^3.22.4",
+        "zod-validation-error": "^2.1.0"
+      }
+    },
+    "node_modules/babel-plugin-react-compiler/node_modules/@babel/generator": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.2.0.tgz",
+      "integrity": "sha512-BA75MVfRlFQG2EZgFYIwyT1r6xSkwfP2bdkY/kLZusEYWiJs4xCowab/alaEaT0wSvmVuXGqiefeBlP+7V1yKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.2.0",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.10",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "node_modules/babel-plugin-react-compiler/node_modules/@jest/types": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^13.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/babel-plugin-react-compiler/node_modules/@types/istanbul-reports": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/babel-plugin-react-compiler/node_modules/@types/yargs": {
+      "version": "13.0.12",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+      "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/babel-plugin-react-compiler/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-react-compiler/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/babel-plugin-react-compiler/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/babel-plugin-react-compiler/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/babel-plugin-react-compiler/node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/babel-plugin-react-compiler/node_modules/pretty-format": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^24.9.0",
+        "ansi-regex": "^4.0.0",
+        "ansi-styles": "^3.2.0",
+        "react-is": "^16.8.4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/babel-plugin-react-compiler/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/babel-plugin-react-compiler/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/babel-plugin-react-native-web": {
@@ -6737,9 +6877,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.180",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.180.tgz",
-      "integrity": "sha512-ED+GEyEh3kYMwt2faNmgMB0b8O5qtATGgR4RmRsIp4T6p7B8vdMbIedYndnvZfsaXvSzegtpfqRMDNCjjiSduA==",
+      "version": "1.5.185",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.185.tgz",
+      "integrity": "sha512-dYOZfUk57hSMPePoIQ1fZWl1Fkj+OshhEVuPacNKWzC1efe56OsHY3l/jCfiAgIICOU3VgOIdoq7ahg7r7n6MQ==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -7669,20 +7809,6 @@
         "expo-module": "bin/expo-module.js"
       }
     },
-    "node_modules/expo-module-scripts/node_modules/@babel/generator": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.2.0.tgz",
-      "integrity": "sha512-BA75MVfRlFQG2EZgFYIwyT1r6xSkwfP2bdkY/kLZusEYWiJs4xCowab/alaEaT0wSvmVuXGqiefeBlP+7V1yKg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.2.0",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.10",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
-      }
-    },
     "node_modules/expo-module-scripts/node_modules/@react-native/babel-plugin-codegen": {
       "version": "0.74.87",
       "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.74.87.tgz",
@@ -7774,27 +7900,6 @@
       },
       "peerDependencies": {
         "@babel/preset-env": "^7.1.6"
-      }
-    },
-    "node_modules/expo-module-scripts/node_modules/@types/istanbul-reports": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*",
-        "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/expo-module-scripts/node_modules/@types/yargs": {
-      "version": "13.0.12",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
-      "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
       }
     },
     "node_modules/expo-module-scripts/node_modules/@typescript-eslint/eslint-plugin": {
@@ -8011,45 +8116,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/expo-module-scripts/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/expo-module-scripts/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/expo-module-scripts/node_modules/babel-plugin-react-compiler": {
-      "version": "0.0.0-experimental-592953e-20240517",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-0.0.0-experimental-592953e-20240517.tgz",
-      "integrity": "sha512-OjG1SVaeQZaJrqkMFJatg8W/MTow8Ak5rx2SI0ETQBO1XvOk/XZGMbltNCPdFJLKghBYoBjC+Y3Ap/Xr7B01mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/generator": "7.2.0",
-        "@babel/types": "^7.19.0",
-        "chalk": "4",
-        "invariant": "^2.2.4",
-        "pretty-format": "^24",
-        "zod": "^3.22.4",
-        "zod-validation-error": "^2.1.0"
-      }
-    },
     "node_modules/expo-module-scripts/node_modules/babel-preset-expo": {
       "version": "11.0.15",
       "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-11.0.15.tgz",
@@ -8078,23 +8144,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
-    },
-    "node_modules/expo-module-scripts/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/expo-module-scripts/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/expo-module-scripts/node_modules/doctrine": {
       "version": "2.1.0",
@@ -8361,19 +8410,6 @@
         "hermes-estree": "0.19.1"
       }
     },
-    "node_modules/expo-module-scripts/node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/expo-module-scripts/node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -8402,54 +8438,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/expo-module-scripts/node_modules/pretty-format": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^24.9.0",
-        "ansi-regex": "^4.0.0",
-        "ansi-styles": "^3.2.0",
-        "react-is": "^16.8.4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/expo-module-scripts/node_modules/pretty-format/node_modules/@jest/types": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^1.1.1",
-        "@types/yargs": "^13.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/expo-module-scripts/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/expo-module-scripts/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/expo-module-scripts/node_modules/ts-jest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "xcode": "^3.0.1"
       },
       "peerDependencies": {
-        "customerio-reactnative": "4.4.3"
+        "customerio-reactnative": "4.5.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -6321,9 +6321,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-4.4.3.tgz",
-      "integrity": "sha512-eoU91+2/SMNId0kQiyvLDuN5saYqkLMJCiLZIEiqJ71QOyQE5AYCv5vPJa4kxEvSNwNq64jytctfhT2uwggqvg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-4.5.0.tgz",
+      "integrity": "sha512-gGHzuUipZid0zZ97fc1mEy7GoCWSu7q+3LSi7lcMAs5SnkjM2l9bFr97uRxFWvfYFGCZBE8mO3xjizmHmiwBBw==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -6737,9 +6737,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.185",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.185.tgz",
-      "integrity": "sha512-dYOZfUk57hSMPePoIQ1fZWl1Fkj+OshhEVuPacNKWzC1efe56OsHY3l/jCfiAgIICOU3VgOIdoq7ahg7r7n6MQ==",
+      "version": "1.5.186",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.186.tgz",
+      "integrity": "sha512-lur7L4BFklgepaJxj4DqPk7vKbTEl0pajNlg2QjE5shefmlmBLm2HvQ7PMf1R/GvlevT/581cop33/quQcfX3A==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -8940,9 +8940,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "customerio-reactnative": "4.4.3"
+    "customerio-reactnative": "4.5.0"
   },
   "devDependencies": {
     "@expo/config-plugins": "^10.0.0",

--- a/plugin/src/android/withCIOAndroid.ts
+++ b/plugin/src/android/withCIOAndroid.ts
@@ -5,6 +5,7 @@ import { withAndroidManifestUpdates } from './withAndroidManifestUpdates';
 import { withAppGoogleServices } from './withAppGoogleServices';
 import { withGistMavenRepository } from './withGistMavenRepository';
 import { withGoogleServicesJSON } from './withGoogleServicesJSON';
+import { withNotificationChannelMetadata } from './withNotificationChannelMetadata';
 import { withProjectGoogleServices } from './withProjectGoogleServices';
 import { withProjectStrings } from './withProjectStrings';
 
@@ -19,6 +20,9 @@ export function withCIOAndroid(
   config = withProjectStrings(config);
   if (props.setHighPriorityPushHandler) {
     config = withAndroidManifestUpdates(config, props);
+  }
+  if (props.pushNotification?.channel) {
+    config = withNotificationChannelMetadata(config, props);
   }
 
   return config;

--- a/plugin/src/android/withNotificationChannelMetadata.ts
+++ b/plugin/src/android/withNotificationChannelMetadata.ts
@@ -1,0 +1,76 @@
+import type { ConfigPlugin } from '@expo/config-plugins';
+import { withAndroidManifest } from '@expo/config-plugins';
+import type { ManifestApplication } from '@expo/config-plugins/build/android/Manifest';
+
+import type { CustomerIOPluginOptionsAndroid } from '../types/cio-types';
+
+export const withNotificationChannelMetadata: ConfigPlugin<
+  CustomerIOPluginOptionsAndroid
+> = (config, props) => {
+  return withAndroidManifest(config, (manifestProps) => {
+    const application = manifestProps.modResults.manifest.application as ManifestApplication[];
+    const channel = props.pushNotification?.channel;
+
+    // Only proceed if channel configuration exists
+    if (channel && (channel.id || channel.name || channel.importance !== undefined)) {
+      // Initialize meta-data array if it doesn't exist
+      if (!application[0]['meta-data']) {
+        application[0]['meta-data'] = [];
+      }
+
+      // Add channel ID metadata if provided
+      if (channel.id) {
+        const hasChannelIdMetadata = application[0]['meta-data'].some(
+          (metadata) => metadata['$']['android:name'] === 'io.customer.notification_channel_id'
+        );
+
+        if (!hasChannelIdMetadata) {
+          application[0]['meta-data'].push({
+            '$': {
+              'android:name': 'io.customer.notification_channel_id',
+              'android:value': channel.id,
+            },
+          });
+          console.log('Successfully added notification channel ID metadata to AndroidManifest.xml');
+        }
+      }
+
+      // Add channel name metadata if provided
+      if (channel.name) {
+        const hasChannelNameMetadata = application[0]['meta-data'].some(
+          (metadata) => metadata['$']['android:name'] === 'io.customer.notification_channel_name'
+        );
+
+        if (!hasChannelNameMetadata) {
+          application[0]['meta-data'].push({
+            '$': {
+              'android:name': 'io.customer.notification_channel_name',
+              'android:value': channel.name,
+            },
+          });
+          console.log('Successfully added notification channel name metadata to AndroidManifest.xml');
+        }
+      }
+
+      // Add channel importance metadata if provided
+      if (channel.importance !== undefined) {
+        const hasChannelImportanceMetadata = application[0]['meta-data'].some(
+          (metadata) => metadata['$']['android:name'] === 'io.customer.notification_channel_importance'
+        );
+
+        if (!hasChannelImportanceMetadata) {
+          application[0]['meta-data'].push({
+            '$': {
+              'android:name': 'io.customer.notification_channel_importance',
+              'android:value': String(channel.importance),
+            },
+          });
+          console.log('Successfully added notification channel importance metadata to AndroidManifest.xml');
+        }
+      }
+    }
+
+    manifestProps.modResults.manifest.application = application;
+    return manifestProps;
+  });
+};

--- a/plugin/src/android/withNotificationChannelMetadata.ts
+++ b/plugin/src/android/withNotificationChannelMetadata.ts
@@ -13,12 +13,10 @@ export const withNotificationChannelMetadata: ConfigPlugin<
 
     // Only proceed if channel configuration exists
     if (channel && (channel.id || channel.name || channel.importance !== undefined)) {
-      // Initialize meta-data array if it doesn't exist
       if (!application[0]['meta-data']) {
         application[0]['meta-data'] = [];
       }
 
-      // Add channel ID metadata if provided
       if (channel.id) {
         const hasChannelIdMetadata = application[0]['meta-data'].some(
           (metadata) => metadata['$']['android:name'] === 'io.customer.notification_channel_id'
@@ -31,11 +29,9 @@ export const withNotificationChannelMetadata: ConfigPlugin<
               'android:value': channel.id,
             },
           });
-          console.log('Successfully added notification channel ID metadata to AndroidManifest.xml');
         }
       }
 
-      // Add channel name metadata if provided
       if (channel.name) {
         const hasChannelNameMetadata = application[0]['meta-data'].some(
           (metadata) => metadata['$']['android:name'] === 'io.customer.notification_channel_name'
@@ -48,11 +44,9 @@ export const withNotificationChannelMetadata: ConfigPlugin<
               'android:value': channel.name,
             },
           });
-          console.log('Successfully added notification channel name metadata to AndroidManifest.xml');
         }
       }
 
-      // Add channel importance metadata if provided
       if (channel.importance !== undefined) {
         const hasChannelImportanceMetadata = application[0]['meta-data'].some(
           (metadata) => metadata['$']['android:name'] === 'io.customer.notification_channel_importance'
@@ -65,7 +59,6 @@ export const withNotificationChannelMetadata: ConfigPlugin<
               'android:value': String(channel.importance),
             },
           });
-          console.log('Successfully added notification channel importance metadata to AndroidManifest.xml');
         }
       }
     }

--- a/plugin/src/android/withNotificationChannelMetadata.ts
+++ b/plugin/src/android/withNotificationChannelMetadata.ts
@@ -4,6 +4,35 @@ import type { ManifestApplication } from '@expo/config-plugins/build/android/Man
 
 import type { CustomerIOPluginOptionsAndroid } from '../types/cio-types';
 
+/**
+ * Adds a metadata entry to the Android manifest if it doesn't already exist
+ */
+const addMetadataIfNotExists = (
+  application: ManifestApplication,
+  name: string,
+  value: string
+): void => {
+  // Initialize meta-data array if it doesn't exist
+  if (!application['meta-data']) {
+    application['meta-data'] = [];
+  }
+
+  // Check if metadata already exists
+  const hasMetadata = application['meta-data'].some(
+    (metadata) => metadata['$']['android:name'] === name
+  );
+
+  // Add metadata if it doesn't exist
+  if (!hasMetadata) {
+    application['meta-data'].push({
+      $: {
+        'android:name': name,
+        'android:value': value,
+      },
+    });
+  }
+};
+
 export const withNotificationChannelMetadata: ConfigPlugin<
   CustomerIOPluginOptionsAndroid
 > = (config, props) => {
@@ -13,53 +42,28 @@ export const withNotificationChannelMetadata: ConfigPlugin<
 
     // Only proceed if channel configuration exists
     if (channel && (channel.id || channel.name || channel.importance !== undefined)) {
-      if (!application[0]['meta-data']) {
-        application[0]['meta-data'] = [];
-      }
-
       if (channel.id) {
-        const hasChannelIdMetadata = application[0]['meta-data'].some(
-          (metadata) => metadata['$']['android:name'] === 'io.customer.notification_channel_id'
+        addMetadataIfNotExists(
+          application[0],
+          'io.customer.notification_channel_id',
+          channel.id
         );
-
-        if (!hasChannelIdMetadata) {
-          application[0]['meta-data'].push({
-            '$': {
-              'android:name': 'io.customer.notification_channel_id',
-              'android:value': channel.id,
-            },
-          });
-        }
       }
 
       if (channel.name) {
-        const hasChannelNameMetadata = application[0]['meta-data'].some(
-          (metadata) => metadata['$']['android:name'] === 'io.customer.notification_channel_name'
+        addMetadataIfNotExists(
+          application[0],
+          'io.customer.notification_channel_name',
+          channel.name
         );
-
-        if (!hasChannelNameMetadata) {
-          application[0]['meta-data'].push({
-            '$': {
-              'android:name': 'io.customer.notification_channel_name',
-              'android:value': channel.name,
-            },
-          });
-        }
       }
 
       if (channel.importance !== undefined) {
-        const hasChannelImportanceMetadata = application[0]['meta-data'].some(
-          (metadata) => metadata['$']['android:name'] === 'io.customer.notification_channel_importance'
+        addMetadataIfNotExists(
+          application[0],
+          'io.customer.notification_channel_importance',
+          String(channel.importance)
         );
-
-        if (!hasChannelImportanceMetadata) {
-          application[0]['meta-data'].push({
-            '$': {
-              'android:name': 'io.customer.notification_channel_importance',
-              'android:value': String(channel.importance),
-            },
-          });
-        }
       }
     }
 

--- a/plugin/src/types/cio-types.ts
+++ b/plugin/src/types/cio-types.ts
@@ -55,6 +55,13 @@ export type CustomerIOPluginOptionsAndroid = {
   androidPath: string;
   googleServicesFile?: string;
   setHighPriorityPushHandler?: boolean;
+  pushNotification?: {
+    channel?: {
+      id?: string;
+      name?: string;
+      importance?: number;
+    };
+  };
 };
 
 export type CustomerIOPluginOptions = {

--- a/scripts/compatibility/configure-plugin.js
+++ b/scripts/compatibility/configure-plugin.js
@@ -100,6 +100,13 @@ function execute() {
       android: {
         googleServicesFile: ANDROID_GOOGLE_SERVICES_FILE_PATH,
         setHighPriorityPushHandler: true,
+        pushNotification: {
+          channel: {
+            id: "cio-expo-id",
+            name: "CIO Test",
+            importance: 4
+          }
+        }
       },
       ios: {
         pushNotification: {

--- a/test-app/app.json
+++ b/test-app/app.json
@@ -65,7 +65,14 @@
         {
           "android": {
             "googleServicesFile": "./files/google-services.json",
-            "setHighPriorityPushHandler": true
+            "setHighPriorityPushHandler": true,
+            "pushNotification": {
+              "channel": {
+                "id": "cio-expo-id",
+                "name": "CIO Test",
+                "importance": 4
+              }
+            }
           },
           "ios": {
             "useFrameworks": "static",

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -3892,7 +3892,7 @@
     "node_modules/customerio-expo-plugin": {
       "version": "2.3.1",
       "resolved": "file:../customerio-expo-plugin-latest.tgz",
-      "integrity": "sha512-W5NVnKh4bC5Dc76jY9IKbUqEruBl/E28lSTbauTOhYA5SEmuW3DsgJzUUCfV3RdHtwea7YCcm1Ouq2terJ2Gzg==",
+      "integrity": "sha512-2TTnnEtnOuO7Bb+gLVZW04dV2sI4bkIlwNZAGfEwbk11FnFVHoEngyeEOAaZ9oRwtifbAg/8QzooCx7GOe8/DA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -13,7 +13,7 @@
         "@react-navigation/native": "^7.1.6",
         "@react-navigation/stack": "^7.2.8",
         "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-        "customerio-reactnative": "^4.4.1",
+        "customerio-reactnative": "customerio/customerio-reactnative#MBL-730-enable-config-channels",
         "dotenv": "^16.4.7",
         "expo": "~53.0.9",
         "expo-build-properties": "~0.14.6",
@@ -1276,9 +1276,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.0.tgz",
-      "integrity": "sha512-LOAozRVbqxEVjSKfhGnuLoE4Kz4Oc5UJzuvFUhSsQzdCdaAQu06mG8zDv2GFSerM62nImUZ7K92vxnQcLSDlCQ==",
+      "version": "7.28.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.1.tgz",
+      "integrity": "sha512-P0QiV/taaa3kXpLY+sXla5zec4E+4t4Aqc9ggHlfZ7a2cp8/x/Gv08jfwEtn9gnnYIMvHx6aoOZ8XJL8eU71Dg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1506,9 +1506,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.0.tgz",
-      "integrity": "sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==",
+      "version": "7.28.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
+      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -2842,9 +2842,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.12.tgz",
-      "integrity": "sha512-LtOrbvDf5ndC9Xi+4QZjVL0woFymF/xSTKZKPgrrl7H7XoeDvnD+E2IclKVDyaK9UM756W/3BXqSU+JEHopA9g==",
+      "version": "24.0.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
+      "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
@@ -3890,9 +3890,9 @@
       }
     },
     "node_modules/customerio-expo-plugin": {
-      "version": "2.3.0",
+      "version": "2.3.1",
       "resolved": "file:../customerio-expo-plugin-latest.tgz",
-      "integrity": "sha512-iyzpC6bUcWb12X4wsPHHSrPK6SXpls+Sw19XYGid0ZuOwBjnj38T7+R/DZePNeklhFh+Vs6aD6T4VVSwfiCdmg==",
+      "integrity": "sha512-W5NVnKh4bC5Dc76jY9IKbUqEruBl/E28lSTbauTOhYA5SEmuW3DsgJzUUCfV3RdHtwea7YCcm1Ouq2terJ2Gzg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3918,8 +3918,7 @@
     },
     "node_modules/customerio-reactnative": {
       "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-4.4.3.tgz",
-      "integrity": "sha512-eoU91+2/SMNId0kQiyvLDuN5saYqkLMJCiLZIEiqJ71QOyQE5AYCv5vPJa4kxEvSNwNq64jytctfhT2uwggqvg==",
+      "resolved": "git+ssh://git@github.com/customerio/customerio-reactnative.git#ad9ea233a5a7e61fcc3d92072e9d511bf685145a",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {
@@ -4066,9 +4065,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.180",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.180.tgz",
-      "integrity": "sha512-ED+GEyEh3kYMwt2faNmgMB0b8O5qtATGgR4RmRsIp4T6p7B8vdMbIedYndnvZfsaXvSzegtpfqRMDNCjjiSduA==",
+      "version": "1.5.185",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.185.tgz",
+      "integrity": "sha512-dYOZfUk57hSMPePoIQ1fZWl1Fkj+OshhEVuPacNKWzC1efe56OsHY3l/jCfiAgIICOU3VgOIdoq7ahg7r7n6MQ==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -13,7 +13,7 @@
         "@react-navigation/native": "^7.1.6",
         "@react-navigation/stack": "^7.2.8",
         "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-        "customerio-reactnative": "customerio/customerio-reactnative#MBL-730-enable-config-channels",
+        "customerio-reactnative": "^4.5.0",
         "dotenv": "^16.4.7",
         "expo": "~53.0.9",
         "expo-build-properties": "~0.14.6",
@@ -3892,7 +3892,7 @@
     "node_modules/customerio-expo-plugin": {
       "version": "2.3.1",
       "resolved": "file:../customerio-expo-plugin-latest.tgz",
-      "integrity": "sha512-2TTnnEtnOuO7Bb+gLVZW04dV2sI4bkIlwNZAGfEwbk11FnFVHoEngyeEOAaZ9oRwtifbAg/8QzooCx7GOe8/DA==",
+      "integrity": "sha512-EiLiPXM0eEWLxD/e2/W0W91siaHdjuwTKkvi1Hy9OoLj7iBpIkEtxXfWKSIeL1hWcVXpH+EDI8eaf96NkVD7kQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3901,7 +3901,7 @@
         "semver": "^7.7.2"
       },
       "peerDependencies": {
-        "customerio-reactnative": "4.4.3"
+        "customerio-reactnative": "4.5.0"
       }
     },
     "node_modules/customerio-expo-plugin/node_modules/semver": {
@@ -3917,8 +3917,9 @@
       }
     },
     "node_modules/customerio-reactnative": {
-      "version": "4.4.3",
-      "resolved": "git+ssh://git@github.com/customerio/customerio-reactnative.git#ad9ea233a5a7e61fcc3d92072e9d511bf685145a",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-4.5.0.tgz",
+      "integrity": "sha512-gGHzuUipZid0zZ97fc1mEy7GoCWSu7q+3LSi7lcMAs5SnkjM2l9bFr97uRxFWvfYFGCZBE8mO3xjizmHmiwBBw==",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {
@@ -4065,9 +4066,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.185",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.185.tgz",
-      "integrity": "sha512-dYOZfUk57hSMPePoIQ1fZWl1Fkj+OshhEVuPacNKWzC1efe56OsHY3l/jCfiAgIICOU3VgOIdoq7ahg7r7n6MQ==",
+      "version": "1.5.186",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.186.tgz",
+      "integrity": "sha512-lur7L4BFklgepaJxj4DqPk7vKbTEl0pajNlg2QjE5shefmlmBLm2HvQ7PMf1R/GvlevT/581cop33/quQcfX3A==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -14,7 +14,7 @@
     "@react-navigation/native": "^7.1.6",
     "@react-navigation/stack": "^7.2.8",
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "customerio/customerio-reactnative#MBL-730-enable-config-channels",
+    "customerio-reactnative": "^4.5.0",
     "dotenv": "^16.4.7",
     "expo": "~53.0.9",
     "expo-build-properties": "~0.14.6",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -14,7 +14,7 @@
     "@react-navigation/native": "^7.1.6",
     "@react-navigation/stack": "^7.2.8",
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^4.4.1",
+    "customerio-reactnative": "customerio/customerio-reactnative#MBL-730-enable-config-channels",
     "dotenv": "^16.4.7",
     "expo": "~53.0.9",
     "expo-build-properties": "~0.14.6",


### PR DESCRIPTION
Closes: [MBL-732](https://linear.app/customerio/issue/MBL-732/expo-enable-setting-android-message-channel-name)

## Overview

This PR adds configuration for the Customer IO Expo config plugin to allow customers to configure and customize Android push notification messaging channels.

The PR creates a config object under `android` -> `pushNotification`-> `channel` object with optional 3 flags:
- `id`: Custom notification channel ID
- `name`: Custom notification channel name
- `importance`: Custom notification channel importance

I've created a dedicated `pushNotification` object to align with iOS and grouped values under `channel` to explicitly state that all these fields are related

## Testing

- Added unit test to ensure meta-data is added correctly to native Android project manifest
- Tested that channel is created correctly when sending a push to the Android app

<img width="322" height="710" alt="Screenshot 2025-07-16 at 8 05 53 PM" src="https://github.com/user-attachments/assets/56665c01-bffa-4a03-8aad-f83790b49b60" />
