### PR TITLE
chore: add auto init config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,3 +62,18 @@ jobs:
 
       - name: Run plugin tests
         run: npm run setup-test-app && npm test -- __tests__/ios/common __tests__/ios/${{ matrix.push_provider }}
+
+  test-utils:
+    name: Test utility functions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run utils tests
+        run: npm test -- __tests__/utils

--- a/__tests__/utils/config.test.ts
+++ b/__tests__/utils/config.test.ts
@@ -1,0 +1,197 @@
+import type { CustomerIOPluginOptionsIOS, NativeSDKConfig } from '../../plugin/src/types/cio-types';
+import { mergeConfigWithEnvValues } from '../../plugin/src/utils/config';
+
+describe('mergeConfigWithEnvValues', () => {
+  const mockIosProps: CustomerIOPluginOptionsIOS = {
+    iosPath: 'ios',
+  };
+
+  const mockNativeConfig: NativeSDKConfig = {
+    cdpApiKey: 'config-api-key',
+    region: 'EU',
+  };
+
+  const mockEnvConfig = {
+    cdpApiKey: 'env-api-key',
+    region: 'US',
+  };
+
+  describe('priority handling', () => {
+    test('should prioritize env config over native config', () => {
+      const props: CustomerIOPluginOptionsIOS = {
+        ...mockIosProps,
+        pushNotification: {
+          env: mockEnvConfig,
+        },
+      };
+
+      const result = mergeConfigWithEnvValues(props, mockNativeConfig);
+
+      expect(result).toEqual({
+        cdpApiKey: 'env-api-key',
+        region: 'US',
+      });
+    });
+
+    test('should use env config when native config is not provided', () => {
+      const props: CustomerIOPluginOptionsIOS = {
+        ...mockIosProps,
+        pushNotification: {
+          env: mockEnvConfig,
+        },
+      };
+
+      const result = mergeConfigWithEnvValues(props);
+
+      expect(result).toEqual({
+        cdpApiKey: 'env-api-key',
+        region: 'US',
+      });
+    });
+
+    test('should use native config when env config is not provided', () => {
+      const result = mergeConfigWithEnvValues(mockIosProps, mockNativeConfig);
+
+      expect(result).toEqual({
+        cdpApiKey: 'config-api-key',
+        region: 'EU',
+      });
+    });
+
+  });
+
+  describe('native config scenarios', () => {
+
+    test('should return native config with undefined region when only cdpApiKey is provided', () => {
+      const configWithoutRegion: NativeSDKConfig = {
+        cdpApiKey: 'config-api-key',
+      };
+
+      const result = mergeConfigWithEnvValues(mockIosProps, configWithoutRegion);
+
+      expect(result).toEqual({
+        cdpApiKey: 'config-api-key',
+        region: undefined,
+      });
+    });
+
+    test('should return undefined when native config has no cdpApiKey', () => {
+      const configWithoutApiKey = {
+        region: 'EU',
+        autoTrackDeviceAttributes: true,
+      } as any;
+
+      const result = mergeConfigWithEnvValues(mockIosProps, configWithoutApiKey);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('env config scenarios', () => {
+
+    test('should return env config with undefined region when only cdpApiKey is provided', () => {
+      const envConfigWithoutRegion = {
+        cdpApiKey: 'env-api-key',
+      };
+
+      const props: CustomerIOPluginOptionsIOS = {
+        ...mockIosProps,
+        pushNotification: {
+          env: envConfigWithoutRegion,
+        },
+      };
+
+      const result = mergeConfigWithEnvValues(props);
+
+      expect(result).toEqual({
+        cdpApiKey: 'env-api-key',
+        region: undefined,
+      });
+    });
+
+    test('should return undefined when env config has no cdpApiKey', () => {
+      const envConfigWithoutApiKey = {
+        region: 'US',
+      } as any;
+
+      const props: CustomerIOPluginOptionsIOS = {
+        ...mockIosProps,
+        pushNotification: {
+          env: envConfigWithoutApiKey,
+        },
+      };
+
+      const result = mergeConfigWithEnvValues(props);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('no config scenarios', () => {
+    test('should return undefined when no native config and no pushNotification', () => {
+      const result = mergeConfigWithEnvValues(mockIosProps);
+
+      expect(result).toBeUndefined();
+    });
+
+    test('should return undefined when no native config and no env config', () => {
+      const props: CustomerIOPluginOptionsIOS = {
+        ...mockIosProps,
+        pushNotification: {},
+      };
+
+      const result = mergeConfigWithEnvValues(props);
+
+      expect(result).toBeUndefined();
+    });
+
+    test('should return undefined when both configs are empty', () => {
+      const emptyNativeConfig = {} as any;
+      const props: CustomerIOPluginOptionsIOS = {
+        ...mockIosProps,
+        pushNotification: {
+          env: {} as any,
+        },
+      };
+
+      const result = mergeConfigWithEnvValues(props, emptyNativeConfig);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('edge cases', () => {
+    test('should handle undefined pushNotification gracefully', () => {
+      const props: CustomerIOPluginOptionsIOS = {
+        ...mockIosProps,
+        pushNotification: undefined,
+      };
+
+      const result = mergeConfigWithEnvValues(props);
+
+      expect(result).toBeUndefined();
+    });
+
+    test('should handle empty strings in cdpApiKey', () => {
+      const configWithEmptyApiKey = {
+        cdpApiKey: '',
+        region: 'EU',
+      } as any;
+
+      const result = mergeConfigWithEnvValues(mockIosProps, configWithEmptyApiKey);
+
+      expect(result).toBeUndefined();
+    });
+
+    test('should handle null values gracefully', () => {
+      const configWithNullApiKey = {
+        cdpApiKey: null,
+        region: 'EU',
+      } as any;
+
+      const result = mergeConfigWithEnvValues(mockIosProps, configWithNullApiKey);
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/__tests__/utils/config.test.ts
+++ b/__tests__/utils/config.test.ts
@@ -68,6 +68,40 @@ describe('mergeConfigWithEnvValues - Resolves conflicts between legacy env confi
 
       consoleSpy.mockRestore();
     });
+
+    test('should allow case-insensitive region matching', () => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+      
+      const envWithLowerCase = {
+        cdpApiKey: 'same-api-key',
+        region: 'us',
+      };
+
+      const nativeWithUpperCase: NativeSDKConfig = {
+        cdpApiKey: 'same-api-key',
+        region: 'US',
+      };
+
+      const props: CustomerIOPluginOptionsIOS = {
+        ...mockIosProps,
+        pushNotification: {
+          env: envWithLowerCase,
+        },
+      };
+
+      const result = mergeConfigWithEnvValues(props, nativeWithUpperCase);
+
+      expect(result).toEqual({
+        cdpApiKey: 'same-api-key',
+        region: 'US', // Should return nativeConfig value
+      });
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Both \'config\' and \'ios.pushNotification.env\' are provided with matching values. Consider removing \'ios.pushNotification.env\' since \'config\' is already specified.'
+      );
+
+      consoleSpy.mockRestore();
+    });
   });
 
   describe('when only native config is provided', () => {

--- a/__tests__/utils/validation.test.ts
+++ b/__tests__/utils/validation.test.ts
@@ -1,7 +1,7 @@
 import type { NativeSDKConfig } from '../../plugin/src/types/cio-types';
 import { validateNativeSDKConfig } from '../../plugin/src/utils/validation';
 
-describe('validateNativeSDKConfig', () => {
+describe('validateNativeSDKConfig - Ensures SDK configuration meets requirements before initialization', () => {
   const validConfig: NativeSDKConfig = {
     cdpApiKey: 'test-api-key'
   };

--- a/__tests__/utils/validation.test.ts
+++ b/__tests__/utils/validation.test.ts
@@ -1,0 +1,269 @@
+import type { NativeSDKConfig } from '../../plugin/src/types/cio-types';
+import { validateNativeSDKConfig } from '../../plugin/src/utils/validation';
+
+describe('validateNativeSDKConfig', () => {
+  const validConfig: NativeSDKConfig = {
+    cdpApiKey: 'test-api-key'
+  };
+
+  describe('cdpApiKey validation', () => {
+    test('should pass with valid cdpApiKey', () => {
+      expect(() => validateNativeSDKConfig(validConfig)).not.toThrow();
+    });
+
+    test('should throw when cdpApiKey is missing', () => {
+      const config = {} as any;
+      expect(() => validateNativeSDKConfig(config)).toThrow(
+        'NativeSDKConfig: cdpApiKey is required, received: undefined'
+      );
+    });
+
+    test('should throw when cdpApiKey is null', () => {
+      const config = { cdpApiKey: null } as any;
+      expect(() => validateNativeSDKConfig(config)).toThrow(
+        'NativeSDKConfig: cdpApiKey is required, received: null'
+      );
+    });
+
+
+    test('should throw when cdpApiKey is empty string', () => {
+      const config = { cdpApiKey: '' };
+      expect(() => validateNativeSDKConfig(config)).toThrow(
+        'NativeSDKConfig: cdpApiKey must be a non-empty string, received: ""'
+      );
+    });
+
+    test('should throw when cdpApiKey is whitespace only', () => {
+      const config = { cdpApiKey: '   ' };
+      expect(() => validateNativeSDKConfig(config)).toThrow(
+        'NativeSDKConfig: cdpApiKey must be a non-empty string, received: "   "'
+      );
+    });
+
+    test('should throw when cdpApiKey is not a string', () => {
+      const config = { cdpApiKey: 123 } as any;
+      expect(() => validateNativeSDKConfig(config)).toThrow(
+        'NativeSDKConfig: cdpApiKey must be a non-empty string, received: 123'
+      );
+    });
+  });
+
+  describe('region validation', () => {
+    test('should pass with valid region US', () => {
+      const config = { ...validConfig, region: 'US' as const };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass with valid region EU', () => {
+      const config = { ...validConfig, region: 'EU' as const };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass when region is undefined', () => {
+      const config = { ...validConfig, region: undefined };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass with lowercase region', () => {
+      const config = { ...validConfig, region: 'us' } as any;
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass with mixed case region', () => {
+      const config = { ...validConfig, region: 'eU' } as any;
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should throw with invalid region', () => {
+      const config = { ...validConfig, region: 'INVALID' } as any;
+      expect(() => validateNativeSDKConfig(config)).toThrow(
+        'NativeSDKConfig: region must be one of "US", "EU", received: INVALID'
+      );
+    });
+  });
+
+  describe('screenViewUse validation', () => {
+    test('should pass with valid screenViewUse all', () => {
+      const config = { ...validConfig, screenViewUse: 'all' as const };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass with valid screenViewUse inapp', () => {
+      const config = { ...validConfig, screenViewUse: 'inapp' as const };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass when screenViewUse is undefined', () => {
+      const config = { ...validConfig, screenViewUse: undefined };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass with uppercase screenViewUse', () => {
+      const config = { ...validConfig, screenViewUse: 'ALL' } as any;
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass with mixed case screenViewUse', () => {
+      const config = { ...validConfig, screenViewUse: 'InApp' } as any;
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should throw with invalid screenViewUse', () => {
+      const config = { ...validConfig, screenViewUse: 'invalid' } as any;
+      expect(() => validateNativeSDKConfig(config)).toThrow(
+        'NativeSDKConfig: screenViewUse must be one of "all", "inapp", received: invalid'
+      );
+    });
+  });
+
+  describe('logLevel validation', () => {
+    test('should pass with valid logLevel none', () => {
+      const config = { ...validConfig, logLevel: 'none' as const };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass with valid logLevel error', () => {
+      const config = { ...validConfig, logLevel: 'error' as const };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass with valid logLevel info', () => {
+      const config = { ...validConfig, logLevel: 'info' as const };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass with valid logLevel debug', () => {
+      const config = { ...validConfig, logLevel: 'debug' as const };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass when logLevel is undefined', () => {
+      const config = { ...validConfig, logLevel: undefined };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass with uppercase logLevel', () => {
+      const config = { ...validConfig, logLevel: 'ERROR' } as any;
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass with mixed case logLevel', () => {
+      const config = { ...validConfig, logLevel: 'DeBuG' } as any;
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should throw with invalid logLevel', () => {
+      const config = { ...validConfig, logLevel: 'invalid' } as any;
+      expect(() => validateNativeSDKConfig(config)).toThrow(
+        'NativeSDKConfig: logLevel must be one of "none", "error", "info", "debug", received: invalid'
+      );
+    });
+  });
+
+  describe('boolean field validation', () => {
+    test('should pass with valid autoTrackDeviceAttributes true', () => {
+      const config = { ...validConfig, autoTrackDeviceAttributes: true };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass with valid autoTrackDeviceAttributes false', () => {
+      const config = { ...validConfig, autoTrackDeviceAttributes: false };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass when autoTrackDeviceAttributes is undefined', () => {
+      const config = { ...validConfig, autoTrackDeviceAttributes: undefined };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should throw when autoTrackDeviceAttributes is not boolean', () => {
+      const config = { ...validConfig, autoTrackDeviceAttributes: 'true' } as any;
+      expect(() => validateNativeSDKConfig(config)).toThrow(
+        'NativeSDKConfig: autoTrackDeviceAttributes must be a boolean, received: true'
+      );
+    });
+
+    test('should pass with valid trackApplicationLifecycleEvents true', () => {
+      const config = { ...validConfig, trackApplicationLifecycleEvents: true };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass with valid trackApplicationLifecycleEvents false', () => {
+      const config = { ...validConfig, trackApplicationLifecycleEvents: false };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should throw when trackApplicationLifecycleEvents is not boolean', () => {
+      const config = { ...validConfig, trackApplicationLifecycleEvents: 1 } as any;
+      expect(() => validateNativeSDKConfig(config)).toThrow(
+        'NativeSDKConfig: trackApplicationLifecycleEvents must be a boolean, received: 1'
+      );
+    });
+  });
+
+  describe('optional string field validation', () => {
+    test('should pass with valid siteId', () => {
+      const config = { ...validConfig, siteId: 'test-site-id' };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass when siteId is undefined', () => {
+      const config = { ...validConfig, siteId: undefined };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should throw when siteId is empty string', () => {
+      const config = { ...validConfig, siteId: '' };
+      expect(() => validateNativeSDKConfig(config)).toThrow(
+        'NativeSDKConfig: siteId must be a non-empty string, received: ""'
+      );
+    });
+
+    test('should throw when siteId is whitespace only', () => {
+      const config = { ...validConfig, siteId: '   ' };
+      expect(() => validateNativeSDKConfig(config)).toThrow(
+        'NativeSDKConfig: siteId must be a non-empty string, received: "   "'
+      );
+    });
+
+    test('should pass with valid migrationSiteId', () => {
+      const config = { ...validConfig, migrationSiteId: 'test-migration-site-id' };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass when migrationSiteId is undefined', () => {
+      const config = { ...validConfig, migrationSiteId: undefined };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should throw when migrationSiteId is empty string', () => {
+      const config = { ...validConfig, migrationSiteId: '' };
+      expect(() => validateNativeSDKConfig(config)).toThrow(
+        'NativeSDKConfig: migrationSiteId must be a non-empty string, received: ""'
+      );
+    });
+  });
+
+  describe('complex configuration validation', () => {
+    test('should pass with all valid optional fields', () => {
+      const config: NativeSDKConfig = {
+        cdpApiKey: 'test-api-key',
+        region: 'US',
+        autoTrackDeviceAttributes: true,
+        trackApplicationLifecycleEvents: false,
+        screenViewUse: 'all',
+        logLevel: 'debug',
+        siteId: 'test-site-id',
+        migrationSiteId: 'test-migration-site-id'
+      };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+
+    test('should pass with minimal valid configuration', () => {
+      const config: NativeSDKConfig = {
+        cdpApiKey: 'test-api-key'
+      };
+      expect(() => validateNativeSDKConfig(config)).not.toThrow();
+    });
+  });
+});

--- a/api-extractor-output/customerio-expo-plugin.api.md
+++ b/api-extractor-output/customerio-expo-plugin.api.md
@@ -6,6 +6,7 @@
 
 // @public
 export type CustomerIOPluginOptions = {
+    config?: NativeSDKConfig;
     android: CustomerIOPluginOptionsAndroid;
     ios: CustomerIOPluginOptionsIOS;
 };
@@ -60,10 +61,25 @@ export type CustomerIOPluginPushNotificationOptions = {
     showPushAppInForeground?: boolean;
     disableNotificationRegistration?: boolean;
     handleDeeplinkInKilledState?: boolean;
-    env: {
-        cdpApiKey: string;
-        region: string;
-    };
+    env?: RichPushConfig;
+};
+
+// @public
+export type NativeSDKConfig = {
+    cdpApiKey: string;
+    region?: 'US' | 'EU';
+    autoTrackDeviceAttributes?: boolean;
+    trackApplicationLifecycleEvents?: boolean;
+    screenViewUse?: 'all' | 'inapp';
+    logLevel?: 'none' | 'error' | 'info' | 'debug';
+    siteId?: string;
+    migrationSiteId?: string;
+};
+
+// @public
+export type RichPushConfig = {
+    cdpApiKey: string;
+    region?: string;
 };
 
 // (No @packageDocumentation comment for this package)

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,7 +25,9 @@ module.exports = {
       rootDir: path.resolve(__dirname),
       testMatch: ['<rootDir>/__tests__/**/*.test.(js|ts)'],
       transform: {
-        '^.+\\.(js|ts)$': 'ts-jest',
+        '^.+\\.(js|ts)$': ['ts-jest', {
+          tsconfig: path.resolve(__dirname, 'tsconfig.test.json'),
+        }],
       },
       testEnvironment: 'node',
     },

--- a/plugin/src/android/withCIOAndroid.ts
+++ b/plugin/src/android/withCIOAndroid.ts
@@ -1,6 +1,6 @@
 import type { ExpoConfig } from '@expo/config-types';
 
-import type { CustomerIOPluginOptionsAndroid } from '../types/cio-types';
+import type { CustomerIOPluginOptionsAndroid, NativeSDKConfig } from '../types/cio-types';
 import { withAndroidManifestUpdates } from './withAndroidManifestUpdates';
 import { withAppGoogleServices } from './withAppGoogleServices';
 import { withGistMavenRepository } from './withGistMavenRepository';
@@ -11,6 +11,7 @@ import { withProjectStrings } from './withProjectStrings';
 
 export function withCIOAndroid(
   config: ExpoConfig,
+  _sdkConfig: NativeSDKConfig | undefined,
   props: CustomerIOPluginOptionsAndroid
 ): ExpoConfig {
   config = withGistMavenRepository(config, props);

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -3,18 +3,24 @@ import type { ExpoConfig } from '@expo/config-types';
 import { withCIOAndroid } from './android/withCIOAndroid';
 import { withCIOIos } from './ios/withCIOIos';
 import type { CustomerIOPluginOptions } from './types/cio-types';
+import { validateNativeSDKConfig } from './utils/validation';
 
 // Entry point for config plugin
 function withCustomerIOPlugin(
   config: ExpoConfig,
   props: CustomerIOPluginOptions
 ) {
+  // Validate SDK config if provided
+  if (props.config) {
+    validateNativeSDKConfig(props.config);
+  }
+
   if (props.ios) {
-    config = withCIOIos(config, props.ios);
+    config = withCIOIos(config, props.config, props.ios);
   }
 
   if (props.android) {
-    config = withCIOAndroid(config, props.android);
+    config = withCIOAndroid(config, props.config, props.android);
   }
 
   return config;

--- a/plugin/src/types/cio-types.ts
+++ b/plugin/src/types/cio-types.ts
@@ -80,11 +80,11 @@ export type CustomerIOPluginOptionsAndroid = {
  */
 export type NativeSDKConfig = {
   cdpApiKey: string; // Required
-  region?: 'US' | 'EU'; // Default: 'US'
+  region?: 'US' | 'EU'; // Default: 'US'. The workspace region set for your workspace on the Customer.io dashboard
   autoTrackDeviceAttributes?: boolean; // Default: true
   trackApplicationLifecycleEvents?: boolean; // Default: true
-  screenViewUse?: 'all' | 'inapp'; // Default: 'all', transforms to ScreenView.All/ScreenView.InApp
-  logLevel?: 'none' | 'error' | 'info' | 'debug'; // Default: 'debug', transforms to CioLogLevel.NONE/ERROR/INFO/DEBUG
+  screenViewUse?: 'all' | 'inapp'; // Default: 'all'. 'all': sent to server + in-app messages, 'inapp': in-app messages only
+  logLevel?: 'none' | 'error' | 'info' | 'debug'; // Default: 'debug'. Controls SDK logging verbosity
   siteId?: string; // Optional, if only siteId defined, migrationSiteId = siteId
   migrationSiteId?: string; // Optional, if only migrationSiteId defined, siteId should be null
 };

--- a/plugin/src/types/cio-types.ts
+++ b/plugin/src/types/cio-types.ts
@@ -75,12 +75,37 @@ export type CustomerIOPluginOptionsAndroid = {
 };
 
 /**
+ * SDK configuration options for auto initialization
+ * @public
+ */
+export type NativeSDKConfig = {
+  cdpApiKey: string; // Required
+  region?: 'US' | 'EU'; // Default: 'US'
+  autoTrackDeviceAttributes?: boolean; // Default: true
+  trackApplicationLifecycleEvents?: boolean; // Default: true
+  screenViewUse?: 'all' | 'inapp'; // Default: 'all', transforms to ScreenView.All/ScreenView.InApp
+  logLevel?: 'none' | 'error' | 'info' | 'debug'; // Default: 'debug', transforms to CioLogLevel.NONE/ERROR/INFO/DEBUG
+  siteId?: string; // Optional, if only siteId defined, migrationSiteId = siteId
+  migrationSiteId?: string; // Optional, if only migrationSiteId defined, siteId should be null
+};
+
+/**
  * Combined plugin options for both iOS and Android platforms
  * @public
  */
 export type CustomerIOPluginOptions = {
+  config?: NativeSDKConfig; // If defined, enables auto initialization of native SDK
   android: CustomerIOPluginOptionsAndroid;
   ios: CustomerIOPluginOptionsIOS;
+};
+
+/**
+ * Rich push configuration used to initialize Notification Service Extension (NSE) on the native side
+ * @public
+ */
+export type RichPushConfig = {
+  cdpApiKey: string;
+  region?: string;
 };
 
 /**
@@ -98,11 +123,8 @@ export type CustomerIOPluginPushNotificationOptions = {
   handleDeeplinkInKilledState?: boolean;
 
   /**
-   * These values will be used to initialize the Notification Service Extension (NSE) on the native side.
-   * They should match the values you use to initialize the SDK in your app
+   * Rich push config should match the values used to initialize SDK in the app.
+   * Optional if `config` is provided at the top level.
    */
-  env: {
-    cdpApiKey: string;
-    region: string;
-  };
+  env?: RichPushConfig;
 };

--- a/plugin/src/utils/config.ts
+++ b/plugin/src/utils/config.ts
@@ -18,7 +18,7 @@ function mergeConfigWithEnvValues(
 
   // Check for conflicts between env and nativeConfig
   if (nativeCdpApiKey && envCdpApiKey) {
-    if (nativeCdpApiKey !== envCdpApiKey || nativeRegion !== envRegion) {
+    if (nativeCdpApiKey !== envCdpApiKey || nativeRegion?.toLowerCase() !== envRegion?.toLowerCase()) {
       const errorMessage = `Configuration conflict: 'config' and 'ios.pushNotification.env' values must match when both are provided.\n` +
         `  config.cdpApiKey: "${nativeCdpApiKey}"\n` +
         `  env.cdpApiKey: "${envCdpApiKey}"\n` +

--- a/plugin/src/utils/config.ts
+++ b/plugin/src/utils/config.ts
@@ -1,0 +1,33 @@
+import type { CustomerIOPluginOptionsIOS, NativeSDKConfig, RichPushConfig } from '../types/cio-types';
+
+/**
+ * Merges config values with env values for backward compatibility.
+ * If env is provided, it takes precedence. If nativeConfig is provided but env is not,
+ * nativeConfig values are used. This prioritizes existing env configuration for backward compatibility.
+ */
+function mergeConfigWithEnvValues(
+  props: CustomerIOPluginOptionsIOS,
+  nativeConfig?: NativeSDKConfig
+): RichPushConfig | undefined {
+  // First priority: env values (backward compatibility)
+  const envConfig = props.pushNotification?.env;
+  if (envConfig?.cdpApiKey) {
+    return {
+      cdpApiKey: envConfig.cdpApiKey,
+      region: envConfig.region,
+    };
+  }
+
+  // Second priority: config values
+  if (nativeConfig?.cdpApiKey) {
+    return {
+      cdpApiKey: nativeConfig.cdpApiKey,
+      region: nativeConfig.region,
+    };
+  }
+
+  // No values provided
+  return undefined;
+}
+
+export { mergeConfigWithEnvValues };

--- a/plugin/src/utils/config.ts
+++ b/plugin/src/utils/config.ts
@@ -9,24 +9,44 @@ function mergeConfigWithEnvValues(
   props: CustomerIOPluginOptionsIOS,
   nativeConfig?: NativeSDKConfig
 ): RichPushConfig | undefined {
-  // First priority: env values (backward compatibility)
+  const nativeCdpApiKey = nativeConfig?.cdpApiKey;
+  const nativeRegion = nativeConfig?.region;
+
   const envConfig = props.pushNotification?.env;
-  if (envConfig?.cdpApiKey) {
+  const envCdpApiKey = envConfig?.cdpApiKey;
+  const envRegion = envConfig?.region;
+
+  // Check for conflicts between env and nativeConfig
+  if (nativeCdpApiKey && envCdpApiKey) {
+    if (nativeCdpApiKey !== envCdpApiKey || nativeRegion !== envRegion) {
+      const errorMessage = `Configuration conflict: 'config' and 'ios.pushNotification.env' values must match when both are provided.\n` +
+        `  config.cdpApiKey: "${nativeCdpApiKey}"\n` +
+        `  env.cdpApiKey: "${envCdpApiKey}"\n` +
+        `  config.region: "${nativeRegion}"\n` +
+        `  env.region: "${envRegion}"`;
+
+      console.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    // Values match - warn about redundant configuration
+    console.warn(
+      `Both 'config' and 'ios.pushNotification.env' are provided with matching values. ` +
+      `Consider removing 'ios.pushNotification.env' since 'config' is already specified.`
+    );
+  }
+
+  // Return config (values are guaranteed to be the same if both exist)
+  const cdpApiKey = nativeCdpApiKey || envCdpApiKey;
+  const region = nativeRegion || envRegion;
+
+  if (cdpApiKey) {
     return {
-      cdpApiKey: envConfig.cdpApiKey,
-      region: envConfig.region,
+      cdpApiKey,
+      region,
     };
   }
 
-  // Second priority: config values
-  if (nativeConfig?.cdpApiKey) {
-    return {
-      cdpApiKey: nativeConfig.cdpApiKey,
-      region: nativeConfig.region,
-    };
-  }
-
-  // No values provided
   return undefined;
 }
 

--- a/plugin/src/utils/validation.ts
+++ b/plugin/src/utils/validation.ts
@@ -1,0 +1,54 @@
+import type { NativeSDKConfig } from '../types/cio-types';
+
+function validateRequired(value: unknown, fieldName: string, context: string): void {
+  if (value === undefined || value === null) {
+    throw new Error(`${context}: ${fieldName} is required, received: ${value}`);
+  }
+}
+
+function validateString(value: unknown, fieldName: string, context: string): void {
+  if (value !== undefined && (typeof value !== 'string' || value.trim() === '')) {
+    throw new Error(`${context}: ${fieldName} must be a non-empty string, received: ${typeof value === 'string' ? `"${value}"` : value}`);
+  }
+}
+
+function validateBoolean(value: unknown, fieldName: string, context: string): void {
+  if (value !== undefined && typeof value !== 'boolean') {
+    throw new Error(`${context}: ${fieldName} must be a boolean, received: ${value}`);
+  }
+}
+
+function validateEnum<T extends string>(
+  value: unknown,
+  fieldName: string,
+  allowedValues: readonly T[],
+  context: string
+): void {
+  if (value === undefined) return;
+
+  validateString(value, fieldName, context);
+
+  const lowerValue = (value as string).toLowerCase();
+  const lowerAllowedValues = allowedValues.map(v => v.toLowerCase());
+  if (!lowerAllowedValues.includes(lowerValue)) {
+    const valuesStr = allowedValues.map(v => `"${v}"`).join(', ');
+    throw new Error(`${context}: ${fieldName} must be one of ${valuesStr}, received: ${value}`);
+  }
+}
+
+function validateNativeSDKConfig(config: NativeSDKConfig): void {
+  const context = 'NativeSDKConfig';
+
+  validateRequired(config.cdpApiKey, 'cdpApiKey', context);
+  validateString(config.cdpApiKey, 'cdpApiKey', context);
+
+  validateEnum(config.region, 'region', ['US', 'EU'] as const, context);
+  validateEnum(config.screenViewUse, 'screenViewUse', ['all', 'inapp'] as const, context);
+  validateEnum(config.logLevel, 'logLevel', ['none', 'error', 'info', 'debug'] as const, context);
+  validateBoolean(config.autoTrackDeviceAttributes, 'autoTrackDeviceAttributes', context);
+  validateBoolean(config.trackApplicationLifecycleEvents, 'trackApplicationLifecycleEvents', context);
+  validateString(config.siteId, 'siteId', context);
+  validateString(config.migrationSiteId, 'migrationSiteId', context);
+}
+
+export { validateNativeSDKConfig };

--- a/test-app/App.js
+++ b/test-app/App.js
@@ -11,6 +11,7 @@ import { initializeCioSdk } from "./helpers/SdkInit";
 const Stack = createStackNavigator();
 
 export default function App() {
+  // TODO: Remove SDK initialization once auto-initialization is fully implemented
   useEffect(() => {
     initializeCioSdk();
   }, []);

--- a/test-app/app.json
+++ b/test-app/app.json
@@ -22,7 +22,9 @@
       "infoPlist": {
         "CFBundleURLTypes": [
           {
-            "CFBundleURLSchemes": ["expo-test-app"]
+            "CFBundleURLSchemes": [
+              "expo-test-app"
+            ]
           }
         ]
       }
@@ -43,7 +45,10 @@
               "host": "nav-test"
             }
           ],
-          "category": ["BROWSABLE", "DEFAULT"]
+          "category": [
+            "BROWSABLE",
+            "DEFAULT"
+          ]
         }
       ]
     },
@@ -63,6 +68,15 @@
       [
         "customerio-expo-plugin",
         {
+          "config": {
+            "cdpApiKey": "@CDP_API_KEY@",
+            "siteId": "@SITE_ID@",
+            "region": "us",
+            "logLevel": "debug",
+            "autoTrackDeviceAttributes": true,
+            "trackApplicationLifecycleEvents": true,
+            "screenViewUse": "all"
+          },
           "android": {
             "googleServicesFile": "./files/google-services.json",
             "setHighPriorityPushHandler": true,
@@ -78,11 +92,7 @@
             "useFrameworks": "static",
             "pushNotification": {
               "provider": "apn",
-              "useRichPush": true,
-              "env": {
-                "cdpApiKey": "@CDP_API_KEY@",
-                "region": "us"
-              }
+              "useRichPush": true
             }
           }
         }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./tsconfig.json",
   "exclude": [
     "ci-test-apps",
+    "__tests__"
   ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "verbatimModuleSyntax": false
+  },
+  "include": [
+    "__tests__"
+  ]
+}


### PR DESCRIPTION
part of: [MBL-1316](https://linear.app/customerio/issue/MBL-1316/add-auto-initialization-configuration-option)

### Changes

- Added `NativeSDKConfig` to support SDK setup via `app.json`
- Added config validation to fail early on misconfigurations during `prebuild`
- Updated test app `app.json` with new config block and added TODO note for future clean-up
- Added `tsconfig.test.json` to fix test import issues
- Updated `jest.config.js` to use test specific TS config
- Updated test workflow to run plugin `utils` tests

### Plugin Config

#### Before

```json
{
  "android": {
    "googleServicesFile": "./files/google-services.json",
    "setHighPriorityPushHandler": true,
    "pushNotification": {
      "channel": {
        "id": "cio-expo-id",
        "name": "CIO Test",
        "importance": 4
      }
    }
  },
  "ios": {
    "useFrameworks": "static",
    "pushNotification": {
      "provider": "apn",
      "useRichPush": true,
      "env": {
        "cdpApiKey": "@CDP_API_KEY@",
        "region": "us"
      }
    }
  }
}
```

#### After

```json
{
  "config": {
    "cdpApiKey": "@CDP_API_KEY@",
    "siteId": "@SITE_ID@",
    "region": "us",
    "logLevel": "debug",
    "autoTrackDeviceAttributes": true,
    "trackApplicationLifecycleEvents": true,
    "screenViewUse": "all"
  },
  "android": {
    "googleServicesFile": "./files/google-services.json",
    "setHighPriorityPushHandler": true,
    "pushNotification": {
      "channel": {
        "id": "cio-expo-id",
        "name": "CIO Test",
        "importance": 4
      }
    }
  },
  "ios": {
    "useFrameworks": "static",
    "pushNotification": {
      "provider": "apn",
      "useRichPush": true
    }
  }
}
```

### Notes

- No breaking changes in plugin or config
- Auto init is disabled if `config` is undefined (backward compatible)
- Auto init is enabled when `config` is defined
- The config is only passed to Android and iOS SDKs in this PR. Implementation for native initialization will follow in later PRs.