### PR TITLE
feat: config to override fcm push priority 

### DIFF
--- a/__tests__/android/app-manifest.test.js
+++ b/__tests__/android/app-manifest.test.js
@@ -72,3 +72,39 @@ test("Plugin injects notification channel metadata in the app manifest", async (
     expect(channelImportanceMetadata['$']['android:value']).toBe('4');
   });
 });
+
+test("Plugin adds service when firebaseMessagingServicePriority is specified", async () => {
+  // Test that firebaseMessagingServicePriority configuration is supported
+  // Note: This test verifies the service exists. Priority testing would require integration testing
+  // since it depends on the actual plugin compilation process.
+  const manifestContent = await fs.readFile(appManifestPath, "utf8");
+
+  parseString(manifestContent, (err, manifest) => {
+    if (err) throw err;
+
+    const expectedServiceName = 'io.customer.messagingpush.CustomerIOFirebaseMessagingService';
+    const expectedAction = 'com.google.firebase.MESSAGING_EVENT';
+
+    const application = manifest?.manifest?.application?.[0];
+    expect(application).toBeDefined();
+
+    const services = application.service || [];
+    const service = services.find(service => service['$']['android:name'] === expectedServiceName);
+    expect(service).toBeDefined();
+
+    // Check that the service has the correct structure
+    expect(service['$']['android:exported']).toBe('false');
+    expect(service['intent-filter']).toBeDefined();
+    expect(service['intent-filter'].length).toBeGreaterThan(0);
+
+    const intentFilter = service['intent-filter'][0];
+    
+    // Check that the action is correct
+    const actions = intentFilter.action || [];
+    const hasExpectedAction = actions.some(action => action['$']['android:name'] === expectedAction);
+    expect(hasExpectedAction).toBe(true);
+
+    // Note: Priority testing would be done in unit tests or integration tests
+    // since the actual priority application depends on plugin compilation behavior
+  });
+});

--- a/__tests__/android/app-manifest.test.js
+++ b/__tests__/android/app-manifest.test.js
@@ -73,10 +73,8 @@ test("Plugin injects notification channel metadata in the app manifest", async (
   });
 });
 
-test("Plugin adds service when firebaseMessagingServicePriority is specified", async () => {
-  // Test that firebaseMessagingServicePriority configuration is supported
-  // Note: This test verifies the service exists. Priority testing would require integration testing
-  // since it depends on the actual plugin compilation process.
+test("Plugin adds service with custom priority when firebaseMessagingServicePriority is specified", async () => {
+  // Test that firebaseMessagingServicePriority adds the service with specified priority (-2 in test app config)
   const manifestContent = await fs.readFile(appManifestPath, "utf8");
 
   parseString(manifestContent, (err, manifest) => {
@@ -84,6 +82,7 @@ test("Plugin adds service when firebaseMessagingServicePriority is specified", a
 
     const expectedServiceName = 'io.customer.messagingpush.CustomerIOFirebaseMessagingService';
     const expectedAction = 'com.google.firebase.MESSAGING_EVENT';
+    const expectedPriority = '-2'; // As set in test-app/app.json
 
     const application = manifest?.manifest?.application?.[0];
     expect(application).toBeDefined();
@@ -104,7 +103,8 @@ test("Plugin adds service when firebaseMessagingServicePriority is specified", a
     const hasExpectedAction = actions.some(action => action['$']['android:name'] === expectedAction);
     expect(hasExpectedAction).toBe(true);
 
-    // Note: Priority testing would be done in unit tests or integration tests
-    // since the actual priority application depends on plugin compilation behavior
+    // Check that the priority is set correctly (matches test-app/app.json config)
+    expect(intentFilter['$']).toBeDefined();
+    expect(intentFilter['$']['android:priority']).toBe(expectedPriority);
   });
 });

--- a/plugin/src/android/withCIOAndroid.ts
+++ b/plugin/src/android/withCIOAndroid.ts
@@ -18,7 +18,7 @@ export function withCIOAndroid(
   config = withAppGoogleServices(config, props);
   config = withGoogleServicesJSON(config, props);
   config = withProjectStrings(config);
-  if (props.setHighPriorityPushHandler) {
+  if (props.setHighPriorityPushHandler || props.pushNotification?.firebaseMessagingServicePriority !== undefined) {
     config = withAndroidManifestUpdates(config, props);
   }
   if (props.pushNotification?.channel) {

--- a/plugin/src/types/cio-types.ts
+++ b/plugin/src/types/cio-types.ts
@@ -71,6 +71,16 @@ export type CustomerIOPluginOptionsAndroid = {
       name?: string;
       importance?: number;
     };
+    /**
+     * Priority for Firebase messaging service intent filter.
+     * Higher numbers = higher priority. Use negative numbers to set lower priority than other services.
+     * 
+     * If this value is provided, the service will be added to the manifest regardless of setHighPriorityPushHandler.
+     * If not provided, behavior depends on setHighPriorityPushHandler:
+     * - setHighPriorityPushHandler: false -> service not added (Android SDK handles it)
+     * - setHighPriorityPushHandler: true -> service added with no priority attribute (Android default)
+     */
+    firebaseMessagingServicePriority?: number;
   };
 };
 

--- a/test-app/app.json
+++ b/test-app/app.json
@@ -71,7 +71,8 @@
                 "id": "cio-expo-id",
                 "name": "CIO Test",
                 "importance": 4
-              }
+              },
+              "firebaseMessagingServicePriority": -2
             }
           },
           "ios": {


### PR DESCRIPTION
Problem

When using Customer.io alongside other push notification services (e.g., expo-notifications), both services can register for the same Firebase messaging intent with equal priority, causing conflicts where push notifications may not be delivered to the intended service.

Solution

In all other SDKs, users can override it by updating manifest but in expo we update it

Added `firebaseMessagingServicePriority` configuration option to control Firebase messaging service precedence:

```
  [
    'customerio-expo-plugin',
    {
      android: {
        pushNotification: {
          firebaseMessagingServicePriority: -2  // Lower priority than expo-notifications
        }
      }
    }
  ]
```

  Behavior

  - If specified: Service is added with custom priority regardless of setHighPriorityPushHandler
  - If not specified: Existing behavior is preserved
  - Higher numbers = higher priority, negative numbers = lower priority

  Generated Manifest

```
  <!-- With priority -->
  <service android:name="io.customer.messagingpush.CustomerIOFirebaseMessagingService" android:exported="false">
      <intent-filter android:priority="-2">
          <action android:name="com.google.firebase.MESSAGING_EVENT" />
      </intent-filter>
  </service>
```

  Use Cases

  - Resolve expo-notifications conflict: Set -2 to let expo-notifications handle first
  - Prioritize Customer.io: Set positive number for higher priority
  - No change needed: Existing configs work unchanged

  Type: EnhancementBreaking: No