### PR TITLE
chore: allow auto initialization on ios without push config

### DIFF
--- a/__tests__/ios/withCIOIosSwift.test.ts
+++ b/__tests__/ios/withCIOIosSwift.test.ts
@@ -1,0 +1,222 @@
+import type { ExpoConfig } from '@expo/config-types';
+import { withCIOIosSwift } from '../../plugin/src/ios/withCIOIosSwift';
+import type { CustomerIOPluginOptionsIOS, NativeSDKConfig } from '../../plugin/src/types/cio-types';
+
+// Mock dependencies
+jest.mock('@expo/config-plugins', () => ({
+  withXcodeProject: jest.fn((config, callback) => {
+    const mockXcodeConfig = {
+      modRequest: { projectRoot: '/test/project', projectName: 'TestApp' },
+      modResults: {
+        pbxCreateGroup: jest.fn(() => 'mock-group'),
+        pbxGroupByName: jest.fn(() => null),
+        findPBXGroupKey: jest.fn(() => 'mock-key'),
+        addToPbxGroup: jest.fn(),
+        addSourceFile: jest.fn(),
+      },
+    };
+    callback(mockXcodeConfig);
+    return config;
+  }),
+  withAppDelegate: jest.fn((_config, callback) => {
+    const mockAppDelegateConfig = {
+      modResults: {
+        contents: `import Expo
+import React
+
+@UIApplicationMain
+public class AppDelegate: ExpoAppDelegate {
+  public override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+}`,
+      },
+    };
+    return callback(mockAppDelegateConfig);
+  }),
+}));
+
+jest.mock('../../plugin/src/helpers/utils/fileManagement', () => ({
+  FileManagement: {
+    copyFile: jest.fn(),
+    readFile: jest.fn(() => 'mock file content {{AUTO_TRACK_PUSH_EVENTS}} {{AUTO_FETCH_DEVICE_TOKEN}} {{SHOW_PUSH_APP_IN_FOREGROUND}}'),
+    writeFile: jest.fn(),
+  },
+}));
+
+jest.mock('../../plugin/src/utils/xcode', () => ({
+  copyFileToXcode: jest.fn(),
+  getOrCreateCustomerIOGroup: jest.fn(() => 'mock-group'),
+}));
+
+jest.mock('../../plugin/src/helpers/utils/patchPluginNativeCode', () => ({
+  patchNativeSDKInitializer: jest.fn((content) => `patched: ${content}`),
+}));
+
+describe('withCIOIosSwift', () => {
+  const mockConfig: ExpoConfig = {
+    name: 'Test App',
+    slug: 'test-app',
+    sdkVersion: '53.0.0',
+  };
+
+  const mockSdkConfig: NativeSDKConfig = {
+    cdpApiKey: 'test-api-key',
+    region: 'US',
+    autoTrackDeviceAttributes: true,
+    trackApplicationLifecycleEvents: true,
+    screenViewUse: 'all',
+    logLevel: 'debug',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('with push notifications configured', () => {
+    const mockPropsWithPush: CustomerIOPluginOptionsIOS = {
+      iosPath: '/test/ios',
+      pushNotification: {
+        provider: 'apn',
+        autoFetchDeviceToken: true,
+        autoTrackPushEvents: true,
+        showPushAppInForeground: true,
+      },
+    };
+
+    it('should copy CioSdkAppDelegateHandler and inject handler call', async () => {
+      const { withAppDelegate } = require('@expo/config-plugins');
+
+      withCIOIosSwift(mockConfig, mockSdkConfig, mockPropsWithPush);
+
+      // Should call withAppDelegate to modify AppDelegate
+      expect(withAppDelegate).toHaveBeenCalled();
+
+      // The callback should modify AppDelegate to add handler call
+      const appDelegateCallback = withAppDelegate.mock.calls[0][1];
+      const result = await appDelegateCallback({
+        modResults: {
+          contents: `@UIApplicationMain
+public class AppDelegate: ExpoAppDelegate {
+  public override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+}`,
+        },
+      });
+
+      expect(result.modResults.contents).toContain('cioSdkHandler.application(application, didFinishLaunchingWithOptions: launchOptions)');
+      expect(result.modResults.contents).toContain('let cioSdkHandler = CioSdkAppDelegateHandler()');
+    });
+  });
+
+  describe('with auto-init only (no push notifications)', () => {
+    const mockPropsAutoInitOnly: CustomerIOPluginOptionsIOS = {
+      iosPath: '/test/ios',
+      // No pushNotification property
+    };
+
+    it('should inject CustomerIOSDKInitializer.initialize() directly into AppDelegate', async () => {
+      const { withAppDelegate } = require('@expo/config-plugins');
+
+      withCIOIosSwift(mockConfig, mockSdkConfig, mockPropsAutoInitOnly);
+
+      // Should still call withAppDelegate to modify AppDelegate
+      expect(withAppDelegate).toHaveBeenCalled();
+
+      // The callback should modify AppDelegate to add direct auto-init call
+      const appDelegateCallback = withAppDelegate.mock.calls[0][1];
+      const result = await appDelegateCallback({
+        modResults: {
+          contents: `@UIApplicationMain
+public class AppDelegate: ExpoAppDelegate {
+  public override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+}`,
+        },
+      });
+
+      // Should inject direct auto-initialization
+      expect(result.modResults.contents).toContain('CustomerIOSDKInitializer.initialize()');
+      expect(result.modResults.contents).toContain('// Auto Initialize Native Customer.io SDK');
+
+      // Should NOT inject CioSdkAppDelegateHandler code
+      expect(result.modResults.contents).not.toContain('cioSdkHandler.application');
+      expect(result.modResults.contents).not.toContain('let cioSdkHandler = CioSdkAppDelegateHandler()');
+    });
+
+  });
+
+  describe('without sdkConfig', () => {
+    const mockPropsNoAutoInit: CustomerIOPluginOptionsIOS = {
+      iosPath: '/test/ios',
+      pushNotification: {
+        provider: 'apn',
+        autoFetchDeviceToken: true,
+      },
+    };
+
+    it('should not inject any auto-initialization code when sdkConfig is undefined', async () => {
+      const { withAppDelegate } = require('@expo/config-plugins');
+
+      withCIOIosSwift(mockConfig, undefined, mockPropsNoAutoInit);
+
+      const appDelegateCallback = withAppDelegate.mock.calls[0][1];
+      const result = await appDelegateCallback({
+        modResults: {
+          contents: `public override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }`,
+        },
+      });
+
+      // Should contain push handler but not auto-init
+      expect(result.modResults.contents).toContain('cioSdkHandler.application');
+      expect(result.modResults.contents).not.toContain('CustomerIOSDKInitializer.initialize()');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle when neither push notifications nor auto-init are configured', () => {
+      const mockPropsEmpty: CustomerIOPluginOptionsIOS = {
+        iosPath: '/test/ios',
+      };
+
+      const { withAppDelegate } = require('@expo/config-plugins');
+
+      // Should not call withAppDelegate when there's nothing to configure
+      withCIOIosSwift(mockConfig, undefined, mockPropsEmpty);
+
+      // withAppDelegate is called but should return early when nothing to inject
+      expect(withAppDelegate).toHaveBeenCalled();
+    });
+
+    it('should skip duplicate injections when code already exists', async () => {
+      const { withAppDelegate } = require('@expo/config-plugins');
+
+      withCIOIosSwift(mockConfig, mockSdkConfig, { iosPath: '/test/ios' });
+
+      const appDelegateCallback = withAppDelegate.mock.calls[0][1];
+      const result = await appDelegateCallback({
+        modResults: {
+          contents: `@UIApplicationMain
+public class AppDelegate: ExpoAppDelegate {
+  public override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+    // Auto Initialize Native Customer.io SDK
+    CustomerIOSDKInitializer.initialize()
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+}`,
+        },
+      });
+
+      // Should not inject duplicate code
+      const initializeOccurrences = (result.modResults.contents.match(/CustomerIOSDKInitializer\.initialize\(\)/g) || []).length;
+      expect(initializeOccurrences).toBe(1);
+    });
+  });
+});

--- a/plugin/src/helpers/constants/ios.ts
+++ b/plugin/src/helpers/constants/ios.ts
@@ -165,6 +165,6 @@ export const CIO_REGISTER_PUSHNOTIFICATION_SNIPPET_v2 = `
 export const CIO_REGISTER_PUSH_NOTIFICATION_PLACEHOLDER = /\{\{REGISTER_SNIPPET\}\}/;
 // Regex to match MessagingPush initialization in AppDelegate (different from NSE initialization)
 export const CIO_MESSAGING_PUSH_APP_DELEGATE_INIT_REGEX = /(MessagingPush(?:APN|FCM)\.initialize)/;
+export const CIO_NATIVE_SDK_INITIALIZE_CALL = 'CustomerIOSDKInitializer.initialize()';
 export const CIO_NATIVE_SDK_INITIALIZE_SNIPPET = `// Auto Initialize Native Customer.io SDK
-    CustomerIOSDKInitializer.initialize()
-    `;
+    ${CIO_NATIVE_SDK_INITIALIZE_CALL}`;

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -1,6 +1,7 @@
 import type { ExpoConfig } from '@expo/config-types';
 
 import { withCIOAndroid } from './android/withCIOAndroid';
+import { isExpoVersion53OrHigher } from './ios/utils';
 import { withCIOIos } from './ios/withCIOIos';
 import type { CustomerIOPluginOptions } from './types/cio-types';
 import { validateNativeSDKConfig } from './utils/validation';
@@ -10,6 +11,15 @@ function withCustomerIOPlugin(
   config: ExpoConfig,
   props: CustomerIOPluginOptions
 ) {
+  // Check if config is being used with unsupported Expo version
+  if (props.config && !isExpoVersion53OrHigher(config)) {
+    throw new Error(
+      'CustomerIO auto initialization (config property) requires Expo SDK 53 or higher. ' +
+      'Please upgrade to Expo SDK 53+ or use manual initialization instead. ' +
+      'See documentation for manual setup instructions.'
+    );
+  }
+
   // Validate SDK config if provided
   if (props.config) {
     validateNativeSDKConfig(props.config);

--- a/plugin/src/ios/withCIOIos.ts
+++ b/plugin/src/ios/withCIOIos.ts
@@ -35,6 +35,8 @@ export function withCIOIos(
     config = withCioNotificationsXcodeProject(config, platformConfig);
     config = withCioXcodeProject(config, platformConfig);
     config = withGoogleServicesJsonFile(config, platformConfig);
+  } else if (sdkConfig && isSwiftProject) {
+    config = withCIOIosSwift(config, sdkConfig, platformConfig);
   }
 
   return config;


### PR DESCRIPTION
### Summary

Auto initialization previously only worked on iOS when push notifications were configured, which was unintuitive since Android had no such restriction. Additionally, since auto init relies on Swift support (only available in Expo SDK 53+), using it on older versions could silently fail.

### Changes

- Added an explicit validation error if config is used with Expo SDK < 53, preventing confusing or broken builds
- Enabled auto-initialization on iOS even if `pushNotification` is not configured in `app.json`
- Added test cases to validate behavior across both push enabled and disabled configurations

### Testing

- Update test app's `app.json` to remove `pushNotification` block under `ios`
- Run `prebuild` and verify generated `AppDelegate` includes auto init correctly
- iOS app should build and run successfully with full SDK functionality using auto initialization