### PR TITLE
feat: support for xcode 26 beta

### DIFF
--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -93,9 +93,6 @@ jobs:
         working-directory: plugin
         run: npm ci
 
-      - name: Setup test project
-        run: npm run setup-test-app
-
       - name: Setup CIO workspace credentials in test apps config
         run: |
           APP_JSON_FILE="test-app/app.json"
@@ -108,6 +105,9 @@ jobs:
           LAST_TAG="${LATEST_TAG:-untagged}"
           COMMITS_AHEAD=$(git rev-list $LAST_TAG..HEAD --count 2>/dev/null || echo "untracked")
           sd "\"commitsAheadCount\".*" "\"commitsAheadCount\": \"$COMMITS_AHEAD\"," "$APP_JSON_FILE"
+
+      - name: Setup test project
+        run: npm run setup-test-app
 
       - name: Build Android app with fastlane
         id: android_build
@@ -228,9 +228,6 @@ jobs:
         working-directory: plugin
         run: npm ci
 
-      - name: Setup test project
-        run: npm run setup-test-app
-
       - name: Setup CIO workspace credentials in test apps config
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
@@ -252,6 +249,9 @@ jobs:
             sd "\"cdpApiKey\".*" "\"cdpApiKey\": \"${{ secrets.CUSTOMERIO_EXPO_WORKSPACE_CDP_API_KEY }}\"," "$APP_JSON_FILE"
             sd "\"siteId\".*" "\"siteId\": \"${{ secrets.CUSTOMERIO_EXPO_WORKSPACE_SITE_ID }}\"," "$APP_JSON_FILE"
           fi
+
+      - name: Setup test project
+        run: npm run setup-test-app
 
       - name: Copy GoogleService-Info.plist to ios project
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-expo-plugin",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-expo-plugin",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -34,7 +34,7 @@
         "xcode": "^3.0.1"
       },
       "peerDependencies": {
-        "customerio-reactnative": "4.7.0"
+        "customerio-reactnative": "4.8.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -6812,9 +6812,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-4.7.0.tgz",
-      "integrity": "sha512-ELR75sujARqx0fOGzDoisFQByGIn8Hz+k+ayisMFr6MV8rfw8bukBQkz2SKcXgr3gf/Dw7J9G8ZZXD4aItjqdQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-4.8.0.tgz",
+      "integrity": "sha512-dszv9oVnKgpLMPqVpxw1H6CgWE0o2EMsa3+XEirwoy2+7nGeByoRIg1BfTdII1VfUovGb42l9Su0dqotcUo9Vg==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "customerio-reactnative": "4.7.0"
+    "customerio-reactnative": "4.8.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/test-app/app.json
+++ b/test-app/app.json
@@ -72,10 +72,7 @@
             "cdpApiKey": "@CDP_API_KEY@",
             "siteId": "@SITE_ID@",
             "region": "us",
-            "logLevel": "debug",
-            "autoTrackDeviceAttributes": true,
-            "trackApplicationLifecycleEvents": true,
-            "screenViewUse": "all"
+            "logLevel": "debug"
           },
           "android": {
             "googleServicesFile": "./files/google-services.json",

--- a/test-app/app.json
+++ b/test-app/app.json
@@ -62,7 +62,8 @@
       "buildTimestamp": "@BUILD_TIMESTAMP@",
       "branchName": "@BRANCH_NAME@",
       "commitHash": "@COMMIT_HASH@",
-      "commitsAheadCount": "@COMMITS_AHEAD_COUNT@"
+      "commitsAheadCount": "@COMMITS_AHEAD_COUNT@",
+      "wisdom": "cache invalidation is hard"
     },
     "plugins": [
       [

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -13,7 +13,7 @@
         "@react-navigation/native": "^7.1.6",
         "@react-navigation/stack": "^7.2.8",
         "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-        "customerio-reactnative": "^4.7.0",
+        "customerio-reactnative": "^4.8.0",
         "dotenv": "^16.4.7",
         "expo": "~53.0.9",
         "expo-build-properties": "~0.14.6",
@@ -3890,9 +3890,9 @@
       }
     },
     "node_modules/customerio-expo-plugin": {
-      "version": "2.5.0",
+      "version": "2.6.0",
       "resolved": "file:../customerio-expo-plugin-latest.tgz",
-      "integrity": "sha512-fIud6g4OIRaAl0O2utxw6uf3+wOxp98h9Dg1Wq35EhBQW5FkD5gCuILiFQfgcLHA/g2KLqsQp0tylGsZEpWcTA==",
+      "integrity": "sha512-jJziZvxqL8RF3cWENa6VxmKC6/KIQLbqjiA7DYx8GT2XwShne27QG8bizQstqd21Y8G2Y8TFI32swIDN98nNPg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3901,7 +3901,7 @@
         "semver": "^7.7.2"
       },
       "peerDependencies": {
-        "customerio-reactnative": "4.7.0"
+        "customerio-reactnative": "4.8.0"
       }
     },
     "node_modules/customerio-expo-plugin/node_modules/semver": {
@@ -3917,9 +3917,9 @@
       }
     },
     "node_modules/customerio-reactnative": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-4.7.0.tgz",
-      "integrity": "sha512-ELR75sujARqx0fOGzDoisFQByGIn8Hz+k+ayisMFr6MV8rfw8bukBQkz2SKcXgr3gf/Dw7J9G8ZZXD4aItjqdQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-4.8.0.tgz",
+      "integrity": "sha512-dszv9oVnKgpLMPqVpxw1H6CgWE0o2EMsa3+XEirwoy2+7nGeByoRIg1BfTdII1VfUovGb42l9Su0dqotcUo9Vg==",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -3892,7 +3892,7 @@
     "node_modules/customerio-expo-plugin": {
       "version": "2.6.0",
       "resolved": "file:../customerio-expo-plugin-latest.tgz",
-      "integrity": "sha512-jJziZvxqL8RF3cWENa6VxmKC6/KIQLbqjiA7DYx8GT2XwShne27QG8bizQstqd21Y8G2Y8TFI32swIDN98nNPg==",
+      "integrity": "sha512-llNATbrWrLmjJTA5eFmF/lJZ3GmcMn/63sbf2n1qRbzz/fUBEArFRU+Q8zqJ3nhKjTddC37lYlMGHft/WaNPXw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -14,7 +14,7 @@
     "@react-navigation/native": "^7.1.6",
     "@react-navigation/stack": "^7.2.8",
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^4.7.0",
+    "customerio-reactnative": "^4.8.0",
     "dotenv": "^16.4.7",
     "expo": "~53.0.9",
     "expo-build-properties": "~0.14.6",


### PR DESCRIPTION
part of: [MBL-1343](https://linear.app/customerio/issue/MBL-1343/ios-26-xcode-26-beta-build-fails-messagingpush-does-not-conform-to)

### Summary

Upgraded React Native SDK from `4.7.0` to `4.8.0` which includes following updates:

- Sticky session queue support for iOS
- Public API alignment for iOS
- Xcode 16 beta fixes
- Fixed deep link issues with FCM when using `CioAppDelegateWrapper`

### Other Changes

- Updated CI workflows to run `expo prebuild` after `app.json` updates to ensure correct native generation for auto initialization
- Simplified SDK `config` in test app's `app.json` for clarity