### PR TITLE
fix: remove react native sdk header import in ios

### DIFF
--- a/__tests__/utils/__snapshots__/patchPluginNativeCode.test.ts.snap
+++ b/__tests__/utils/__snapshots__/patchPluginNativeCode.test.ts.snap
@@ -31,9 +31,13 @@ class CustomerIOSDKInitializer {
         if let siteId = siteId {
             let inAppConfig = MessagingInAppConfigBuilder(siteId: siteId, region: region).build()
             MessagingInApp.initialize(withConfig: inAppConfig)
+            let logger = DIGraphShared.shared.logger
             // Retrieves ReactInAppEventListener from DI graph, populated when it is accessed in React Native SDK.
             if let listener: InAppEventListener? = DIGraphShared.shared.getOverriddenInstance() {
+                logger.debug("[Expo][InApp] React InAppEventListener found in DI graph and set")
                 MessagingInApp.shared.setEventListener(listener)
+            } else {
+                logger.debug("[Expo][InApp] React InAppEventListener not found in DI graph, will be set by React Native module when accessed")
             }
         }
     }
@@ -91,9 +95,13 @@ class CustomerIOSDKInitializer {
         if let siteId = siteId {
             let inAppConfig = MessagingInAppConfigBuilder(siteId: siteId, region: region).build()
             MessagingInApp.initialize(withConfig: inAppConfig)
+            let logger = DIGraphShared.shared.logger
             // Retrieves ReactInAppEventListener from DI graph, populated when it is accessed in React Native SDK.
             if let listener: InAppEventListener? = DIGraphShared.shared.getOverriddenInstance() {
+                logger.debug("[Expo][InApp] React InAppEventListener found in DI graph and set")
                 MessagingInApp.shared.setEventListener(listener)
+            } else {
+                logger.debug("[Expo][InApp] React InAppEventListener not found in DI graph, will be set by React Native module when accessed")
             }
         }
     }

--- a/__tests__/utils/__snapshots__/patchPluginNativeCode.test.ts.snap
+++ b/__tests__/utils/__snapshots__/patchPluginNativeCode.test.ts.snap
@@ -4,7 +4,6 @@ exports[`Native SDK Configuration Patching patchNativeSDKInitializer() snapshots
 "import CioDataPipelines
 import CioInternalCommon
 import CioMessagingInApp
-import customerio_reactnative
 
 class CustomerIOSDKInitializer {
     static func initialize() {
@@ -30,9 +29,12 @@ class CustomerIOSDKInitializer {
         CustomerIO.initialize(withConfig: builder.build())
 
         if let siteId = siteId {
-          let inAppConfig = MessagingInAppConfigBuilder(siteId: siteId, region: region).build()
-          MessagingInApp.initialize(withConfig: inAppConfig)
-          MessagingInApp.shared.setEventListener(ReactInAppEventListener.shared)
+            let inAppConfig = MessagingInAppConfigBuilder(siteId: siteId, region: region).build()
+            MessagingInApp.initialize(withConfig: inAppConfig)
+            // Retrieves ReactInAppEventListener from DI graph, populated when it is accessed in React Native SDK.
+            if let listener: InAppEventListener? = DIGraphShared.shared.getOverriddenInstance() {
+                MessagingInApp.shared.setEventListener(listener)
+            }
         }
     }
 
@@ -62,7 +64,6 @@ exports[`Native SDK Configuration Patching patchNativeSDKInitializer() snapshots
 "import CioDataPipelines
 import CioInternalCommon
 import CioMessagingInApp
-import customerio_reactnative
 
 class CustomerIOSDKInitializer {
     static func initialize() {
@@ -88,9 +89,12 @@ class CustomerIOSDKInitializer {
         CustomerIO.initialize(withConfig: builder.build())
 
         if let siteId = siteId {
-          let inAppConfig = MessagingInAppConfigBuilder(siteId: siteId, region: region).build()
-          MessagingInApp.initialize(withConfig: inAppConfig)
-          MessagingInApp.shared.setEventListener(ReactInAppEventListener.shared)
+            let inAppConfig = MessagingInAppConfigBuilder(siteId: siteId, region: region).build()
+            MessagingInApp.initialize(withConfig: inAppConfig)
+            // Retrieves ReactInAppEventListener from DI graph, populated when it is accessed in React Native SDK.
+            if let listener: InAppEventListener? = DIGraphShared.shared.getOverriddenInstance() {
+                MessagingInApp.shared.setEventListener(listener)
+            }
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "xcode": "^3.0.1"
       },
       "peerDependencies": {
-        "customerio-reactnative": "git+https://github.com/customerio/customerio-reactnative#deccbd9d38d30fad87cf28df0dcf7b24688826a6"
+        "customerio-reactnative": "4.8.2"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -6812,9 +6812,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "4.8.1",
-      "resolved": "git+ssh://git@github.com/customerio/customerio-reactnative.git#deccbd9d38d30fad87cf28df0dcf7b24688826a6",
-      "integrity": "sha512-lEf0LAYhUA2NSH7niu0kbzbnbO+BWnH0d26wUsJ5x5EAGvCQtsOxEmJOxlT/BTObrIc5POUeD5s/wgwf+aRBAA==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-4.8.2.tgz",
+      "integrity": "sha512-zjfWhuO/p52x4pfRxJyEWMIyjjC/X+8duA0BVZrLz0cu0NJfJWaUpV2Oreak4epAysRYFg1oC+OrwhIkeJIEIQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-expo-plugin",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-expo-plugin",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -34,7 +34,7 @@
         "xcode": "^3.0.1"
       },
       "peerDependencies": {
-        "customerio-reactnative": "4.8.0"
+        "customerio-reactnative": "git+https://github.com/customerio/customerio-reactnative#deccbd9d38d30fad87cf28df0dcf7b24688826a6"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -6812,9 +6812,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-4.8.0.tgz",
-      "integrity": "sha512-dszv9oVnKgpLMPqVpxw1H6CgWE0o2EMsa3+XEirwoy2+7nGeByoRIg1BfTdII1VfUovGb42l9Su0dqotcUo9Vg==",
+      "version": "4.8.1",
+      "resolved": "git+ssh://git@github.com/customerio/customerio-reactnative.git#deccbd9d38d30fad87cf28df0dcf7b24688826a6",
+      "integrity": "sha512-lEf0LAYhUA2NSH7niu0kbzbnbO+BWnH0d26wUsJ5x5EAGvCQtsOxEmJOxlT/BTObrIc5POUeD5s/wgwf+aRBAA==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "customerio-reactnative": "4.8.0"
+    "customerio-reactnative": "git+https://github.com/customerio/customerio-reactnative#deccbd9d38d30fad87cf28df0dcf7b24688826a6"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "customerio-reactnative": "git+https://github.com/customerio/customerio-reactnative#deccbd9d38d30fad87cf28df0dcf7b24688826a6"
+    "customerio-reactnative": "4.8.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/plugin/src/helpers/native-files/ios/CustomerIOSDKInitializer.swift
+++ b/plugin/src/helpers/native-files/ios/CustomerIOSDKInitializer.swift
@@ -28,9 +28,13 @@ class CustomerIOSDKInitializer {
         if let siteId = siteId {
             let inAppConfig = MessagingInAppConfigBuilder(siteId: siteId, region: region).build()
             MessagingInApp.initialize(withConfig: inAppConfig)
+            let logger = DIGraphShared.shared.logger
             // Retrieves ReactInAppEventListener from DI graph, populated when it is accessed in React Native SDK.
             if let listener: InAppEventListener? = DIGraphShared.shared.getOverriddenInstance() {
+                logger.debug("[Expo][InApp] React InAppEventListener found in DI graph and set")
                 MessagingInApp.shared.setEventListener(listener)
+            } else {
+                logger.debug("[Expo][InApp] React InAppEventListener not found in DI graph, will be set by React Native module when accessed")
             }
         }
     }

--- a/plugin/src/helpers/native-files/ios/CustomerIOSDKInitializer.swift
+++ b/plugin/src/helpers/native-files/ios/CustomerIOSDKInitializer.swift
@@ -1,7 +1,6 @@
 import CioDataPipelines
 import CioInternalCommon
 import CioMessagingInApp
-import customerio_reactnative
 
 class CustomerIOSDKInitializer {
     static func initialize() {
@@ -27,9 +26,12 @@ class CustomerIOSDKInitializer {
         CustomerIO.initialize(withConfig: builder.build())
 
         if let siteId = siteId {
-          let inAppConfig = MessagingInAppConfigBuilder(siteId: siteId, region: region).build()
-          MessagingInApp.initialize(withConfig: inAppConfig)
-          MessagingInApp.shared.setEventListener(ReactInAppEventListener.shared)
+            let inAppConfig = MessagingInAppConfigBuilder(siteId: siteId, region: region).build()
+            MessagingInApp.initialize(withConfig: inAppConfig)
+            // Retrieves ReactInAppEventListener from DI graph, populated when it is accessed in React Native SDK.
+            if let listener: InAppEventListener? = DIGraphShared.shared.getOverriddenInstance() {
+                MessagingInApp.shared.setEventListener(listener)
+            }
         }
     }
 

--- a/scripts/compatibility/configure-plugin.js
+++ b/scripts/compatibility/configure-plugin.js
@@ -125,6 +125,7 @@ function execute() {
       Object.assign(cioPluginConfig, {
         config: {
           ...envConfig,
+          siteId: "dummy-site-id",
         },
         android: androidConfig,
         ios: baseIosConfig,

--- a/test-app/helpers/InAppMessagingListener.js
+++ b/test-app/helpers/InAppMessagingListener.js
@@ -1,22 +1,59 @@
 import { CustomerIO, InAppMessageEventType } from 'customerio-reactnative';
 
 export function registerInAppMessagingEventListener() {
-  CustomerIO.inAppMessaging.registerEventsListener((event) => {
+  const logInAppEvent = (name, params) => {
+    console.log(`[ExpoInAppEventListener] onEventReceived: ${name}, params: `, params);
+  };
+
+  const onInAppEventReceived = (eventName, eventParams) => {
+    logInAppEvent(eventName, eventParams);
+
+    const { deliveryId, messageId, actionValue, actionName } = eventParams;
+    const data = {
+      'event-name': eventName,
+      'delivery-id': deliveryId ?? 'NULL',
+      'message-id': messageId ?? 'NULL'
+    };
+    if (actionName) {
+      data['action-name'] = actionName;
+    }
+    if (actionValue) {
+      data['action-value'] = actionValue;
+    }
+
+    CustomerIO.track('ExpoInAppEventListener', data);
+  };
+
+  const inAppMessagingSDK = CustomerIO.inAppMessaging;
+  const inAppEventListener = inAppMessagingSDK.registerEventsListener((event) => {
     switch (event.eventType) {
       case InAppMessageEventType.messageShown:
-        console.log('EXPO-TEST: In App message shown');
+        onInAppEventReceived('messageShown', event);
         break;
+
       case InAppMessageEventType.messageDismissed:
-        console.log('EXPO-TEST: In App message dismissed');
+        onInAppEventReceived('messageDismissed', event);
         break;
+
       case InAppMessageEventType.errorWithMessage:
-        console.log('EXPO-TEST: In App error showing message');
+        onInAppEventReceived('errorWithMessage', event);
         break;
+
       case InAppMessageEventType.messageActionTaken:
-        console.log(
-          'EXPO-TEST: Message action taken'
-        );
+        onInAppEventReceived('messageActionTaken', event);
+        // Dismiss in app message if the action is 'dismiss' or 'close'
+        if (event.actionValue === 'dismiss' || event.actionValue === 'close') {
+          inAppMessagingSDK.dismissMessage();
+        }
         break;
+
+      default:
+        onInAppEventReceived('unsupported event', event);
     }
   });
+
+  // Remove listener once unmounted
+  return () => {
+    inAppEventListener.remove();
+  };
 }

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -13,7 +13,7 @@
         "@react-navigation/native": "^7.1.6",
         "@react-navigation/stack": "^7.2.8",
         "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-        "customerio-reactnative": "git+https://github.com/customerio/customerio-reactnative#deccbd9d38d30fad87cf28df0dcf7b24688826a6",
+        "customerio-reactnative": "^4.8.2",
         "dotenv": "^16.4.7",
         "expo": "~53.0.9",
         "expo-build-properties": "~0.14.6",
@@ -3892,7 +3892,7 @@
     "node_modules/customerio-expo-plugin": {
       "version": "2.7.0",
       "resolved": "file:../customerio-expo-plugin-latest.tgz",
-      "integrity": "sha512-JbAEzdf0kCQyS/XdG9aMKuWptjueLUraG+4/Fvthx8P4Juv+WzSj9QlMXNa4QQFZajKPyD/Uh7uiPTMyPt19DA==",
+      "integrity": "sha512-6PU9dYAZcOL0vOFvbnZ0tt2ho1XY3ta9ynkgfxQ+Fo3qyU05E6IP6qSy0FhkEYfASlxGHzUukyDHVQH4fZmowA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3901,7 +3901,7 @@
         "semver": "^7.7.2"
       },
       "peerDependencies": {
-        "customerio-reactnative": "git+https://github.com/customerio/customerio-reactnative#deccbd9d38d30fad87cf28df0dcf7b24688826a6"
+        "customerio-reactnative": "4.8.2"
       }
     },
     "node_modules/customerio-expo-plugin/node_modules/semver": {
@@ -3917,9 +3917,9 @@
       }
     },
     "node_modules/customerio-reactnative": {
-      "version": "4.8.1",
-      "resolved": "git+ssh://git@github.com/customerio/customerio-reactnative.git#deccbd9d38d30fad87cf28df0dcf7b24688826a6",
-      "integrity": "sha512-lEf0LAYhUA2NSH7niu0kbzbnbO+BWnH0d26wUsJ5x5EAGvCQtsOxEmJOxlT/BTObrIc5POUeD5s/wgwf+aRBAA==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-4.8.2.tgz",
+      "integrity": "sha512-zjfWhuO/p52x4pfRxJyEWMIyjjC/X+8duA0BVZrLz0cu0NJfJWaUpV2Oreak4epAysRYFg1oC+OrwhIkeJIEIQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -13,7 +13,7 @@
         "@react-navigation/native": "^7.1.6",
         "@react-navigation/stack": "^7.2.8",
         "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-        "customerio-reactnative": "^4.8.0",
+        "customerio-reactnative": "git+https://github.com/customerio/customerio-reactnative#deccbd9d38d30fad87cf28df0dcf7b24688826a6",
         "dotenv": "^16.4.7",
         "expo": "~53.0.9",
         "expo-build-properties": "~0.14.6",
@@ -3890,9 +3890,9 @@
       }
     },
     "node_modules/customerio-expo-plugin": {
-      "version": "2.6.0",
+      "version": "2.7.0",
       "resolved": "file:../customerio-expo-plugin-latest.tgz",
-      "integrity": "sha512-llNATbrWrLmjJTA5eFmF/lJZ3GmcMn/63sbf2n1qRbzz/fUBEArFRU+Q8zqJ3nhKjTddC37lYlMGHft/WaNPXw==",
+      "integrity": "sha512-JbAEzdf0kCQyS/XdG9aMKuWptjueLUraG+4/Fvthx8P4Juv+WzSj9QlMXNa4QQFZajKPyD/Uh7uiPTMyPt19DA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3901,7 +3901,7 @@
         "semver": "^7.7.2"
       },
       "peerDependencies": {
-        "customerio-reactnative": "4.8.0"
+        "customerio-reactnative": "git+https://github.com/customerio/customerio-reactnative#deccbd9d38d30fad87cf28df0dcf7b24688826a6"
       }
     },
     "node_modules/customerio-expo-plugin/node_modules/semver": {
@@ -3917,9 +3917,9 @@
       }
     },
     "node_modules/customerio-reactnative": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-4.8.0.tgz",
-      "integrity": "sha512-dszv9oVnKgpLMPqVpxw1H6CgWE0o2EMsa3+XEirwoy2+7nGeByoRIg1BfTdII1VfUovGb42l9Su0dqotcUo9Vg==",
+      "version": "4.8.1",
+      "resolved": "git+ssh://git@github.com/customerio/customerio-reactnative.git#deccbd9d38d30fad87cf28df0dcf7b24688826a6",
+      "integrity": "sha512-lEf0LAYhUA2NSH7niu0kbzbnbO+BWnH0d26wUsJ5x5EAGvCQtsOxEmJOxlT/BTObrIc5POUeD5s/wgwf+aRBAA==",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -14,7 +14,7 @@
     "@react-navigation/native": "^7.1.6",
     "@react-navigation/stack": "^7.2.8",
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "git+https://github.com/customerio/customerio-reactnative#deccbd9d38d30fad87cf28df0dcf7b24688826a6",
+    "customerio-reactnative": "^4.8.2",
     "dotenv": "^16.4.7",
     "expo": "~53.0.9",
     "expo-build-properties": "~0.14.6",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -14,7 +14,7 @@
     "@react-navigation/native": "^7.1.6",
     "@react-navigation/stack": "^7.2.8",
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^4.8.0",
+    "customerio-reactnative": "git+https://github.com/customerio/customerio-reactnative#deccbd9d38d30fad87cf28df0dcf7b24688826a6",
     "dotenv": "^16.4.7",
     "expo": "~53.0.9",
     "expo-build-properties": "~0.14.6",

--- a/test-app/screens/Dashboard.js
+++ b/test-app/screens/Dashboard.js
@@ -13,7 +13,7 @@ import SendEventModal from './SendEventModal';
 
 export default function DashboardScreen({ navigation }) {
   useEffect(() => {
-    registerInAppMessagingEventListener();
+    return registerInAppMessagingEventListener();
   }, []);
 
   const [loginModalVisible, seLoginModalVisible] = useState(false);


### PR DESCRIPTION
part of: [MBL-1366](https://linear.app/customerio/issue/MBL-1366/fix-or-remove-react-native-ios-import-dependency-from-expo-plugin-auto)

### Summary

Resolves compatibility issues caused by importing React Native SDK header (`import customerio_reactnative`) in iOS environment. This change removes the need for importing the header entirely by relying on shared dependency graph and improved event listener setup logic in React Native SDK.

### Changes

- Handled the case where React Native in app event listener is loaded early (before the SDK is initialized):
  - Native initializer retrieves the listener from shared DI graph and sets it directly during SDK initialization
- For more common case where the event listener is loaded later (after UI is ready):
  - React Native SDK sets the listener during its in app module `initialize()` call
- Removed iOS side import of React Native SDK header (`import customerio_reactnative`) eliminating iOS compatibility issues
- Updated compatibility test to include `siteId` to fully exercise auto initialization behavior
- Updated sample app's in app event listener to emit events to Fly for easier testing

### Testing

- Confirmed in app events work across both manual and auto initialization

### Notes

- No breaking changes
- Requires React Native SDK changes: https://github.com/customerio/customerio-reactnative/pull/513
- Temporary branch references in `package.json` will be removed once React Native SDK update is released