### PR TITLE
chore: add logger util

### DIFF
--- a/__tests__/utils/config.test.ts
+++ b/__tests__/utils/config.test.ts
@@ -19,7 +19,7 @@ describe('mergeConfigWithEnvValues - Resolves conflicts between legacy env confi
   describe('when both environment and native configs are provided', () => {
     test('should throw error when configs have conflicting values', () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-      
+
       const props: CustomerIOPluginOptionsIOS = {
         ...mockIosProps,
         pushNotification: {
@@ -37,7 +37,7 @@ describe('mergeConfigWithEnvValues - Resolves conflicts between legacy env confi
 
     test('should warn and return config when both configs have matching values', () => {
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
-      
+
       const matchingEnvConfig = {
         cdpApiKey: 'same-api-key',
         region: 'EU',
@@ -63,7 +63,7 @@ describe('mergeConfigWithEnvValues - Resolves conflicts between legacy env confi
       });
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        'Both \'config\' and \'ios.pushNotification.env\' are provided with matching values. Consider removing \'ios.pushNotification.env\' since \'config\' is already specified.'
+        '[CustomerIO] Both \'config\' and \'ios.pushNotification.env\' are provided with matching values. Consider removing \'ios.pushNotification.env\' since \'config\' is already specified.'
       );
 
       consoleSpy.mockRestore();
@@ -71,7 +71,7 @@ describe('mergeConfigWithEnvValues - Resolves conflicts between legacy env confi
 
     test('should allow case-insensitive region matching', () => {
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
-      
+
       const envWithLowerCase = {
         cdpApiKey: 'same-api-key',
         region: 'us',
@@ -97,7 +97,7 @@ describe('mergeConfigWithEnvValues - Resolves conflicts between legacy env confi
       });
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        'Both \'config\' and \'ios.pushNotification.env\' are provided with matching values. Consider removing \'ios.pushNotification.env\' since \'config\' is already specified.'
+        '[CustomerIO] Both \'config\' and \'ios.pushNotification.env\' are provided with matching values. Consider removing \'ios.pushNotification.env\' since \'config\' is already specified.'
       );
 
       consoleSpy.mockRestore();

--- a/plugin/src/android/withAndroidManifestUpdates.ts
+++ b/plugin/src/android/withAndroidManifestUpdates.ts
@@ -3,6 +3,7 @@ import { withAndroidManifest } from '@expo/config-plugins';
 import type { ManifestApplication } from '@expo/config-plugins/build/android/Manifest';
 
 import type { CustomerIOPluginOptionsAndroid } from '../types/cio-types';
+import { logger } from '../utils/logger';
 
 // Default low priority for Firebase messaging service when setHighPriorityPushHandler is false
 export const DEFAULT_LOW_PRIORITY = -10;
@@ -41,7 +42,7 @@ export const withAndroidManifestUpdates: ConfigPlugin<
       // Handle priority based on setHighPriorityPushHandler value
       if (options.setHighPriorityPushHandler === true) {
         // High priority - no priority attribute means default high priority
-        console.log(
+        logger.info(
           'Successfully set CustomerIO push handler as high priority in AndroidManifest.xml'
         );
       } else if (options.setHighPriorityPushHandler === false) {
@@ -49,7 +50,7 @@ export const withAndroidManifestUpdates: ConfigPlugin<
         intentFilter.$ = {
           'android:priority': DEFAULT_LOW_PRIORITY.toString(),
         };
-        console.log(
+        logger.info(
           `Successfully set CustomerIO push handler as low priority (${DEFAULT_LOW_PRIORITY}) in AndroidManifest.xml`
         );
       }
@@ -70,7 +71,7 @@ export const withAndroidManifestUpdates: ConfigPlugin<
         const intentFilter = existingService['intent-filter'][0] as any;
         if (intentFilter.$ && intentFilter.$['android:priority']) {
           delete intentFilter.$['android:priority'];
-          console.log(
+          logger.info(
             'Successfully updated existing CustomerIO push handler to high priority in AndroidManifest.xml'
           );
         }
@@ -87,7 +88,7 @@ export const withAndroidManifestUpdates: ConfigPlugin<
           intentFilter.$ = {};
         }
         intentFilter.$['android:priority'] = DEFAULT_LOW_PRIORITY.toString();
-        console.log(
+        logger.info(
           `Successfully updated existing CustomerIO push handler to low priority (${DEFAULT_LOW_PRIORITY}) in AndroidManifest.xml`
         );
       }

--- a/plugin/src/android/withAppGoogleServices.ts
+++ b/plugin/src/android/withAppGoogleServices.ts
@@ -6,6 +6,7 @@ import {
   CIO_APP_GOOGLE_SNIPPET,
 } from '../helpers/constants/android';
 import type { CustomerIOPluginOptionsAndroid } from '../types/cio-types';
+import { logger } from '../utils/logger';
 
 export const withAppGoogleServices: ConfigPlugin<
   CustomerIOPluginOptionsAndroid
@@ -19,7 +20,7 @@ export const withAppGoogleServices: ConfigPlugin<
         `$1\n${CIO_APP_GOOGLE_SNIPPET}`
       );
     } else {
-      console.log('app/build.gradle snippet already exists. Skipping...');
+      logger.info('app/build.gradle snippet already exists. Skipping...');
     }
 
     return props;

--- a/plugin/src/android/withGistMavenRepository.ts
+++ b/plugin/src/android/withGistMavenRepository.ts
@@ -1,11 +1,12 @@
-import { withProjectBuildGradle } from '@expo/config-plugins';
 import type { ConfigPlugin } from '@expo/config-plugins';
+import { withProjectBuildGradle } from '@expo/config-plugins';
 
 import {
   CIO_GIST_MAVEN_REGEX,
   CIO_PROJECT_ALLPROJECTS_REGEX,
   CIO_PROJECT_GIST_MAVEN_SNIPPET,
 } from '../helpers/constants/android';
+import { logger } from '../utils/logger';
 import type { CustomerIOPluginOptionsAndroid } from './../types/cio-types';
 
 export const withGistMavenRepository: ConfigPlugin<
@@ -19,7 +20,7 @@ export const withGistMavenRepository: ConfigPlugin<
         `$1\n${CIO_PROJECT_GIST_MAVEN_SNIPPET}`
       );
     } else {
-      console.log('build.gradle snippet alreade exists. Skipping...');
+      logger.info('build.gradle snippet already exists. Skipping...');
     }
 
     return props;

--- a/plugin/src/android/withGoogleServicesJSON.ts
+++ b/plugin/src/android/withGoogleServicesJSON.ts
@@ -1,6 +1,7 @@
 import type { ConfigPlugin } from '@expo/config-plugins';
 import { withProjectBuildGradle } from '@expo/config-plugins';
 
+import { logger } from '../utils/logger';
 import { FileManagement } from './../helpers/utils/fileManagement';
 import type { CustomerIOPluginOptionsAndroid } from './../types/cio-types';
 
@@ -21,17 +22,17 @@ export const withGoogleServicesJSON: ConfigPlugin<
             `${androidPath}/app/google-services.json`
           );
         } catch {
-          console.log(
+          logger.info(
             `There was an error copying your google-services.json file. You can copy it manually into ${androidPath}/app/google-services.json`
           );
         }
       } else {
-        console.log(
+        logger.info(
           `The Google Services file provided in ${googleServicesFile} doesn't seem to exist. You can copy it manually into ${androidPath}/app/google-services.json`
         );
       }
     } else {
-      console.log(
+      logger.info(
         `File already exists: ${androidPath}/app/google-services.json. Skipping...`
       );
     }

--- a/plugin/src/android/withMainApplicationModifications.ts
+++ b/plugin/src/android/withMainApplicationModifications.ts
@@ -6,6 +6,7 @@ import { PLATFORM } from '../helpers/constants/common';
 import { patchNativeSDKInitializer } from '../helpers/utils/patchPluginNativeCode';
 import type { NativeSDKConfig } from '../types/cio-types';
 import { addCodeToMethod, addImportToFile, copyTemplateFile } from '../utils/android';
+import { logger } from '../utils/logger';
 
 export const withMainApplicationModifications: ConfigPlugin<NativeSDKConfig> = (configOuter, sdkConfig) => {
   return withMainApplication(configOuter, async (config) => {
@@ -42,7 +43,7 @@ const setupCustomerIOSDKInitializer = (
       content = addCodeToMethod(content, CIO_MAINAPPLICATION_ONCREATE_REGEX, CIO_NATIVE_SDK_INITIALIZE_SNIPPET);
     }
   } catch (error) {
-    console.warn(`Could not setup ${SDK_INITIALIZER_CLASS}:`, error);
+    logger.warn(`Could not setup ${SDK_INITIALIZER_CLASS}:`, error);
     return config.modResults.contents;
   }
 

--- a/plugin/src/helpers/utils/fileManagement.ts
+++ b/plugin/src/helpers/utils/fileManagement.ts
@@ -1,14 +1,15 @@
-import {
-  readFile,
-  writeFile,
-  appendFile,
-  existsSync,
-  copyFileSync,
-  mkdirSync,
-  writeFileSync,
-  readFileSync,
-} from 'fs';
 import type { MakeDirectoryOptions } from 'fs';
+import {
+  appendFile,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFile,
+  readFileSync,
+  writeFile,
+  writeFileSync,
+} from 'fs';
+import { logger } from '../../utils/logger';
 
 export class FileManagement {
   static async read(path: string): Promise<string> {
@@ -55,7 +56,7 @@ export class FileManagement {
     try {
       copyFileSync(src, dest);
     } catch (err) {
-      console.log(`Error copying file from ${src} to ${dest}: `, err);
+      logger.error(`Error copying file from ${src} to ${dest}: `, err);
     }
   }
 
@@ -63,7 +64,7 @@ export class FileManagement {
     try {
       mkdirSync(path, options);
     } catch (err) {
-      console.log(`Error creating directory ${path}: `, err);
+      logger.error(`Error creating directory ${path}: `, err);
     }
   }
 
@@ -71,7 +72,7 @@ export class FileManagement {
     try {
       writeFileSync(path, data);
     } catch (err) {
-      console.log(`Error writing to file ${path}: `, err);
+      logger.error(`Error writing to file ${path}: `, err);
     }
   }
 
@@ -79,7 +80,7 @@ export class FileManagement {
     try {
       return readFileSync(path, 'utf-8');
     } catch (err) {
-      console.log(`Error reading file ${path}: `, err);
+      logger.error(`Error reading file ${path}: `, err);
     }
 
     return '';

--- a/plugin/src/helpers/utils/injectCIOPodfileCode.ts
+++ b/plugin/src/helpers/utils/injectCIOPodfileCode.ts
@@ -1,4 +1,5 @@
 import type { CustomerIOPluginOptionsIOS } from '../../types/cio-types';
+import { logger } from '../../utils/logger';
 import { getRelativePathToRNSDK } from '../constants/ios';
 import { injectCodeByRegex } from './codeInjection';
 import { FileManagement } from './fileManagement';
@@ -36,7 +37,7 @@ ${blockEnd}
       ).join('\n')
     );
   } else {
-    console.log('CustomerIO Podfile snippets already exists. Skipping...');
+    logger.info('CustomerIO Podfile snippets already exists. Skipping...');
   }
 }
 

--- a/plugin/src/ios/withAppDelegateModifications.ts
+++ b/plugin/src/ios/withAppDelegateModifications.ts
@@ -32,6 +32,7 @@ import {
 } from '../helpers/utils/codeInjection';
 import { FileManagement } from '../helpers/utils/fileManagement';
 import type { CustomerIOPluginOptionsIOS } from '../types/cio-types';
+import { logger } from '../utils/logger';
 import { isFcmPushProvider } from './utils';
 
 const addImport = (stringContents: string, appName: string) => {
@@ -268,7 +269,7 @@ export const withAppDelegateModifications: ConfigPlugin<
 
       config.modResults.contents = stringContents;
     } else {
-      console.log('Customerio AppDelegate changes already exist. Skipping...');
+      logger.info('Customerio AppDelegate changes already exist. Skipping...');
     }
 
     return config;

--- a/plugin/src/ios/withCIOIos.ts
+++ b/plugin/src/ios/withCIOIos.ts
@@ -6,6 +6,7 @@ import type {
   NativeSDKConfig,
 } from '../types/cio-types';
 import { mergeConfigWithEnvValues } from '../utils/config';
+import { logger } from '../utils/logger';
 import { isExpoVersion53OrHigher } from './utils';
 import { withAppDelegateModifications } from './withAppDelegateModifications';
 import { withCIOIosSwift } from './withCIOIosSwift';
@@ -68,7 +69,7 @@ const mergeDeprecatedPropertiesAndLogWarnings = (
   // loop over all the deprecated properties and log a warning if they are set
   Object.entries(deprecatedTopLevelProperties).forEach(([key, value]) => {
     if (value !== undefined) {
-      console.warn(
+      logger.warn(
         `The ios.${key} property is deprecated. Please use ios.pushNotification.${key} instead.`
       );
 
@@ -82,7 +83,7 @@ const mergeDeprecatedPropertiesAndLogWarnings = (
           [propKey]: value,
         };
       } else {
-        console.warn(
+        logger.warn(
           `The ios.${key} property is deprecated. Since the value of ios.pushNotification.${key} is set, it will be used.`
         );
       }

--- a/plugin/src/ios/withCIOIosSwift.ts
+++ b/plugin/src/ios/withCIOIosSwift.ts
@@ -18,6 +18,7 @@ import { replaceCodeByRegex } from '../helpers/utils/codeInjection';
 import { FileManagement } from '../helpers/utils/fileManagement';
 import { patchNativeSDKInitializer } from '../helpers/utils/patchPluginNativeCode';
 import type { CustomerIOPluginOptionsIOS, NativeSDKConfig } from '../types/cio-types';
+import { logger } from '../utils/logger';
 import { getIosNativeFilesPath } from '../utils/plugin';
 import { copyFileToXcode, getOrCreateCustomerIOGroup } from '../utils/xcode';
 import { isFcmPushProvider } from './utils';
@@ -37,7 +38,7 @@ const copyAndConfigureAppDelegateHandler = (
   // Destination path in the iOS project
   const projectName = config.modRequest.projectName || '';
   if (!projectName) {
-    console.warn(
+    logger.warn(
       'Project name is undefined, cannot copy CustomerIO files'
     );
     return config;
@@ -230,7 +231,7 @@ const modifyAppDelegateWithPushAppDelegateHandler = (
 
   // Check if modifications have already been applied
   if (appDelegateContent.includes(CIO_SDK_APP_DELEGATE_HANDLER_CLASS)) {
-    console.log(
+    logger.info(
       'CustomerIO Swift AppDelegate changes already exist. Skipping...'
     );
     return config;
@@ -274,7 +275,7 @@ const modifyAppDelegateWithNativeSDKInitializer = (
 
   // Check if modifications have already been applied
   if (appDelegateContent.includes(CIO_NATIVE_SDK_INITIALIZE_CALL)) {
-    console.log(
+    logger.info(
       'CustomerIO Swift AppDelegate changes already exist. Skipping...'
     );
     return config;
@@ -314,7 +315,7 @@ const addHandlerPropertyDeclaration = (content: string): string => {
   const match = content.match(classDeclarationRegex);
 
   if (!match) {
-    console.warn('Could not find AppDelegate class declaration');
+    logger.warn('Could not find AppDelegate class declaration');
     return content;
   }
 
@@ -339,7 +340,7 @@ const modifyDidFinishLaunchingWithOptions = (content: string, codeToInject: stri
   const returnStatementMatch = content.match(returnStatementRegex);
 
   if (!returnStatementMatch) {
-    console.warn(
+    logger.warn(
       'Could not find return statement with super.application in didFinishLaunchingWithOptions'
     );
     return content;
@@ -394,7 +395,7 @@ const addDidRegisterForRemoteNotificationsWithDeviceToken = (
     const classEndMatch = content.match(classEndRegex);
 
     if (!classEndMatch) {
-      console.warn('Could not find end of AppDelegate class');
+      logger.warn('Could not find end of AppDelegate class');
       return content;
     }
 
@@ -452,7 +453,7 @@ const addDidFailToRegisterForRemoteNotificationsWithError = (
     const classEndMatch = content.match(classEndRegex);
 
     if (!classEndMatch) {
-      console.warn('Could not find end of AppDelegate class');
+      logger.warn('Could not find end of AppDelegate class');
       return content;
     }
 
@@ -489,7 +490,7 @@ const addHandleDeeplinkInKilledState = (content: string): string => {
   const returnStatementMatch = content.match(returnStatementRegex);
 
   if (!returnStatementMatch) {
-    console.warn('Could not find return statement with launchOptions');
+    logger.warn('Could not find return statement with launchOptions');
     return content;
   }
 

--- a/plugin/src/ios/withGoogleServicesJsonFile.ts
+++ b/plugin/src/ios/withGoogleServicesJsonFile.ts
@@ -2,6 +2,7 @@ import type { ConfigPlugin, XcodeProject } from '@expo/config-plugins';
 import { IOSConfig, withXcodeProject } from '@expo/config-plugins';
 
 import type { CustomerIOPluginOptionsIOS } from '../types/cio-types';
+import { logger } from '../utils/logger';
 import { FileManagement } from './../helpers/utils/fileManagement';
 import { isFcmPushProvider } from './utils';
 
@@ -15,7 +16,7 @@ export const withGoogleServicesJsonFile: ConfigPlugin<
       return props;
     }
 
-    console.log(
+    logger.info(
       'Only specify Customer.io ios.pushNotification.googleServicesFile config if you are not already including' +
       ' GoogleService-Info.plist as part of Firebase integration'
     );
@@ -26,7 +27,7 @@ export const withGoogleServicesJsonFile: ConfigPlugin<
     const appName = props.modRequest.projectName;
 
     if (FileManagement.exists(`${iosPath}/GoogleService-Info.plist`)) {
-      console.log(
+      logger.info(
         `File already exists: ${iosPath}/GoogleService-Info.plist. Skipping...`
       );
       return props;
@@ -37,7 +38,7 @@ export const withGoogleServicesJsonFile: ConfigPlugin<
     ) {
       // This is where RN Firebase potentially copies GoogleService-Info.plist
       // Do not copy if it's already done by Firebase to avoid conflict in Resources
-      console.log(
+      logger.info(
         `File already exists: ${iosPath}/${appName}/GoogleService-Info.plist. Skipping...`
       );
       return props;
@@ -45,7 +46,7 @@ export const withGoogleServicesJsonFile: ConfigPlugin<
 
     if (googleServicesFile && FileManagement.exists(googleServicesFile)) {
       if (config.ios?.googleServicesFile) {
-        console.warn(
+        logger.warn(
           'Specifying both Expo ios.googleServicesFile and Customer.io ios.pushNotification.googleServicesFile can cause a conflict' +
           ' duplicating GoogleService-Info.plist in the iOS project resources. Please remove Customer.io ios.pushNotification.googleServicesFile'
         );
@@ -59,12 +60,12 @@ export const withGoogleServicesJsonFile: ConfigPlugin<
 
         addFileToXcodeProject(props.modResults, 'GoogleService-Info.plist');
       } catch {
-        console.error(
+        logger.error(
           `There was an error copying your GoogleService-Info.plist file. You can copy it manually into ${iosPath}/GoogleService-Info.plist`
         );
       }
     } else {
-      console.error(
+      logger.error(
         `The Google Services file provided in ${googleServicesFile} doesn't seem to exist. You can copy it manually into ${iosPath}/GoogleService-Info.plist`
       );
     }
@@ -78,7 +79,7 @@ function addFileToXcodeProject(project: XcodeProject, fileName: string) {
   const filepath = fileName;
 
   if (!IOSConfig.XcodeUtils.ensureGroupRecursively(project, groupName)) {
-    console.error(
+    logger.error(
       `Error copying GoogleService-Info.plist. Failed to find or create '${groupName}' group in Xcode.`
     );
     return;

--- a/plugin/src/ios/withNotificationsXcodeProject.ts
+++ b/plugin/src/ios/withNotificationsXcodeProject.ts
@@ -9,6 +9,7 @@ import {
 import { replaceCodeByRegex } from '../helpers/utils/codeInjection';
 import { injectCIONotificationPodfileCode } from '../helpers/utils/injectCIOPodfileCode';
 import type { CustomerIOPluginOptionsIOS, RichPushConfig } from '../types/cio-types';
+import { logger } from '../utils/logger';
 import { getIosNativeFilesPath } from '../utils/plugin';
 import { FileManagement } from './../helpers/utils/fileManagement';
 import { isExpoVersion53OrHigher, isFcmPushProvider } from './utils';
@@ -34,7 +35,7 @@ const addNotificationServiceExtension = async (
     }
     return xcodeProject;
   } catch (error: unknown) {
-    console.error(error);
+    logger.error(String(error));
     return null;
   }
 };
@@ -120,7 +121,7 @@ const addRichPushXcodeProj = async (
   // Check if `CIO_NOTIFICATION_TARGET_NAME` group already exist in the project
   // If true then skip creating a new group to avoid duplicate folders
   if (xcodeProject.pbxTargetByName(CIO_NOTIFICATION_TARGET_NAME)) {
-    console.warn(
+    logger.warn(
       `${CIO_NOTIFICATION_TARGET_NAME} already exists in project. Skipping...`
     );
     return;
@@ -194,7 +195,7 @@ const addRichPushXcodeProj = async (
   projObjects.PBXContainerItemProxy = projObjects.PBXTargetDependency || {};
 
   if (xcodeProject.pbxTargetByName(CIO_NOTIFICATION_TARGET_NAME)) {
-    console.warn(
+    logger.warn(
       `${CIO_NOTIFICATION_TARGET_NAME} already exists in project. Skipping...`
     );
     return;
@@ -314,7 +315,7 @@ const updateNseEnv = (
     const mappedRegion =
       regionMap[region.toLowerCase() as keyof typeof regionMap] || '';
     if (!mappedRegion) {
-      console.warn(
+      logger.warn(
         `${region} is an invalid region. Please use the values from the docs: https://customer.io/docs/sdk/expo/getting-started/#configure-the-plugin`
       );
     } else {
@@ -355,7 +356,7 @@ async function addPushNotificationFile(
       targetFile
     );
   } else {
-    console.log(`${getTargetFile(targetFileName)} already exists. Skipping...`);
+    logger.info(`${getTargetFile(targetFileName)} already exists. Skipping...`);
     return;
   }
 

--- a/plugin/src/utils/android.ts
+++ b/plugin/src/utils/android.ts
@@ -2,6 +2,7 @@ import type { ExportedConfigWithProps } from '@expo/config-plugins';
 import type { ApplicationProjectFile } from '@expo/config-plugins/build/android/Paths';
 import path from 'path';
 import { FileManagement } from '../helpers/utils/fileManagement';
+import { logger } from './logger';
 import { getAndroidNativeFilesPath } from './plugin';
 
 // Generic utility to add import to Kotlin files
@@ -106,7 +107,7 @@ export const copyTemplateFile = (
     const destinationPath = path.join(packagePath, filename);
     FileManagement.writeFile(destinationPath, content);
   } catch (error) {
-    console.warn(`Failed to copy ${filename} to Android project:`, error);
+    logger.warn(`Failed to copy ${filename} to Android project:`, error);
     throw error;
   }
 };

--- a/plugin/src/utils/config.ts
+++ b/plugin/src/utils/config.ts
@@ -1,4 +1,5 @@
 import type { CustomerIOPluginOptionsIOS, NativeSDKConfig, RichPushConfig } from '../types/cio-types';
+import { logger } from './logger';
 
 /**
  * Merges config values with env values for backward compatibility.
@@ -25,12 +26,12 @@ function mergeConfigWithEnvValues(
         `  config.region: "${nativeRegion}"\n` +
         `  env.region: "${envRegion}"`;
 
-      console.error(errorMessage);
+      logger.error(errorMessage);
       throw new Error(errorMessage);
     }
 
     // Values match - warn about redundant configuration
-    console.warn(
+    logger.warn(
       `Both 'config' and 'ios.pushNotification.env' are provided with matching values. ` +
       `Consider removing 'ios.pushNotification.env' since 'config' is already specified.`
     );

--- a/plugin/src/utils/logger.ts
+++ b/plugin/src/utils/logger.ts
@@ -1,0 +1,37 @@
+// Use CUSTOMERIO_DEBUG_MODE if defined; otherwise enable in development mode only
+const VERBOSE_MODE =
+  process.env.CUSTOMERIO_DEBUG_MODE !== undefined
+    ? process.env.CUSTOMERIO_DEBUG_MODE === 'true'
+    : process.env.NODE_ENV === 'development';
+const PREFIX = '[CustomerIO]';
+const formatMessage = (message: string): string => `${PREFIX} ${message}`;
+
+export const logger = {
+  format: formatMessage,
+
+  error: (message: string, ...args: unknown[]): void => {
+    console.error(formatMessage(message), ...args);
+  },
+
+  warn: (message: string, ...args: unknown[]): void => {
+    console.warn(formatMessage(message), ...args);
+  },
+
+  info: (message: string, ...args: unknown[]): void => {
+    if (VERBOSE_MODE) {
+      console.info(formatMessage(message), ...args);
+    }
+  },
+
+  log: (message: string, ...args: unknown[]): void => {
+    if (VERBOSE_MODE) {
+      console.log(formatMessage(message), ...args);
+    }
+  },
+
+  debug: (message: string, ...args: unknown[]): void => {
+    if (VERBOSE_MODE) {
+      console.debug(formatMessage(message), ...args);
+    }
+  }
+};

--- a/plugin/src/utils/xcode.ts
+++ b/plugin/src/utils/xcode.ts
@@ -1,6 +1,7 @@
 import type { XcodeProject } from "@expo/config-plugins";
 import path from 'path';
 import { FileManagement } from "../helpers/utils/fileManagement";
+import { logger } from './logger';
 
 /**
  * Gets an existing CustomerIO group or creates a new one in the Xcode project
@@ -68,7 +69,7 @@ export function copyFileToXcode({
     xcodeProject.addSourceFile(`${projectName}/${targetFileName}`, null, customerIOGroup);
     return destinationPath;
   } catch (error) {
-    console.warn(`Failed to add ${targetFileName} to Xcode project:`, error);
+    logger.warn(`Failed to add ${targetFileName} to Xcode project:`, error);
     throw error;
   }
 }


### PR DESCRIPTION
part of: [MBL-1370](https://linear.app/customerio/issue/MBL-1370/make-expo-plugin-config-validation-lenient-for-eas-compatibility)

### Summary

Refactored all logging logic into a centralized utility for consistent usage, easier formatting, and improved maintainability across the plugin.

### Changes

- Moved all `console.log`, `console.warn`, etc. calls into a new unified logger utility file
- Logger now exposes standardized methods such as `logger.warn()` and `logger.format()` to streamline usage
- Updated all plugin logs to use this new utility
- Refactored and updated related tests to reflect the logger usage

### Notes

- No changes to plugin behavior