### PR TITLE
fix: typescript and test script cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
   },
   "eslintIgnore": [
     "node_modules/",
-    "plugin/lib/"
+    "plugin/lib/",
+    "ci-test-apps/"
   ],
   "prettier": {
     "quoteProps": "consistent",

--- a/plugin/src/android/withCIOAndroid.ts
+++ b/plugin/src/android/withCIOAndroid.ts
@@ -12,11 +12,11 @@ import { withProjectStrings } from './withProjectStrings';
 
 export function withCIOAndroid(
   config: ExpoConfig,
-  sdkConfig: NativeSDKConfig | undefined,
-  props?: CustomerIOPluginOptionsAndroid
+  sdkConfig?: NativeSDKConfig,
+  props?: CustomerIOPluginOptionsAndroid,
 ): ExpoConfig {
   // Only run notification setup if props are provided
-  if(props) {
+  if (props) {
     config = withGistMavenRepository(config, props);
     config = withProjectGoogleServices(config, props);
     config = withAppGoogleServices(config, props);
@@ -34,6 +34,7 @@ export function withCIOAndroid(
     config = withMainApplicationModifications(config, sdkConfig);
   }
 
+  // Update project strings for user agent metadata
   config = withProjectStrings(config);
 
   return config;

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -19,6 +19,7 @@ function withCustomerIOPlugin(
     );
   }
 
+  // Apply platform specific modifications
   config = withCIOIos(config, props.config, props.ios);
   config = withCIOAndroid(config, props.config, props.android);
 

--- a/plugin/src/ios/withCIOIos.ts
+++ b/plugin/src/ios/withCIOIos.ts
@@ -1,5 +1,4 @@
 import type { ExpoConfig } from '@expo/config-types';
-
 import type {
   CustomerIOPluginOptionsIOS,
   CustomerIOPluginPushNotificationOptions,
@@ -16,8 +15,8 @@ import { withCioXcodeProject } from './withXcodeProject';
 
 export function withCIOIos(
   config: ExpoConfig,
-  sdkConfig: NativeSDKConfig | undefined,
-  props?: CustomerIOPluginOptionsIOS
+  sdkConfig?: NativeSDKConfig,
+  props?: CustomerIOPluginOptionsIOS,
 ) {
   const isSwiftProject = isExpoVersion53OrHigher(config);
   const platformConfig = mergeDeprecatedPropertiesAndLogWarnings(props);
@@ -50,15 +49,17 @@ export function withCIOIos(
   while the rest of the plugin code remains unchanged.
 */
 const mergeDeprecatedPropertiesAndLogWarnings = (
-  props?: CustomerIOPluginOptionsIOS
-) => {
+  props?: CustomerIOPluginOptionsIOS,
+): CustomerIOPluginOptionsIOS | undefined => {
   // The deprecatedTopLevelProperties maps the top level properties
   // that are deprecated to the new ios.pushNotification.* properties
   // that should be used instead. The deprecated properties are
   // still available for backwards compatibility, but they will
   // be removed in the future.
 
-  if(!props) return props
+  if (!props) {
+    return props
+  }
 
   const deprecatedTopLevelProperties = {
     showPushAppInForeground: props.showPushAppInForeground,

--- a/plugin/src/ios/withCIOIosSwift.ts
+++ b/plugin/src/ios/withCIOIosSwift.ts
@@ -32,7 +32,7 @@ const CIO_SDK_APP_DELEGATE_HANDLER_FILENAME = `${CIO_SDK_APP_DELEGATE_HANDLER_CL
  */
 const copyAndConfigureAppDelegateHandler = (
   config: ExportedConfigWithProps<XcodeProject>,
-  sdkConfig: NativeSDKConfig | undefined,
+  sdkConfig?: NativeSDKConfig,
   props?: CustomerIOPluginOptionsIOS,
 ): ExportedConfigWithProps<XcodeProject> => {
   // Destination path in the iOS project
@@ -194,7 +194,7 @@ const copyAndConfigureNativeSDKInitializer = ({
 
 export const withCIOIosSwift = (
   configOuter: ExpoConfig,
-  sdkConfig: NativeSDKConfig | undefined,
+  sdkConfig?: NativeSDKConfig,
   props?: CustomerIOPluginOptionsIOS,
 ) => {
   // First, copy required swift files to iOS folder and add it to Xcode project

--- a/scripts/test-plugin.sh
+++ b/scripts/test-plugin.sh
@@ -1,18 +1,61 @@
 #!/bin/bash
 
+# Example usages:
+#   npm run test-plugin -- apn
+#   npm run test-plugin -- apn --skip-build
+#   npm run test-plugin -- fcm -u
+#   npm run test-plugin -- fcm --skip-build -u
+
 source scripts/utils.sh
 set -e
 
+# Parse flags
+SKIP_BUILD=false
+UPDATE_SNAPSHOTS=false
+PUSH_PROVIDER=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --skip-build)
+      SKIP_BUILD=true
+      shift
+      ;;
+    -u|--update-snapshots)
+      UPDATE_SNAPSHOTS=true
+      shift
+      ;;
+    apn|fcm)
+      if [[ -z "$PUSH_PROVIDER" ]]; then
+        PUSH_PROVIDER="$1"
+      else
+        echo "❌ Multiple push providers specified"
+        echo "Usage: npm run test-plugin -- [apn|fcm] [--skip-build] [-u|--update-snapshots]"
+        exit 1
+      fi
+      shift
+      ;;
+    *)
+      echo "❌ Unknown option: $1"
+      echo "Usage: npm run test-plugin -- [apn|fcm] [--skip-build] [-u|--update-snapshots]"
+      exit 1
+      ;;
+  esac
+done
+
 # Check required argument exists
-if [[ -z "$1" ]]; then
-  echo "❌ Usage: test-plugin.sh [apn|fcm]"
+if [[ -z "$PUSH_PROVIDER" ]]; then
+  echo "❌ Usage: npm run test-plugin -- [apn|fcm] [--skip-build] [-u|--update-snapshots]"
   exit 1
 fi
 
-sh ./scripts/clean-all.sh
+# Skip clean and build if flag is set
+if [[ "$SKIP_BUILD" == false ]]; then
+  sh ./scripts/clean-all.sh
+fi
 
 # Extract push provider from params
-case "$1" in
+case "$PUSH_PROVIDER" in
   apn)
     pushProviderValue="apn"
     ;;
@@ -20,7 +63,7 @@ case "$1" in
     pushProviderValue="fcm"
     ;;
   *)
-    echo "❌ Invalid argument: $1"
+    echo "❌ Invalid argument: $PUSH_PROVIDER"
     echo "Valid options are: apn, fcm"
     exit 1
     ;;
@@ -32,9 +75,16 @@ touch "test-app/local.env"
 echo "pushProvider=$pushProviderValue" >> "test-app/local.env"
 
 # Build plugin and sample app native projects
-sh ./scripts/build-all.sh
+if [[ "$SKIP_BUILD" == false ]]; then
+  sh ./scripts/build-all.sh
+fi
 
 # Run tests
-npm test -- __tests__/utils
-npm test -- __tests__/android
-npm test -- __tests__/ios/common __tests__/ios/$pushProviderValue
+SNAPSHOT_FLAG=""
+if [[ "$UPDATE_SNAPSHOTS" == true ]]; then
+  SNAPSHOT_FLAG="-u"
+fi
+
+npm test $SNAPSHOT_FLAG -- __tests__/utils
+npm test $SNAPSHOT_FLAG -- __tests__/android
+npm test $SNAPSHOT_FLAG -- __tests__/ios/common __tests__/ios/$pushProviderValue

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -3890,9 +3890,9 @@
       }
     },
     "node_modules/customerio-expo-plugin": {
-      "version": "2.7.0",
+      "version": "2.7.1",
       "resolved": "file:../customerio-expo-plugin-latest.tgz",
-      "integrity": "sha512-6PU9dYAZcOL0vOFvbnZ0tt2ho1XY3ta9ynkgfxQ+Fo3qyU05E6IP6qSy0FhkEYfASlxGHzUukyDHVQH4fZmowA==",
+      "integrity": "sha512-2zYtMfRd0k0K65ITo/mXX1buTIVKAqsNZzt+ZRyhRsFrzyTJZX8ohzQxlcWygNwGjVkU7VJGvhIAkSr6jfeuOQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,6 @@
     "strict": true,
     "target": "esnext",
     "verbatimModuleSyntax": true
-  }
+  },
+  "exclude": ["ci-test-apps/**"]
 }


### PR DESCRIPTION
part of: [MBL-1372](https://linear.app/customerio/issue/MBL-1372/make-expo-plugin-push-config-optional-for-sdk-auto-initialization)

### Summary

Minor changes to prepare for upcoming release, improving local dev/testing workflows and reducing noise from temporary files.

### Changes

- Updated TypeScript types in plugin to handle `undefined` values more explicitly
- Updated `test-plugin` script to optionally skip clean and build steps, allowing faster iteration during local testing
- Excluded `ci-test-apps` from both `tsconfig` and `ESLint` to avoid unnecessary validation during local development.

### Notes

- No changes to plugin behavior
- Improves local dev experience, especially when testing plugin changes in isolation.