### PR TITLE
fix: prevent message type crash in release builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-expo-plugin",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-expo-plugin",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -34,7 +34,7 @@
         "xcode": "^3.0.1"
       },
       "peerDependencies": {
-        "customerio-reactnative": "5.0.0"
+        "customerio-reactnative": "5.0.1"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -7160,9 +7160,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-5.0.0.tgz",
-      "integrity": "sha512-/ZensY1gmJPu8n2M5BPRUHq7GLYk2FyeIKpy9tjz9CIA/Fw4Otjoo3KPLRPJsNNce3e8p6oeEeoG47nz4gZ2QQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-5.0.1.tgz",
+      "integrity": "sha512-+31palCL6Aw6IuwSuTx6rjZF33S1+/pLxvg7bWe+8vTCpAyolo2KHCvXvq0JueReSIQ2/nAo+sgjR5MhO2RwwA==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "customerio-reactnative": "5.0.0"
+    "customerio-reactnative": "5.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -4070,9 +4070,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-expo-plugin": {
-      "version": "2.9.0",
+      "version": "2.9.1",
       "resolved": "file:../customerio-expo-plugin-latest.tgz",
-      "integrity": "sha512-TUN8JhpE7QP7AhzR60bp6WvVUGbdCNL559I1XzVpeAvhImTMdhW5xtMCcAB7T0PrIKi2SSDr/H+eVILFQ0upzg==",
+      "integrity": "sha512-135EFu3CSucapyX+4UBAAQ0QMRl1S2eNulSmWyz8EyakFPtvDAmBGoNAW2rLBxkmr/tONynIR3xO+gdTgN7T8g==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -4081,7 +4081,7 @@
         "semver": "^7.7.2"
       },
       "peerDependencies": {
-        "customerio-reactnative": "5.0.0"
+        "customerio-reactnative": "5.0.1"
       }
     },
     "node_modules/customerio-expo-plugin/node_modules/semver": {
@@ -4097,9 +4097,9 @@
       }
     },
     "node_modules/customerio-reactnative": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-5.0.0.tgz",
-      "integrity": "sha512-/ZensY1gmJPu8n2M5BPRUHq7GLYk2FyeIKpy9tjz9CIA/Fw4Otjoo3KPLRPJsNNce3e8p6oeEeoG47nz4gZ2QQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-5.0.1.tgz",
+      "integrity": "sha512-+31palCL6Aw6IuwSuTx6rjZF33S1+/pLxvg7bWe+8vTCpAyolo2KHCvXvq0JueReSIQ2/nAo+sgjR5MhO2RwwA==",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps plugin to 2.9.1 and updates peer dependency to customerio-reactnative 5.0.1 (including test app sync).
> 
> - **Versioning**:
>   - Bump `customerio-expo-plugin` to `2.9.1`.
>   - Update peer dependency `customerio-reactnative` to `5.0.1`.
> - **Test app**:
>   - Sync test app to use `customerio-expo-plugin@2.9.1` and `customerio-reactnative@5.0.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49649f4eb6db167ec0cc266dbcfae4715c7d3ec7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->