### PR TITLE
fix: resolve Podfile :path at prebuild time, dispatching on RN version

### DIFF
--- a/__tests__/ios/apn/PodFile.test.js
+++ b/__tests__/ios/apn/PodFile.test.js
@@ -9,40 +9,28 @@ const podFilePath = path.join(iosPath, "Podfile");
 test("Plugin injects expected customerio-reactnative/apn and customerio-reactnative-richpush/apn in Podfile", async () => {
     const content = await fs.readFile(podFilePath, "utf8");
 
-    // Ensure CustomerIO Host App block exists with the install-time path
-    // resolver lambda and an apn subspec line that references the variable.
+    // Path is resolved at prebuild time and baked directly into :path => '...'.
+    // The exact string can vary by RN version (lexical for RN <0.80, realpath
+    // for RN >=0.80) so we assert the shape, not the literal string.
     expect(content).toContain("# --- CustomerIO Host App START ---");
     expect(content).toContain("# --- CustomerIO Host App END ---");
-    expect(content).toContain("customerio_reactnative_path = (lambda do");
-    const hasSingleSubspec = content.includes("pod 'customerio-reactnative/apn', :path => customerio_reactnative_path");
-    const hasMultiSubspecWithApn = content.includes(":subspecs =>") && content.includes("'apn'") && content.includes(":path => customerio_reactnative_path");
+
+    const hasSingleSubspec = /pod 'customerio-reactnative\/apn', :path => '[^']+'/.test(content);
+    const hasMultiSubspecWithApn = content.includes(":subspecs =>") && content.includes("'apn'") && /:path => '[^']+'/.test(content);
     expect(hasSingleSubspec || hasMultiSubspecWithApn).toBe(true);
 
-    // Ensure NotificationService target is added with the rich push pod and
-    // a local path-resolver lambda (separate Ruby scope from the host app
-    // block, so the lambda is emitted again here).
+    // Ensure NotificationService target is added with the rich push pod
+    // pointing at the same baked path.
     const podFileAsLines = content.split('\n').map(line => line.trim());
     const startIndex = podFileAsLines.indexOf("# --- CustomerIO Notification START ---");
     const endIndex = podFileAsLines.indexOf("# --- CustomerIO Notification END ---", startIndex);
     expect(startIndex).toBeGreaterThan(-1);
     expect(endIndex).toBeGreaterThan(startIndex);
     const targetBlock = podFileAsLines.slice(startIndex, endIndex + 1).filter(line => line.length > 0);
-    const expectedLines = [
-      "# --- CustomerIO Notification START ---",
-      "target 'NotificationService' do",
-      "use_frameworks! :linkage => :static",
-      "customerio_reactnative_path = (lambda do",
-      "out = `node --print \"require.resolve('customerio-reactnative/package.json')\" 2>/dev/null`.strip",
-      "if $?.success? && !out.empty?",
-      "Pathname.new(File.dirname(out)).relative_path_from(Pathname.new(__dir__)).to_s",
-      "else",
-      "'../node_modules/customerio-reactnative'",
-      "end",
-      "end).call",
-      "pod 'customerio-reactnative-richpush/apn', :path => customerio_reactnative_path",
-      "end",
-      "# --- CustomerIO Notification END ---"
-    ];
-
-    expect(targetBlock).toEqual(expectedLines);
+    expect(targetBlock[0]).toBe("# --- CustomerIO Notification START ---");
+    expect(targetBlock[1]).toBe("target 'NotificationService' do");
+    expect(targetBlock[2]).toBe("use_frameworks! :linkage => :static");
+    expect(targetBlock[3]).toMatch(/^pod 'customerio-reactnative-richpush\/apn', :path => '[^']+'$/);
+    expect(targetBlock[4]).toBe("end");
+    expect(targetBlock[5]).toBe("# --- CustomerIO Notification END ---");
 });

--- a/__tests__/ios/apn/PodFile.test.js
+++ b/__tests__/ios/apn/PodFile.test.js
@@ -9,14 +9,18 @@ const podFilePath = path.join(iosPath, "Podfile");
 test("Plugin injects expected customerio-reactnative/apn and customerio-reactnative-richpush/apn in Podfile", async () => {
     const content = await fs.readFile(podFilePath, "utf8");
 
-    // Ensure CustomerIO Host App block exists and APN pod is added (single-subspec or :subspecs including 'apn')
+    // Ensure CustomerIO Host App block exists with the install-time path
+    // resolver lambda and an apn subspec line that references the variable.
     expect(content).toContain("# --- CustomerIO Host App START ---");
     expect(content).toContain("# --- CustomerIO Host App END ---");
-    const hasSingleSubspec = content.includes("pod 'customerio-reactnative/apn', :path => '../node_modules/customerio-reactnative'");
-    const hasMultiSubspecWithApn = content.includes("customerio-reactnative") && content.includes("'apn'") && content.includes(":subspecs =>");
+    expect(content).toContain("customerio_reactnative_path = (lambda do");
+    const hasSingleSubspec = content.includes("pod 'customerio-reactnative/apn', :path => customerio_reactnative_path");
+    const hasMultiSubspecWithApn = content.includes(":subspecs =>") && content.includes("'apn'") && content.includes(":path => customerio_reactnative_path");
     expect(hasSingleSubspec || hasMultiSubspecWithApn).toBe(true);
 
-    // Ensure NotificationService target is added with rich push pod
+    // Ensure NotificationService target is added with the rich push pod and
+    // a local path-resolver lambda (separate Ruby scope from the host app
+    // block, so the lambda is emitted again here).
     const podFileAsLines = content.split('\n').map(line => line.trim());
     const startIndex = podFileAsLines.indexOf("# --- CustomerIO Notification START ---");
     const endIndex = podFileAsLines.indexOf("# --- CustomerIO Notification END ---", startIndex);
@@ -27,7 +31,15 @@ test("Plugin injects expected customerio-reactnative/apn and customerio-reactnat
       "# --- CustomerIO Notification START ---",
       "target 'NotificationService' do",
       "use_frameworks! :linkage => :static",
-      "pod 'customerio-reactnative-richpush/apn', :path => '../node_modules/customerio-reactnative'",
+      "customerio_reactnative_path = (lambda do",
+      "out = `node --print \"require.resolve('customerio-reactnative/package.json')\" 2>/dev/null`.strip",
+      "if $?.success? && !out.empty?",
+      "Pathname.new(File.dirname(out)).relative_path_from(Pathname.new(__dir__)).to_s",
+      "else",
+      "'../node_modules/customerio-reactnative'",
+      "end",
+      "end).call",
+      "pod 'customerio-reactnative-richpush/apn', :path => customerio_reactnative_path",
       "end",
       "# --- CustomerIO Notification END ---"
     ];

--- a/__tests__/ios/fcm/PodFile.test.js
+++ b/__tests__/ios/fcm/PodFile.test.js
@@ -9,14 +9,18 @@ const podFilePath = path.join(iosPath, "Podfile");
 test("Plugin injects expected customerio-reactnative/fcm and customerio-reactnative-richpush/fcm in Podfile", async () => {
     const content = await fs.readFile(podFilePath, "utf8");
 
-    // Ensure CustomerIO Host App block exists and FCM pod is added (single-subspec or :subspecs including 'fcm')
+    // Ensure CustomerIO Host App block exists with the install-time path
+    // resolver lambda and an fcm subspec line that references the variable.
     expect(content).toContain("# --- CustomerIO Host App START ---");
     expect(content).toContain("# --- CustomerIO Host App END ---");
-    const hasSingleSubspec = content.includes("pod 'customerio-reactnative/fcm', :path => '../node_modules/customerio-reactnative'");
-    const hasMultiSubspecWithFcm = content.includes("customerio-reactnative") && content.includes("'fcm'") && content.includes(":subspecs =>");
+    expect(content).toContain("customerio_reactnative_path = (lambda do");
+    const hasSingleSubspec = content.includes("pod 'customerio-reactnative/fcm', :path => customerio_reactnative_path");
+    const hasMultiSubspecWithFcm = content.includes(":subspecs =>") && content.includes("'fcm'") && content.includes(":path => customerio_reactnative_path");
     expect(hasSingleSubspec || hasMultiSubspecWithFcm).toBe(true);
 
-    // Ensure NotificationService target is added with rich push pod
+    // Ensure NotificationService target is added with the rich push pod and
+    // a local path-resolver lambda (separate Ruby scope from the host app
+    // block, so the lambda is emitted again here).
     const podFileAsLines = content.split('\n').map(line => line.trim());
     const startIndex = podFileAsLines.indexOf("# --- CustomerIO Notification START ---");
     const endIndex = podFileAsLines.indexOf("# --- CustomerIO Notification END ---", startIndex);
@@ -27,7 +31,15 @@ test("Plugin injects expected customerio-reactnative/fcm and customerio-reactnat
       "# --- CustomerIO Notification START ---",
       "target 'NotificationService' do",
       "use_frameworks! :linkage => :static",
-      "pod 'customerio-reactnative-richpush/fcm', :path => '../node_modules/customerio-reactnative'",
+      "customerio_reactnative_path = (lambda do",
+      "out = `node --print \"require.resolve('customerio-reactnative/package.json')\" 2>/dev/null`.strip",
+      "if $?.success? && !out.empty?",
+      "Pathname.new(File.dirname(out)).relative_path_from(Pathname.new(__dir__)).to_s",
+      "else",
+      "'../node_modules/customerio-reactnative'",
+      "end",
+      "end).call",
+      "pod 'customerio-reactnative-richpush/fcm', :path => customerio_reactnative_path",
       "end",
       "# --- CustomerIO Notification END ---"
     ];

--- a/__tests__/ios/fcm/PodFile.test.js
+++ b/__tests__/ios/fcm/PodFile.test.js
@@ -1,4 +1,4 @@
-const { testAppPath, isExpoVersion53OrHigher } = require("../../utils");
+const { testAppPath } = require("../../utils");
 const fs = require("fs-extra");
 const path = require("path");
 
@@ -9,40 +9,28 @@ const podFilePath = path.join(iosPath, "Podfile");
 test("Plugin injects expected customerio-reactnative/fcm and customerio-reactnative-richpush/fcm in Podfile", async () => {
     const content = await fs.readFile(podFilePath, "utf8");
 
-    // Ensure CustomerIO Host App block exists with the install-time path
-    // resolver lambda and an fcm subspec line that references the variable.
+    // Path is resolved at prebuild time and baked directly into :path => '...'.
+    // The exact string can vary by RN version (lexical for RN <0.80, realpath
+    // for RN >=0.80) so we assert the shape, not the literal string.
     expect(content).toContain("# --- CustomerIO Host App START ---");
     expect(content).toContain("# --- CustomerIO Host App END ---");
-    expect(content).toContain("customerio_reactnative_path = (lambda do");
-    const hasSingleSubspec = content.includes("pod 'customerio-reactnative/fcm', :path => customerio_reactnative_path");
-    const hasMultiSubspecWithFcm = content.includes(":subspecs =>") && content.includes("'fcm'") && content.includes(":path => customerio_reactnative_path");
+
+    const hasSingleSubspec = /pod 'customerio-reactnative\/fcm', :path => '[^']+'/.test(content);
+    const hasMultiSubspecWithFcm = content.includes(":subspecs =>") && content.includes("'fcm'") && /:path => '[^']+'/.test(content);
     expect(hasSingleSubspec || hasMultiSubspecWithFcm).toBe(true);
 
-    // Ensure NotificationService target is added with the rich push pod and
-    // a local path-resolver lambda (separate Ruby scope from the host app
-    // block, so the lambda is emitted again here).
+    // Ensure NotificationService target is added with the rich push pod
+    // pointing at the same baked path.
     const podFileAsLines = content.split('\n').map(line => line.trim());
     const startIndex = podFileAsLines.indexOf("# --- CustomerIO Notification START ---");
     const endIndex = podFileAsLines.indexOf("# --- CustomerIO Notification END ---", startIndex);
     expect(startIndex).toBeGreaterThan(-1);
     expect(endIndex).toBeGreaterThan(startIndex);
     const targetBlock = podFileAsLines.slice(startIndex, endIndex + 1).filter(line => line.length > 0);
-    const expectedLines = [
-      "# --- CustomerIO Notification START ---",
-      "target 'NotificationService' do",
-      "use_frameworks! :linkage => :static",
-      "customerio_reactnative_path = (lambda do",
-      "out = `node --print \"require.resolve('customerio-reactnative/package.json')\" 2>/dev/null`.strip",
-      "if $?.success? && !out.empty?",
-      "Pathname.new(File.dirname(out)).relative_path_from(Pathname.new(__dir__)).to_s",
-      "else",
-      "'../node_modules/customerio-reactnative'",
-      "end",
-      "end).call",
-      "pod 'customerio-reactnative-richpush/fcm', :path => customerio_reactnative_path",
-      "end",
-      "# --- CustomerIO Notification END ---"
-    ];
-
-    expect(targetBlock).toEqual(expectedLines);
+    expect(targetBlock[0]).toBe("# --- CustomerIO Notification START ---");
+    expect(targetBlock[1]).toBe("target 'NotificationService' do");
+    expect(targetBlock[2]).toBe("use_frameworks! :linkage => :static");
+    expect(targetBlock[3]).toMatch(/^pod 'customerio-reactnative-richpush\/fcm', :path => '[^']+'$/);
+    expect(targetBlock[4]).toBe("end");
+    expect(targetBlock[5]).toBe("# --- CustomerIO Notification END ---");
 });

--- a/__tests__/ios/getRelativePathToRNSDK.test.ts
+++ b/__tests__/ios/getRelativePathToRNSDK.test.ts
@@ -57,12 +57,28 @@ describe('getRelativePathToRNSDK fixtures', () => {
     fs.rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  it('flat npm: resolves to ../node_modules/customerio-reactnative', () => {
-    const projectRoot = path.join(tmpRoot, 'flat-npm');
+  it('flat npm + RN >=0.80: resolves to ../node_modules/customerio-reactnative', () => {
+    const projectRoot = path.join(tmpRoot, 'flat-npm-rn81');
     const iosPath = path.join(projectRoot, 'ios');
     fs.mkdirSync(iosPath, { recursive: true });
     makeCioPkg(path.join(projectRoot, 'node_modules', 'customerio-reactnative'));
     makeRnPkg(projectRoot, '0.81.4');
+
+    expect(getRelativePathToRNSDK(iosPath)).toBe(
+      path.join('..', 'node_modules', 'customerio-reactnative')
+    );
+  });
+
+  it('flat npm + RN <0.80: resolves to ../node_modules/customerio-reactnative (no regression)', () => {
+    // The dominant install layout (regular npm, no monorepo, no symlinks)
+    // must emit the same string regardless of which RN version pins the
+    // dispatch branch. This locks in the no-regression guarantee for the
+    // overwhelming majority of users when we changed the resolver.
+    const projectRoot = path.join(tmpRoot, 'flat-npm-rn79');
+    const iosPath = path.join(projectRoot, 'ios');
+    fs.mkdirSync(iosPath, { recursive: true });
+    makeCioPkg(path.join(projectRoot, 'node_modules', 'customerio-reactnative'));
+    makeRnPkg(projectRoot, '0.79.5');
 
     expect(getRelativePathToRNSDK(iosPath)).toBe(
       path.join('..', 'node_modules', 'customerio-reactnative')

--- a/__tests__/ios/getRelativePathToRNSDK.test.ts
+++ b/__tests__/ios/getRelativePathToRNSDK.test.ts
@@ -7,26 +7,47 @@ import { getRelativePathToRNSDK } from '../../plugin/src/helpers/constants/ios';
 // These tests build real on-disk fixture trees (including symlinks for the
 // pnpm case) and exercise the resolver against them. The behaviour we care
 // about is that the returned :path agrees with what React Native autolinking
-// emits, regardless of layout.
+// emits, which depends on both layout and RN version (see the dispatch in
+// `getRelativePathToRNSDK`).
 
-const PKG_JSON_CONTENT = JSON.stringify({
+const CIO_PKG_JSON = JSON.stringify({
   name: 'customerio-reactnative',
   version: '6.4.0',
 });
 
-function makePkgJson(dir: string) {
+function makeCioPkg(dir: string) {
   fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, 'package.json'), PKG_JSON_CONTENT);
+  fs.writeFileSync(path.join(dir, 'package.json'), CIO_PKG_JSON);
 }
+
+function makeRnPkg(rootDir: string, version: string) {
+  const dir = path.join(rootDir, 'node_modules', 'react-native');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: 'react-native', version })
+  );
+}
+
+let logSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  // Silence the always-on plugin logs so test output stays readable.
+  logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+});
 
 describe('getRelativePathToRNSDK fixtures', () => {
   let tmpRoot: string;
 
   beforeEach(() => {
     // realpath because os.tmpdir() goes through /var → /private/var symlinks
-    // on macOS. The fallback resolver path normalizes through realpath, so
-    // tests need to compare against the resolved form to avoid spurious
-    // mismatches that don't happen in real-world layouts.
+    // on macOS, and the modern (RN >=0.80) branch realpath()s the resolved
+    // dir; tests need to compare against the resolved form to avoid
+    // spurious mismatches from that base-path indirection.
     tmpRoot = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), 'cio-resolve-'))
     );
@@ -40,19 +61,19 @@ describe('getRelativePathToRNSDK fixtures', () => {
     const projectRoot = path.join(tmpRoot, 'flat-npm');
     const iosPath = path.join(projectRoot, 'ios');
     fs.mkdirSync(iosPath, { recursive: true });
-    makePkgJson(path.join(projectRoot, 'node_modules', 'customerio-reactnative'));
+    makeCioPkg(path.join(projectRoot, 'node_modules', 'customerio-reactnative'));
+    makeRnPkg(projectRoot, '0.81.4');
 
     expect(getRelativePathToRNSDK(iosPath)).toBe(
       path.join('..', 'node_modules', 'customerio-reactnative')
     );
   });
 
-  it('pnpm: resolves to the symlink path, NOT the .pnpm realpath', () => {
-    const projectRoot = path.join(tmpRoot, 'pnpm-app');
+  it('pnpm + RN <0.80: returns the symlink path (matches @react-native-community/cli)', () => {
+    const projectRoot = path.join(tmpRoot, 'pnpm-rn79');
     const iosPath = path.join(projectRoot, 'ios');
     fs.mkdirSync(iosPath, { recursive: true });
 
-    // Real package lives inside the pnpm virtual store.
     const realDir = path.join(
       projectRoot,
       'node_modules',
@@ -61,21 +82,47 @@ describe('getRelativePathToRNSDK fixtures', () => {
       'node_modules',
       'customerio-reactnative'
     );
-    makePkgJson(realDir);
+    makeCioPkg(realDir);
 
-    // Public symlink that React Native autolinking sees.
     const symlinkDir = path.join(projectRoot, 'node_modules', 'customerio-reactnative');
     fs.symlinkSync(realDir, symlinkDir, 'dir');
+    makeRnPkg(projectRoot, '0.79.5');
 
     const resolved = getRelativePathToRNSDK(iosPath);
 
-    // The whole point of the fix: we must return the symlink path, not the
-    // realpath inside .pnpm/. CocoaPods compares :path strings character-for-
-    // character, so the realpath form would conflict with autolinking.
+    // The fix the plan was originally designed for: under RN 0.79 community
+    // CLI, autolinking emits the symlink path. We must too.
     expect(resolved).toBe(
       path.join('..', 'node_modules', 'customerio-reactnative')
     );
     expect(resolved).not.toContain('.pnpm');
+  });
+
+  it('pnpm + RN >=0.80: returns the .pnpm realpath (matches expo-modules-autolinking)', () => {
+    const projectRoot = path.join(tmpRoot, 'pnpm-rn81');
+    const iosPath = path.join(projectRoot, 'ios');
+    fs.mkdirSync(iosPath, { recursive: true });
+
+    const realDir = path.join(
+      projectRoot,
+      'node_modules',
+      '.pnpm',
+      'customerio-reactnative@6.4.0_abc',
+      'node_modules',
+      'customerio-reactnative'
+    );
+    makeCioPkg(realDir);
+
+    const symlinkDir = path.join(projectRoot, 'node_modules', 'customerio-reactnative');
+    fs.symlinkSync(realDir, symlinkDir, 'dir');
+    makeRnPkg(projectRoot, '0.81.4');
+
+    const resolved = getRelativePathToRNSDK(iosPath);
+
+    // Modern expo-modules-autolinking realpaths; we must too, otherwise
+    // CocoaPods sees two :path values for the same pod.
+    expect(resolved).toContain('.pnpm');
+    expect(resolved).toBe(path.relative(iosPath, realDir));
   });
 
   it('yarn classic workspace: resolves to the hoisted parent node_modules', () => {
@@ -84,13 +131,39 @@ describe('getRelativePathToRNSDK fixtures', () => {
     const iosPath = path.join(appPath, 'ios');
     fs.mkdirSync(iosPath, { recursive: true });
 
-    // Hoisted to the workspace root; the leaf app has no local copy.
-    makePkgJson(path.join(wsRoot, 'node_modules', 'customerio-reactnative'));
+    makeCioPkg(path.join(wsRoot, 'node_modules', 'customerio-reactnative'));
     fs.mkdirSync(path.join(appPath, 'node_modules'), { recursive: true });
+    // RN hoisted to ws root too; modern Expo path here.
+    makeRnPkg(wsRoot, '0.81.4');
 
     expect(getRelativePathToRNSDK(iosPath)).toBe(
       path.join('..', '..', '..', 'node_modules', 'customerio-reactnative')
     );
+  });
+
+  it('RN version unknown: defaults to realpath (modern behavior)', () => {
+    const projectRoot = path.join(tmpRoot, 'no-rn');
+    const iosPath = path.join(projectRoot, 'ios');
+    fs.mkdirSync(iosPath, { recursive: true });
+
+    const realDir = path.join(
+      projectRoot,
+      'node_modules',
+      '.pnpm',
+      'customerio-reactnative@6.4.0_abc',
+      'node_modules',
+      'customerio-reactnative'
+    );
+    makeCioPkg(realDir);
+    fs.symlinkSync(
+      realDir,
+      path.join(projectRoot, 'node_modules', 'customerio-reactnative'),
+      'dir'
+    );
+    // Deliberately no react-native fixture.
+
+    const resolved = getRelativePathToRNSDK(iosPath);
+    expect(resolved).toContain('.pnpm');
   });
 
   it('throws a clear error when customerio-reactnative is missing', () => {

--- a/__tests__/ios/getRelativePathToRNSDK.test.ts
+++ b/__tests__/ios/getRelativePathToRNSDK.test.ts
@@ -1,0 +1,105 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { getRelativePathToRNSDK } from '../../plugin/src/helpers/constants/ios';
+
+// These tests build real on-disk fixture trees (including symlinks for the
+// pnpm case) and exercise the resolver against them. The behaviour we care
+// about is that the returned :path agrees with what React Native autolinking
+// emits, regardless of layout.
+
+const PKG_JSON_CONTENT = JSON.stringify({
+  name: 'customerio-reactnative',
+  version: '6.4.0',
+});
+
+function makePkgJson(dir: string) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'package.json'), PKG_JSON_CONTENT);
+}
+
+describe('getRelativePathToRNSDK fixtures', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    // realpath because os.tmpdir() goes through /var → /private/var symlinks
+    // on macOS. The fallback resolver path normalizes through realpath, so
+    // tests need to compare against the resolved form to avoid spurious
+    // mismatches that don't happen in real-world layouts.
+    tmpRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'cio-resolve-'))
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('flat npm: resolves to ../node_modules/customerio-reactnative', () => {
+    const projectRoot = path.join(tmpRoot, 'flat-npm');
+    const iosPath = path.join(projectRoot, 'ios');
+    fs.mkdirSync(iosPath, { recursive: true });
+    makePkgJson(path.join(projectRoot, 'node_modules', 'customerio-reactnative'));
+
+    expect(getRelativePathToRNSDK(iosPath)).toBe(
+      path.join('..', 'node_modules', 'customerio-reactnative')
+    );
+  });
+
+  it('pnpm: resolves to the symlink path, NOT the .pnpm realpath', () => {
+    const projectRoot = path.join(tmpRoot, 'pnpm-app');
+    const iosPath = path.join(projectRoot, 'ios');
+    fs.mkdirSync(iosPath, { recursive: true });
+
+    // Real package lives inside the pnpm virtual store.
+    const realDir = path.join(
+      projectRoot,
+      'node_modules',
+      '.pnpm',
+      'customerio-reactnative@6.4.0_abc',
+      'node_modules',
+      'customerio-reactnative'
+    );
+    makePkgJson(realDir);
+
+    // Public symlink that React Native autolinking sees.
+    const symlinkDir = path.join(projectRoot, 'node_modules', 'customerio-reactnative');
+    fs.symlinkSync(realDir, symlinkDir, 'dir');
+
+    const resolved = getRelativePathToRNSDK(iosPath);
+
+    // The whole point of the fix: we must return the symlink path, not the
+    // realpath inside .pnpm/. CocoaPods compares :path strings character-for-
+    // character, so the realpath form would conflict with autolinking.
+    expect(resolved).toBe(
+      path.join('..', 'node_modules', 'customerio-reactnative')
+    );
+    expect(resolved).not.toContain('.pnpm');
+  });
+
+  it('yarn classic workspace: resolves to the hoisted parent node_modules', () => {
+    const wsRoot = path.join(tmpRoot, 'yarn-ws');
+    const appPath = path.join(wsRoot, 'apps', 'mobile');
+    const iosPath = path.join(appPath, 'ios');
+    fs.mkdirSync(iosPath, { recursive: true });
+
+    // Hoisted to the workspace root; the leaf app has no local copy.
+    makePkgJson(path.join(wsRoot, 'node_modules', 'customerio-reactnative'));
+    fs.mkdirSync(path.join(appPath, 'node_modules'), { recursive: true });
+
+    expect(getRelativePathToRNSDK(iosPath)).toBe(
+      path.join('..', '..', '..', 'node_modules', 'customerio-reactnative')
+    );
+  });
+
+  it('throws a clear error when customerio-reactnative is missing', () => {
+    const projectRoot = path.join(tmpRoot, 'no-dep');
+    const iosPath = path.join(projectRoot, 'ios');
+    fs.mkdirSync(iosPath, { recursive: true });
+
+    expect(() => getRelativePathToRNSDK(iosPath)).toThrow(
+      /customerio-reactnative was not found/
+    );
+  });
+});

--- a/__tests__/ios/injectCIOPodfileCode.test.ts
+++ b/__tests__/ios/injectCIOPodfileCode.test.ts
@@ -1,6 +1,5 @@
 import {
   buildHostAppPodSnippet,
-  buildResolveSnippet,
   type InjectCIOPodfileOptions,
 } from '../../plugin/src/helpers/utils/injectCIOPodfileCode';
 
@@ -17,69 +16,49 @@ jest.mock('../../plugin/src/helpers/utils/fileManagement', () => ({
 
 const IOS_PATH = '/fake/project/ios';
 
-// The snippet must (a) emit a `customerio_reactnative_path` lambda that calls
-// Node's require.resolve at pod install time, and (b) reference that variable
-// on every `pod 'customerio-reactnative...'` line. The prebuild-time path
-// from `getRelativePathToRNSDK` is baked into the lambda only as the
-// fallback. This is the structure that keeps our path in agreement with
-// React Native autolinking under pnpm/yarn symlinks.
+// The snippet bakes the prebuild-resolved relative path directly into
+// :path => '...'. The choice of lexical vs realpath happens earlier, in
+// `getRelativePathToRNSDK`, which dispatches on the installed React Native
+// version. These tests cover the snippet shape and the subspec matrix.
 
-const FALLBACK_PATH = '../node_modules/customerio-reactnative';
-
-function expectsLambda(snippet: string) {
-  expect(snippet).toContain('customerio_reactnative_path = (lambda do');
-  expect(snippet).toContain(
-    `\`node --print "require.resolve('customerio-reactnative/package.json')" 2>/dev/null\`.strip`
-  );
-  expect(snippet).toContain(
-    'Pathname.new(File.dirname(out)).relative_path_from(Pathname.new(__dir__)).to_s'
-  );
-  expect(snippet).toContain(`'${FALLBACK_PATH}'`);
-  expect(snippet).toContain('end).call');
-}
+const RESOLVED_PATH = '../node_modules/customerio-reactnative';
 
 function expectsPodLine(snippet: string, line: string) {
-  expect(snippet).toContain(line);
-  // The pod line must reference the variable, not a baked path.
-  expect(snippet).not.toMatch(/pod 'customerio-reactnative.*:path => '[^']*'/);
+  expect(snippet).toBe(line);
 }
 
 describe('buildHostAppPodSnippet', () => {
-  it('emits the lambda + apn subspec line referencing the variable', () => {
+  it('emits the apn subspec line with a baked :path', () => {
     const snippet = buildHostAppPodSnippet(IOS_PATH, false, {
       locationEnabled: false,
     });
-    expectsLambda(snippet);
     expectsPodLine(
       snippet,
-      "pod 'customerio-reactnative/apn', :path => customerio_reactnative_path"
+      `pod 'customerio-reactnative/apn', :path => '${RESOLVED_PATH}'`
     );
   });
 
-  it('emits the lambda + fcm subspec line referencing the variable', () => {
+  it('emits the fcm subspec line with a baked :path', () => {
     const snippet = buildHostAppPodSnippet(IOS_PATH, true, {
       locationEnabled: false,
     });
-    expectsLambda(snippet);
     expectsPodLine(
       snippet,
-      "pod 'customerio-reactnative/fcm', :path => customerio_reactnative_path"
+      `pod 'customerio-reactnative/fcm', :path => '${RESOLVED_PATH}'`
     );
   });
 
   it('defaults to single subspec when options are omitted', () => {
     const apnSnippet = buildHostAppPodSnippet(IOS_PATH, false);
-    expectsLambda(apnSnippet);
     expectsPodLine(
       apnSnippet,
-      "pod 'customerio-reactnative/apn', :path => customerio_reactnative_path"
+      `pod 'customerio-reactnative/apn', :path => '${RESOLVED_PATH}'`
     );
 
     const fcmSnippet = buildHostAppPodSnippet(IOS_PATH, true);
-    expectsLambda(fcmSnippet);
     expectsPodLine(
       fcmSnippet,
-      "pod 'customerio-reactnative/fcm', :path => customerio_reactnative_path"
+      `pod 'customerio-reactnative/fcm', :path => '${RESOLVED_PATH}'`
     );
   });
 
@@ -89,17 +68,15 @@ describe('buildHostAppPodSnippet', () => {
       hasPush: true,
     };
     const fcmSnippet = buildHostAppPodSnippet(IOS_PATH, true, options);
-    expectsLambda(fcmSnippet);
     expectsPodLine(
       fcmSnippet,
-      "pod 'customerio-reactnative', :subspecs => ['fcm', 'location'], :path => customerio_reactnative_path"
+      `pod 'customerio-reactnative', :subspecs => ['fcm', 'location'], :path => '${RESOLVED_PATH}'`
     );
 
     const apnSnippet = buildHostAppPodSnippet(IOS_PATH, false, options);
-    expectsLambda(apnSnippet);
     expectsPodLine(
       apnSnippet,
-      "pod 'customerio-reactnative', :subspecs => ['apn', 'location'], :path => customerio_reactnative_path"
+      `pod 'customerio-reactnative', :subspecs => ['apn', 'location'], :path => '${RESOLVED_PATH}'`
     );
   });
 
@@ -109,33 +86,16 @@ describe('buildHostAppPodSnippet', () => {
       hasPush: false,
     };
     const snippet = buildHostAppPodSnippet(IOS_PATH, true, options);
-    expectsLambda(snippet);
     expectsPodLine(
       snippet,
-      "pod 'customerio-reactnative', :subspecs => ['location'], :path => customerio_reactnative_path"
+      `pod 'customerio-reactnative', :subspecs => ['location'], :path => '${RESOLVED_PATH}'`
     );
   });
 
-  it('emits exactly one lambda definition per snippet (idempotence)', () => {
-    const snippet = buildHostAppPodSnippet(IOS_PATH, false, {
-      locationEnabled: true,
-      hasPush: true,
-    });
-    const matches = snippet.match(/customerio_reactnative_path = \(lambda do/g);
-    expect(matches).toHaveLength(1);
-  });
-});
-
-describe('buildResolveSnippet', () => {
-  it('embeds the supplied fallback string verbatim inside the lambda', () => {
-    const snippet = buildResolveSnippet('../my/custom/fallback');
-    expect(snippet).toContain(`'../my/custom/fallback'`);
-  });
-
-  it('does not bake the fallback as the :path => value (it goes in the lambda only)', () => {
-    const snippet = buildResolveSnippet(FALLBACK_PATH);
-    // Should not be of the form `:path => '<fallback>'` — that would be
-    // the old behavior we are deliberately moving away from.
-    expect(snippet).not.toMatch(/:path => '[^']*'/);
+  it('does not emit any Ruby lambda or install-time resolver block', () => {
+    const snippet = buildHostAppPodSnippet(IOS_PATH, false);
+    // Lambda was the previous shape; we resolve at prebuild now and bake.
+    expect(snippet).not.toContain('lambda do');
+    expect(snippet).not.toContain('require.resolve');
   });
 });

--- a/__tests__/ios/injectCIOPodfileCode.test.ts
+++ b/__tests__/ios/injectCIOPodfileCode.test.ts
@@ -1,5 +1,6 @@
 import {
   buildHostAppPodSnippet,
+  buildResolveSnippet,
   type InjectCIOPodfileOptions,
 } from '../../plugin/src/helpers/utils/injectCIOPodfileCode';
 
@@ -16,59 +17,125 @@ jest.mock('../../plugin/src/helpers/utils/fileManagement', () => ({
 
 const IOS_PATH = '/fake/project/ios';
 
+// The snippet must (a) emit a `customerio_reactnative_path` lambda that calls
+// Node's require.resolve at pod install time, and (b) reference that variable
+// on every `pod 'customerio-reactnative...'` line. The prebuild-time path
+// from `getRelativePathToRNSDK` is baked into the lambda only as the
+// fallback. This is the structure that keeps our path in agreement with
+// React Native autolinking under pnpm/yarn symlinks.
+
+const FALLBACK_PATH = '../node_modules/customerio-reactnative';
+
+function expectsLambda(snippet: string) {
+  expect(snippet).toContain('customerio_reactnative_path = (lambda do');
+  expect(snippet).toContain(
+    `\`node --print "require.resolve('customerio-reactnative/package.json')" 2>/dev/null\`.strip`
+  );
+  expect(snippet).toContain(
+    'Pathname.new(File.dirname(out)).relative_path_from(Pathname.new(__dir__)).to_s'
+  );
+  expect(snippet).toContain(`'${FALLBACK_PATH}'`);
+  expect(snippet).toContain('end).call');
+}
+
+function expectsPodLine(snippet: string, line: string) {
+  expect(snippet).toContain(line);
+  // The pod line must reference the variable, not a baked path.
+  expect(snippet).not.toMatch(/pod 'customerio-reactnative.*:path => '[^']*'/);
+}
+
 describe('buildHostAppPodSnippet', () => {
-  it('returns single-subspec pod line when locationEnabled is false', () => {
-    expect(
-      buildHostAppPodSnippet(IOS_PATH, false, { locationEnabled: false })
-    ).toBe(
-      "pod 'customerio-reactnative/apn', :path => '../node_modules/customerio-reactnative'"
-    );
-    expect(
-      buildHostAppPodSnippet(IOS_PATH, true, { locationEnabled: false })
-    ).toBe(
-      "pod 'customerio-reactnative/fcm', :path => '../node_modules/customerio-reactnative'"
+  it('emits the lambda + apn subspec line referencing the variable', () => {
+    const snippet = buildHostAppPodSnippet(IOS_PATH, false, {
+      locationEnabled: false,
+    });
+    expectsLambda(snippet);
+    expectsPodLine(
+      snippet,
+      "pod 'customerio-reactnative/apn', :path => customerio_reactnative_path"
     );
   });
 
-  it('returns single-subspec pod line when options are omitted', () => {
-    expect(buildHostAppPodSnippet(IOS_PATH, false)).toBe(
-      "pod 'customerio-reactnative/apn', :path => '../node_modules/customerio-reactnative'"
-    );
-    expect(buildHostAppPodSnippet(IOS_PATH, true)).toBe(
-      "pod 'customerio-reactnative/fcm', :path => '../node_modules/customerio-reactnative'"
+  it('emits the lambda + fcm subspec line referencing the variable', () => {
+    const snippet = buildHostAppPodSnippet(IOS_PATH, true, {
+      locationEnabled: false,
+    });
+    expectsLambda(snippet);
+    expectsPodLine(
+      snippet,
+      "pod 'customerio-reactnative/fcm', :path => customerio_reactnative_path"
     );
   });
 
-  it('returns subspecs with fcm and location when locationEnabled and hasPush', () => {
+  it('defaults to single subspec when options are omitted', () => {
+    const apnSnippet = buildHostAppPodSnippet(IOS_PATH, false);
+    expectsLambda(apnSnippet);
+    expectsPodLine(
+      apnSnippet,
+      "pod 'customerio-reactnative/apn', :path => customerio_reactnative_path"
+    );
+
+    const fcmSnippet = buildHostAppPodSnippet(IOS_PATH, true);
+    expectsLambda(fcmSnippet);
+    expectsPodLine(
+      fcmSnippet,
+      "pod 'customerio-reactnative/fcm', :path => customerio_reactnative_path"
+    );
+  });
+
+  it('uses :subspecs => with push + location when both enabled', () => {
     const options: InjectCIOPodfileOptions = {
       locationEnabled: true,
       hasPush: true,
     };
-    expect(buildHostAppPodSnippet(IOS_PATH, true, options)).toBe(
-      "pod 'customerio-reactnative', :subspecs => ['fcm', 'location'], :path => '../node_modules/customerio-reactnative'"
+    const fcmSnippet = buildHostAppPodSnippet(IOS_PATH, true, options);
+    expectsLambda(fcmSnippet);
+    expectsPodLine(
+      fcmSnippet,
+      "pod 'customerio-reactnative', :subspecs => ['fcm', 'location'], :path => customerio_reactnative_path"
+    );
+
+    const apnSnippet = buildHostAppPodSnippet(IOS_PATH, false, options);
+    expectsLambda(apnSnippet);
+    expectsPodLine(
+      apnSnippet,
+      "pod 'customerio-reactnative', :subspecs => ['apn', 'location'], :path => customerio_reactnative_path"
     );
   });
 
-  it('returns subspecs with apn and location when locationEnabled and hasPush', () => {
-    const options: InjectCIOPodfileOptions = {
-      locationEnabled: true,
-      hasPush: true,
-    };
-    expect(buildHostAppPodSnippet(IOS_PATH, false, options)).toBe(
-      "pod 'customerio-reactnative', :subspecs => ['apn', 'location'], :path => '../node_modules/customerio-reactnative'"
-    );
-  });
-
-  it('returns only location subspec when locationEnabled and no push', () => {
+  it('emits only the location subspec line when locationEnabled and !hasPush', () => {
     const options: InjectCIOPodfileOptions = {
       locationEnabled: true,
       hasPush: false,
     };
-    expect(buildHostAppPodSnippet(IOS_PATH, true, options)).toBe(
-      "pod 'customerio-reactnative', :subspecs => ['location'], :path => '../node_modules/customerio-reactnative'"
+    const snippet = buildHostAppPodSnippet(IOS_PATH, true, options);
+    expectsLambda(snippet);
+    expectsPodLine(
+      snippet,
+      "pod 'customerio-reactnative', :subspecs => ['location'], :path => customerio_reactnative_path"
     );
-    expect(buildHostAppPodSnippet(IOS_PATH, false, options)).toBe(
-      "pod 'customerio-reactnative', :subspecs => ['location'], :path => '../node_modules/customerio-reactnative'"
-    );
+  });
+
+  it('emits exactly one lambda definition per snippet (idempotence)', () => {
+    const snippet = buildHostAppPodSnippet(IOS_PATH, false, {
+      locationEnabled: true,
+      hasPush: true,
+    });
+    const matches = snippet.match(/customerio_reactnative_path = \(lambda do/g);
+    expect(matches).toHaveLength(1);
+  });
+});
+
+describe('buildResolveSnippet', () => {
+  it('embeds the supplied fallback string verbatim inside the lambda', () => {
+    const snippet = buildResolveSnippet('../my/custom/fallback');
+    expect(snippet).toContain(`'../my/custom/fallback'`);
+  });
+
+  it('does not bake the fallback as the :path => value (it goes in the lambda only)', () => {
+    const snippet = buildResolveSnippet(FALLBACK_PATH);
+    // Should not be of the form `:path => '<fallback>'` — that would be
+    // the old behavior we are deliberately moving away from.
+    expect(snippet).not.toMatch(/:path => '[^']*'/);
   });
 });

--- a/__tests__/postInstallHelper.test.ts
+++ b/__tests__/postInstallHelper.test.ts
@@ -1,0 +1,146 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// The postinstall helper is plain CommonJS that reads INIT_CWD and writes
+// expoVersion into customerio-reactnative/package.json. These tests build
+// real fixture trees and verify the value lands in the right file under
+// flat-npm, pnpm, and yarn-workspace layouts — and that no exception escapes
+// when the package is missing.
+
+const HELPER_PATH = '../plugin/src/postInstallHelper';
+
+const INITIAL_RN_PKG = {
+  name: 'customerio-reactnative',
+  version: '6.4.0',
+};
+
+function makeRNPkgJson(dir: string) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify(INITIAL_RN_PKG, null, 2)
+  );
+}
+
+function readRNPkgJson(dir: string): { name: string; version: string; expoVersion?: string } {
+  return JSON.parse(
+    fs.readFileSync(path.join(dir, 'package.json'), 'utf8')
+  );
+}
+
+describe('postInstallHelper.runPostInstall', () => {
+  let tmpRoot: string;
+  let pluginVersion: string;
+  let originalInitCwd: string | undefined;
+
+  beforeAll(() => {
+    pluginVersion = require('../package.json').version;
+  });
+
+  beforeEach(() => {
+    // realpath needed on macOS because os.tmpdir() symlinks /var to /private/var.
+    tmpRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'cio-postinstall-'))
+    );
+    originalInitCwd = process.env.INIT_CWD;
+    // Reload helper between tests so it picks up the new INIT_CWD.
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    if (originalInitCwd === undefined) {
+      delete process.env.INIT_CWD;
+    } else {
+      process.env.INIT_CWD = originalInitCwd;
+    }
+  });
+
+  it('flat npm: writes expoVersion into <consumer>/node_modules/customerio-reactnative/package.json', () => {
+    const consumerRoot = path.join(tmpRoot, 'flat-npm');
+    const rnDir = path.join(consumerRoot, 'node_modules', 'customerio-reactnative');
+    makeRNPkgJson(rnDir);
+
+    process.env.INIT_CWD = consumerRoot;
+    const { runPostInstall } = require(HELPER_PATH);
+    runPostInstall();
+
+    expect(readRNPkgJson(rnDir).expoVersion).toBe(pluginVersion);
+  });
+
+  it('pnpm: writes through the symlinked path (real file ends up updated)', () => {
+    const consumerRoot = path.join(tmpRoot, 'pnpm-app');
+    const realDir = path.join(
+      consumerRoot,
+      'node_modules',
+      '.pnpm',
+      'customerio-reactnative@6.4.0_abc',
+      'node_modules',
+      'customerio-reactnative'
+    );
+    makeRNPkgJson(realDir);
+
+    const symlinkDir = path.join(
+      consumerRoot,
+      'node_modules',
+      'customerio-reactnative'
+    );
+    fs.mkdirSync(path.dirname(symlinkDir), { recursive: true });
+    fs.symlinkSync(realDir, symlinkDir, 'dir');
+
+    process.env.INIT_CWD = consumerRoot;
+    const { runPostInstall } = require(HELPER_PATH);
+    runPostInstall();
+
+    // Writing through the symlink updates the real file.
+    expect(readRNPkgJson(realDir).expoVersion).toBe(pluginVersion);
+    expect(readRNPkgJson(symlinkDir).expoVersion).toBe(pluginVersion);
+  });
+
+  it('yarn classic workspace: walks up to the hoisted node_modules', () => {
+    const wsRoot = path.join(tmpRoot, 'yarn-ws');
+    const appPath = path.join(wsRoot, 'apps', 'mobile');
+    fs.mkdirSync(path.join(appPath, 'node_modules'), { recursive: true });
+    const rnDir = path.join(wsRoot, 'node_modules', 'customerio-reactnative');
+    makeRNPkgJson(rnDir);
+
+    process.env.INIT_CWD = appPath;
+    const { runPostInstall } = require(HELPER_PATH);
+    runPostInstall();
+
+    expect(readRNPkgJson(rnDir).expoVersion).toBe(pluginVersion);
+  });
+
+  it('does not throw when customerio-reactnative is not installed', () => {
+    const consumerRoot = path.join(tmpRoot, 'no-dep');
+    fs.mkdirSync(consumerRoot, { recursive: true });
+
+    process.env.INIT_CWD = consumerRoot;
+    const { runPostInstall } = require(HELPER_PATH);
+
+    expect(() => runPostInstall()).not.toThrow();
+  });
+
+  it('is idempotent — repeated runs do not rewrite when value matches', () => {
+    const consumerRoot = path.join(tmpRoot, 'idem');
+    const rnDir = path.join(consumerRoot, 'node_modules', 'customerio-reactnative');
+    makeRNPkgJson(rnDir);
+
+    process.env.INIT_CWD = consumerRoot;
+    const { runPostInstall } = require(HELPER_PATH);
+    runPostInstall();
+
+    const pkgPath = path.join(rnDir, 'package.json');
+    const firstMtime = fs.statSync(pkgPath).mtimeMs;
+
+    // Spin briefly so a rewrite would be detectable via mtime.
+    const start = Date.now();
+    while (Date.now() - start < 20) { /* noop */ }
+
+    runPostInstall();
+    const secondMtime = fs.statSync(pkgPath).mtimeMs;
+
+    expect(secondMtime).toBe(firstMtime);
+  });
+});

--- a/plugin/src/helpers/constants/ios.ts
+++ b/plugin/src/helpers/constants/ios.ts
@@ -1,17 +1,97 @@
+import fs from 'fs';
+import * as semver from 'semver';
+
 const path = require('path');
-import { resolveRNSDK } from '../../utils/resolveRNSDK';
+import { resolveRNSDK, tryReadRNVersion } from '../../utils/resolveRNSDK';
 
+// Threshold at which React Native pod autolinking moves from
+// @react-native-community/cli (lexical, symlink-preserving) to
+// expo-modules-autolinking (realpath). The two flavors emit different
+// :path strings on pnpm/yarn-symlink layouts, so to keep CocoaPods happy
+// we must match whichever flavor will resolve the same package later.
+const RN_REALPATH_AUTOLINKING_MIN_VERSION = '0.80.0';
+
+const PLUGIN_LOG_PREFIX = '[CustomerIO Plugin]';
+
+// Always-on so the trail shows up in customer-shared `expo prebuild`
+// output without needing a separate verbose-mode opt-in.
+function pluginLog(message: string): void {
+  // eslint-disable-next-line no-console
+  console.log(`${PLUGIN_LOG_PREFIX} ${message}`);
+}
+
+/**
+ * Returns the relative path from the iOS project dir to the installed
+ * customerio-reactnative directory, in the exact form React Native pod
+ * autolinking will emit for the same package. The two autolinking
+ * flavors disagree on path shape under pnpm/yarn symlinks:
+ *
+ *   - RN <0.80 (`@react-native-community/cli`): walks node_modules
+ *     lexically, preserves symlinks. We keep the symlink path too —
+ *     `tryResolveRNSDK` already does this without calling realpath.
+ *
+ *   - RN >=0.80 (`expo-modules-autolinking`): realpaths the package
+ *     via Node, emitting the underlying `.pnpm/...` (or yarn-classic)
+ *     path. We match by realpath'ing the resolved directory.
+ *
+ * Decision points are logged so a customer's prebuild output is enough
+ * to triage path-resolution issues without a follow-up "set
+ * CUSTOMERIO_DEBUG_MODE and rerun" round-trip.
+ */
 export function getRelativePathToRNSDK(iosPath: string) {
-  // Root path of the Expo project
   const rootAppPath = path.dirname(iosPath);
+  pluginLog(
+    `Resolving customerio-reactnative for Podfile (iosPath=${iosPath}, projectRoot=${rootAppPath})`
+  );
 
-  // Resolve the RN SDK using the symlink path when available so the
-  // emitted Podfile :path agrees with React Native autolinking under
-  // pnpm and yarn workspaces. See resolveRNSDK for details.
   const { packageDir } = resolveRNSDK(rootAppPath);
+  pluginLog(`customerio-reactnative resolved to: ${packageDir}`);
 
-  // Example: ../node_modules/customerio-reactnative
-  return path.relative(iosPath, packageDir);
+  const rnVersion = tryReadRNVersion(rootAppPath);
+  pluginLog(`Detected react-native version: ${rnVersion ?? 'unknown'}`);
+
+  const useLexical = shouldUseLexicalPath(rnVersion);
+  pluginLog(
+    useLexical
+      ? `RN <${RN_REALPATH_AUTOLINKING_MIN_VERSION} — using lexical/symlink path to match @react-native-community/cli autolinking`
+      : `RN >=${RN_REALPATH_AUTOLINKING_MIN_VERSION} or unknown — using realpath to match expo-modules-autolinking`
+  );
+
+  let absolutePath: string;
+  if (useLexical) {
+    absolutePath = packageDir;
+  } else {
+    try {
+      absolutePath = fs.realpathSync(packageDir);
+      if (absolutePath !== packageDir) {
+        pluginLog(`Realpath differs from resolved dir: ${absolutePath}`);
+      }
+    } catch (err) {
+      pluginLog(
+        `realpathSync failed (${
+          err instanceof Error ? err.message : String(err)
+        }); falling back to symlink path`
+      );
+      absolutePath = packageDir;
+    }
+  }
+
+  const relativePath = path.relative(iosPath, absolutePath);
+  pluginLog(`Final Podfile :path => '${relativePath}'`);
+  return relativePath;
+}
+
+function shouldUseLexicalPath(rnVersion: string | null): boolean {
+  if (!rnVersion) {
+    // Modern Expo (realpath) has been the working path for the last few
+    // SDKs, so it's the safer default when RN can't be detected.
+    return false;
+  }
+  const coerced = semver.valid(rnVersion) || semver.coerce(rnVersion);
+  if (!coerced) {
+    return false;
+  }
+  return semver.lt(coerced, RN_REALPATH_AUTOLINKING_MIN_VERSION);
 }
 
 export const IOS_DEPLOYMENT_TARGET = '13.0';

--- a/plugin/src/helpers/constants/ios.ts
+++ b/plugin/src/helpers/constants/ios.ts
@@ -1,18 +1,17 @@
 const path = require('path');
-const resolveFrom = require('resolve-from');
+import { resolveRNSDK } from '../../utils/resolveRNSDK';
 
 export function getRelativePathToRNSDK(iosPath: string) {
   // Root path of the Expo project
   const rootAppPath = path.dirname(iosPath);
 
-  // Path of the cio RN package.json file. Example: test-app/node_modules/customerio-reactnative/package.json
-  const pluginPackageJsonPath = resolveFrom.silent(
-    rootAppPath,
-    `customerio-reactnative/package.json`
-  );
+  // Resolve the RN SDK using the symlink path when available so the
+  // emitted Podfile :path agrees with React Native autolinking under
+  // pnpm and yarn workspaces. See resolveRNSDK for details.
+  const { packageDir } = resolveRNSDK(rootAppPath);
 
   // Example: ../node_modules/customerio-reactnative
-  return path.relative(iosPath, path.dirname(pluginPackageJsonPath));
+  return path.relative(iosPath, packageDir);
 }
 
 export const IOS_DEPLOYMENT_TARGET = '13.0';

--- a/plugin/src/helpers/utils/injectCIOPodfileCode.ts
+++ b/plugin/src/helpers/utils/injectCIOPodfileCode.ts
@@ -13,15 +13,12 @@ export type InjectCIOPodfileOptions = {
 
 /** Builds the host-app pod snippet for the Podfile.
  *
- * Emits a `customerio_reactnative_path` Ruby lambda that resolves the
- * customerio-reactnative path at pod install time using Node's
- * `require.resolve`, with the prebuild-time relative path baked in as a
- * fallback. Each pod line then references the variable instead of a baked
- * path string. This guarantees the path our pod entry uses is identical to
- * whatever path React Native autolinking emits in the same Podfile (both go
- * through Node's resolver at the same moment), avoiding CocoaPods'
- * "multiple dependencies with different sources" error under pnpm/yarn
- * symlinks.
+ * The :path is resolved at prebuild time by `getRelativePathToRNSDK`,
+ * which dispatches on the installed React Native version so the path
+ * matches what RN pod autolinking will emit (lexical for RN <0.80,
+ * realpath for RN >=0.80). Baking the resolved string directly avoids
+ * any Ruby/install-time logic in the Podfile and keeps the snippet
+ * trivially diff-able.
  *
  * Exported for tests.
  */
@@ -30,47 +27,19 @@ export function buildHostAppPodSnippet(
   isFcmPushProvider: boolean,
   options?: InjectCIOPodfileOptions
 ): string {
-  const fallbackPath = getRelativePathToRNSDK(iosPath);
+  const resolvedPath = getRelativePathToRNSDK(iosPath);
   const locationEnabled = options?.locationEnabled === true;
   const hasPush = options?.hasPush !== false;
 
-  const podLine = (() => {
-    if (!locationEnabled) {
-      const subspec = isFcmPushProvider ? 'fcm' : 'apn';
-      return `pod 'customerio-reactnative/${subspec}', :path => customerio_reactnative_path`;
-    }
-    if (!hasPush) {
-      return `pod 'customerio-reactnative', :subspecs => ['location'], :path => customerio_reactnative_path`;
-    }
-    const pushSubspec = isFcmPushProvider ? 'fcm' : 'apn';
-    return `pod 'customerio-reactnative', :subspecs => ['${pushSubspec}', 'location'], :path => customerio_reactnative_path`;
-  })();
-
-  return [
-    buildResolveSnippet(fallbackPath),
-    podLine,
-  ].join('\n  ');
-}
-
-/** Ruby lambda that resolves customerio-reactnative at pod install time.
- * Shape mirrors the canonical Expo pattern (e.g. `@expo/config-plugins`'s
- * `Maps.ts`) so the path matches what `use_native_modules!` emits.
- * Exported for tests.
- */
-export function buildResolveSnippet(fallbackPath: string): string {
-  // The fallback string lives literally inside the lambda. Single-quoted to
-  // be safe with Ruby (the prebuild-resolved path is always relative and
-  // POSIX, no escape concerns in practice).
-  return [
-    `customerio_reactnative_path = (lambda do`,
-    `    out = \`node --print "require.resolve('customerio-reactnative/package.json')" 2>/dev/null\`.strip`,
-    `    if $?.success? && !out.empty?`,
-    `      Pathname.new(File.dirname(out)).relative_path_from(Pathname.new(__dir__)).to_s`,
-    `    else`,
-    `      '${fallbackPath}'`,
-    `    end`,
-    `  end).call`,
-  ].join('\n  ');
+  if (!locationEnabled) {
+    const subspec = isFcmPushProvider ? 'fcm' : 'apn';
+    return `pod 'customerio-reactnative/${subspec}', :path => '${resolvedPath}'`;
+  }
+  if (!hasPush) {
+    return `pod 'customerio-reactnative', :subspecs => ['location'], :path => '${resolvedPath}'`;
+  }
+  const pushSubspec = isFcmPushProvider ? 'fcm' : 'apn';
+  return `pod 'customerio-reactnative', :subspecs => ['${pushSubspec}', 'location'], :path => '${resolvedPath}'`;
 }
 
 export async function injectCIOPodfileCode(
@@ -126,12 +95,7 @@ export async function injectCIONotificationPodfileCode(
   const matches = podfile.match(new RegExp(blockStart));
 
   if (!matches) {
-    // The NSE target is a separate `target 'NotificationService'` block; the
-    // lambda from the host-app block is out of scope here. Emit the same
-    // resolver locally so customerio-reactnative-richpush points at the
-    // same directory Node resolves at install time, consistent with the
-    // host-app pod entry.
-    const resolveSnippet = buildResolveSnippet(getRelativePathToRNSDK(iosPath));
+    const resolvedPath = getRelativePathToRNSDK(iosPath);
     const subspec = isFcmPushProvider ? 'fcm' : 'apn';
     const useFrameworksLine =
       useFrameworks === 'static' ? 'use_frameworks! :linkage => :static' : '';
@@ -140,8 +104,7 @@ export async function injectCIONotificationPodfileCode(
 ${blockStart}
 target 'NotificationService' do
   ${useFrameworksLine}
-  ${resolveSnippet}
-  pod 'customerio-reactnative-richpush/${subspec}', :path => customerio_reactnative_path
+  pod 'customerio-reactnative-richpush/${subspec}', :path => '${resolvedPath}'
 end
 ${blockEnd}
 `.trim();

--- a/plugin/src/helpers/utils/injectCIOPodfileCode.ts
+++ b/plugin/src/helpers/utils/injectCIOPodfileCode.ts
@@ -11,27 +11,66 @@ export type InjectCIOPodfileOptions = {
   hasPush?: boolean;
 };
 
-/** Builds the host app pod line for the Podfile (single subspec or :subspecs with location). Exported for tests. */
+/** Builds the host-app pod snippet for the Podfile.
+ *
+ * Emits a `customerio_reactnative_path` Ruby lambda that resolves the
+ * customerio-reactnative path at pod install time using Node's
+ * `require.resolve`, with the prebuild-time relative path baked in as a
+ * fallback. Each pod line then references the variable instead of a baked
+ * path string. This guarantees the path our pod entry uses is identical to
+ * whatever path React Native autolinking emits in the same Podfile (both go
+ * through Node's resolver at the same moment), avoiding CocoaPods'
+ * "multiple dependencies with different sources" error under pnpm/yarn
+ * symlinks.
+ *
+ * Exported for tests.
+ */
 export function buildHostAppPodSnippet(
   iosPath: string,
   isFcmPushProvider: boolean,
   options?: InjectCIOPodfileOptions
 ): string {
-  const path = getRelativePathToRNSDK(iosPath);
+  const fallbackPath = getRelativePathToRNSDK(iosPath);
   const locationEnabled = options?.locationEnabled === true;
   const hasPush = options?.hasPush !== false;
 
-  if (!locationEnabled) {
-    const subspec = isFcmPushProvider ? 'fcm' : 'apn';
-    return `pod 'customerio-reactnative/${subspec}', :path => '${path}'`;
-  }
+  const podLine = (() => {
+    if (!locationEnabled) {
+      const subspec = isFcmPushProvider ? 'fcm' : 'apn';
+      return `pod 'customerio-reactnative/${subspec}', :path => customerio_reactnative_path`;
+    }
+    if (!hasPush) {
+      return `pod 'customerio-reactnative', :subspecs => ['location'], :path => customerio_reactnative_path`;
+    }
+    const pushSubspec = isFcmPushProvider ? 'fcm' : 'apn';
+    return `pod 'customerio-reactnative', :subspecs => ['${pushSubspec}', 'location'], :path => customerio_reactnative_path`;
+  })();
 
-  if (!hasPush) {
-    return `pod 'customerio-reactnative', :subspecs => ['location'], :path => '${path}'`;
-  }
+  return [
+    buildResolveSnippet(fallbackPath),
+    podLine,
+  ].join('\n  ');
+}
 
-  const pushSubspec = isFcmPushProvider ? 'fcm' : 'apn';
-  return `pod 'customerio-reactnative', :subspecs => ['${pushSubspec}', 'location'], :path => '${path}'`;
+/** Ruby lambda that resolves customerio-reactnative at pod install time.
+ * Shape mirrors the canonical Expo pattern (e.g. `@expo/config-plugins`'s
+ * `Maps.ts`) so the path matches what `use_native_modules!` emits.
+ * Exported for tests.
+ */
+export function buildResolveSnippet(fallbackPath: string): string {
+  // The fallback string lives literally inside the lambda. Single-quoted to
+  // be safe with Ruby (the prebuild-resolved path is always relative and
+  // POSIX, no escape concerns in practice).
+  return [
+    `customerio_reactnative_path = (lambda do`,
+    `    out = \`node --print "require.resolve('customerio-reactnative/package.json')" 2>/dev/null\`.strip`,
+    `    if $?.success? && !out.empty?`,
+    `      Pathname.new(File.dirname(out)).relative_path_from(Pathname.new(__dir__)).to_s`,
+    `    else`,
+    `      '${fallbackPath}'`,
+    `    end`,
+    `  end).call`,
+  ].join('\n  ');
 }
 
 export async function injectCIOPodfileCode(
@@ -87,12 +126,22 @@ export async function injectCIONotificationPodfileCode(
   const matches = podfile.match(new RegExp(blockStart));
 
   if (!matches) {
+    // The NSE target is a separate `target 'NotificationService'` block; the
+    // lambda from the host-app block is out of scope here. Emit the same
+    // resolver locally so customerio-reactnative-richpush points at the
+    // same directory Node resolves at install time, consistent with the
+    // host-app pod entry.
+    const resolveSnippet = buildResolveSnippet(getRelativePathToRNSDK(iosPath));
+    const subspec = isFcmPushProvider ? 'fcm' : 'apn';
+    const useFrameworksLine =
+      useFrameworks === 'static' ? 'use_frameworks! :linkage => :static' : '';
+
     const snippetToInjectInPodfile = `
 ${blockStart}
 target 'NotificationService' do
-  ${useFrameworks === 'static' ? 'use_frameworks! :linkage => :static' : ''}
-  pod 'customerio-reactnative-richpush/${isFcmPushProvider ? 'fcm' : 'apn'
-      }', :path => '${getRelativePathToRNSDK(iosPath)}'
+  ${useFrameworksLine}
+  ${resolveSnippet}
+  pod 'customerio-reactnative-richpush/${subspec}', :path => customerio_reactnative_path
 end
 ${blockEnd}
 `.trim();

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -8,6 +8,7 @@ import type {
   LocationTrackingMode,
   NativeSDKConfig,
 } from './types/cio-types';
+import { withExpoVersion } from './utils/writeExpoVersion';
 
 export type { LocationTrackingMode, NativeSDKConfig };
 
@@ -24,6 +25,12 @@ function withCustomerIOPlugin(
       'See documentation for manual setup instructions.'
     );
   }
+
+  // Belt-and-suspenders write of the plugin version into the RN SDK's
+  // package.json. The postinstall hook does the same write at install time;
+  // this covers installs where postinstall didn't run cleanly (pnpm with
+  // strict store layouts, --ignore-scripts, cached CI installs, etc).
+  config = withExpoVersion(config);
 
   // Apply platform specific modifications
   config = withCIOIos(config, props.config, props.ios, props.location);

--- a/plugin/src/postInstallHelper.js
+++ b/plugin/src/postInstallHelper.js
@@ -1,32 +1,90 @@
 const fs = require('fs');
+const path = require('path');
+
+const RN_SDK_PACKAGE = 'customerio-reactnative';
+
+// Locate customerio-reactnative/package.json from a postinstall context.
+//
+// `INIT_CWD` is set by npm, pnpm, and yarn during lifecycle scripts to point
+// at the consumer's project root. That makes it the most reliable starting
+// point — the plugin's own __dirname can be deep inside `.pnpm/...` under pnpm.
+//
+// We probe `${INIT_CWD}/node_modules/customerio-reactnative/package.json` first
+// so we agree with the symlinked layout React Native autolinking expects, then
+// fall back to resolve-from from the consumer root, then to the legacy
+// __dirname-relative walk-up for environments where INIT_CWD is missing.
+function findRNSDKPackageJson() {
+  const candidates = [];
+
+  if (process.env.INIT_CWD) {
+    candidates.push(
+      path.join(process.env.INIT_CWD, 'node_modules', RN_SDK_PACKAGE, 'package.json')
+    );
+  }
+
+  // Legacy flat-npm layout fallback: plugin lives at
+  // <consumer>/node_modules/customerio-expo-plugin/plugin/src and the SDK at
+  // <consumer>/node_modules/customerio-reactnative.
+  candidates.push(path.join(__dirname, '..', '..', '..', RN_SDK_PACKAGE, 'package.json'));
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Final fallback: resolve-from from INIT_CWD. This walks up node_modules
+  // and handles yarn classic workspaces where the dep is hoisted.
+  if (process.env.INIT_CWD) {
+    try {
+      const resolveFrom = require('resolve-from');
+      const resolved = resolveFrom.silent(
+        process.env.INIT_CWD,
+        `${RN_SDK_PACKAGE}/package.json`
+      );
+      if (resolved) return resolved;
+    } catch (_) {
+      // resolve-from missing or unable to resolve — fall through to null.
+    }
+  }
+
+  return null;
+}
 
 function runPostInstall() {
-  // react native SDK package.json path
-  const reactNativePackageJsonFile = `${__dirname}/../../../customerio-reactnative/package.json`;
-  const expoPackageJsonFile = `${__dirname}/../../package.json`;
+  const expoPackageJsonFile = path.join(__dirname, '..', '..', 'package.json');
+
   try {
-    // if react native SDK is installed
-    if (fs.existsSync(reactNativePackageJsonFile)) {
-      const reactNativePackageJson = fs.readFileSync(
-        reactNativePackageJsonFile,
-        'utf8'
-      );
-      const expoPackageJson = require(expoPackageJsonFile);
-
-      const reactNativePackage = JSON.parse(reactNativePackageJson);
-      reactNativePackage.expoVersion = expoPackageJson.version;
-
-      fs.writeFileSync(
-        reactNativePackageJsonFile,
-        JSON.stringify(reactNativePackage, null, 2)
-      );
+    const reactNativePackageJsonFile = findRNSDKPackageJson();
+    if (!reactNativePackageJsonFile) {
+      // Not necessarily an error: the plugin may be installed without the RN
+      // SDK (e.g., during a tooling-only install). The prebuild-time write
+      // covers the common case anyway.
+      return;
     }
+
+    const expoPackageJson = require(expoPackageJsonFile);
+    const reactNativePackage = JSON.parse(
+      fs.readFileSync(reactNativePackageJsonFile, 'utf8')
+    );
+
+    if (reactNativePackage.expoVersion === expoPackageJson.version) {
+      return;
+    }
+
+    reactNativePackage.expoVersion = expoPackageJson.version;
+    fs.writeFileSync(
+      reactNativePackageJsonFile,
+      JSON.stringify(reactNativePackage, null, 2)
+    );
   } catch (error) {
     console.warn(
-      'Unable to find customerio-reactnative package.json file. Please make sure you have installed the customerio-reactnative package.',
+      'customerio-expo-plugin postinstall: failed to write expoVersion into customerio-reactnative/package.json. ' +
+        'The expo prebuild step will retry this. Original error:',
       error
     );
   }
 }
 
 exports.runPostInstall = runPostInstall;
+exports.findRNSDKPackageJson = findRNSDKPackageJson;

--- a/plugin/src/utils/resolveRNSDK.ts
+++ b/plugin/src/utils/resolveRNSDK.ts
@@ -1,0 +1,66 @@
+import fs from 'fs';
+import path from 'path';
+
+const RN_SDK_PACKAGE = 'customerio-reactnative';
+
+export type ResolvedRNSDK = {
+  // Absolute path to the package directory.
+  packageDir: string;
+  // Absolute path to package.json inside that directory.
+  packageJsonPath: string;
+};
+
+// Resolves the customerio-reactnative SDK location starting from `fromDir`.
+//
+// Probe-then-fallback so the result agrees with React Native autolinking
+// across npm flat, pnpm, and yarn-workspace layouts:
+//   1. `fromDir/node_modules/customerio-reactnative/package.json` — preferred.
+//      Works for npm flat, pnpm (the symlinked path; we never realpath it),
+//      and yarn workspaces with leaf node_modules. Matches what RN
+//      autolinking emits for its pod entry, so CocoaPods sees one
+//      consistent :path.
+//   2. `resolve-from` walking up from `fromDir` — only used when (1) misses.
+//      Handles yarn classic workspaces where the dep is hoisted to a parent
+//      node_modules. yarn classic has no symlinks, so the realpath is fine.
+//
+// Returns null if neither finds the package.
+export function tryResolveRNSDK(fromDir: string): ResolvedRNSDK | null {
+  const directPkgJson = path.join(
+    fromDir,
+    'node_modules',
+    RN_SDK_PACKAGE,
+    'package.json'
+  );
+  if (fs.existsSync(directPkgJson)) {
+    return {
+      packageDir: path.dirname(directPkgJson),
+      packageJsonPath: directPkgJson,
+    };
+  }
+
+  const resolveFrom = require('resolve-from');
+  const fallbackPkgJson = resolveFrom.silent(
+    fromDir,
+    `${RN_SDK_PACKAGE}/package.json`
+  );
+  if (fallbackPkgJson) {
+    return {
+      packageDir: path.dirname(fallbackPkgJson),
+      packageJsonPath: fallbackPkgJson,
+    };
+  }
+
+  return null;
+}
+
+// Same as tryResolveRNSDK but throws a clear error when the package is missing.
+export function resolveRNSDK(fromDir: string): ResolvedRNSDK {
+  const resolved = tryResolveRNSDK(fromDir);
+  if (!resolved) {
+    throw new Error(
+      `${RN_SDK_PACKAGE} was not found relative to ${fromDir}. ` +
+      `Ensure it is installed in your project (or in a parent workspace's node_modules).`
+    );
+  }
+  return resolved;
+}

--- a/plugin/src/utils/resolveRNSDK.ts
+++ b/plugin/src/utils/resolveRNSDK.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 const RN_SDK_PACKAGE = 'customerio-reactnative';
+const REACT_NATIVE_PACKAGE = 'react-native';
 
 export type ResolvedRNSDK = {
   // Absolute path to the package directory.
@@ -9,6 +10,50 @@ export type ResolvedRNSDK = {
   // Absolute path to package.json inside that directory.
   packageJsonPath: string;
 };
+
+// Reads the installed react-native package's version starting from `fromDir`.
+// Used to decide which autolinking flavor will resolve customerio-reactnative
+// at pod install time, so our :path agrees with what autolinking emits:
+//   - RN <0.80 ships @react-native-community/cli, which uses a lexical
+//     resolution (no realpath following).
+//   - RN >=0.80 routes pod autolinking through expo-modules-autolinking,
+//     which realpaths.
+// Returns null if react-native cannot be located or its package.json cannot
+// be read; callers should default to the modern (realpath) behavior in that
+// case since it has been the working path for the last several Expo SDKs.
+export function tryReadRNVersion(fromDir: string): string | null {
+  try {
+    const direct = path.join(
+      fromDir,
+      'node_modules',
+      REACT_NATIVE_PACKAGE,
+      'package.json'
+    );
+    if (fs.existsSync(direct)) {
+      return readVersion(direct);
+    }
+    const resolveFrom = require('resolve-from');
+    const fallback = resolveFrom.silent(
+      fromDir,
+      `${REACT_NATIVE_PACKAGE}/package.json`
+    );
+    if (fallback) {
+      return readVersion(fallback);
+    }
+  } catch {
+    // Fall through to null.
+  }
+  return null;
+}
+
+function readVersion(pkgJsonPath: string): string | null {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+    return typeof pkg.version === 'string' ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
 
 // Resolves the customerio-reactnative SDK location starting from `fromDir`.
 //

--- a/plugin/src/utils/resolveRNSDK.ts
+++ b/plugin/src/utils/resolveRNSDK.ts
@@ -68,31 +68,38 @@ function readVersion(pkgJsonPath: string): string | null {
 //      Handles yarn classic workspaces where the dep is hoisted to a parent
 //      node_modules. yarn classic has no symlinks, so the realpath is fine.
 //
-// Returns null if neither finds the package.
+// Returns null if neither finds the package, including the case where
+// `resolve-from` itself can't be required (mirrors tryReadRNVersion's
+// graceful-failure shape so callers can rely on the documented contract).
 export function tryResolveRNSDK(fromDir: string): ResolvedRNSDK | null {
-  const directPkgJson = path.join(
-    fromDir,
-    'node_modules',
-    RN_SDK_PACKAGE,
-    'package.json'
-  );
-  if (fs.existsSync(directPkgJson)) {
-    return {
-      packageDir: path.dirname(directPkgJson),
-      packageJsonPath: directPkgJson,
-    };
-  }
+  try {
+    const directPkgJson = path.join(
+      fromDir,
+      'node_modules',
+      RN_SDK_PACKAGE,
+      'package.json'
+    );
+    if (fs.existsSync(directPkgJson)) {
+      return {
+        packageDir: path.dirname(directPkgJson),
+        packageJsonPath: directPkgJson,
+      };
+    }
 
-  const resolveFrom = require('resolve-from');
-  const fallbackPkgJson = resolveFrom.silent(
-    fromDir,
-    `${RN_SDK_PACKAGE}/package.json`
-  );
-  if (fallbackPkgJson) {
-    return {
-      packageDir: path.dirname(fallbackPkgJson),
-      packageJsonPath: fallbackPkgJson,
-    };
+    const resolveFrom = require('resolve-from');
+    const fallbackPkgJson = resolveFrom.silent(
+      fromDir,
+      `${RN_SDK_PACKAGE}/package.json`
+    );
+    if (fallbackPkgJson) {
+      return {
+        packageDir: path.dirname(fallbackPkgJson),
+        packageJsonPath: fallbackPkgJson,
+      };
+    }
+  } catch {
+    // Fall through to null. resolveRNSDK() turns this into a clear
+    // "customerio-reactnative was not found" error for the caller.
   }
 
   return null;

--- a/plugin/src/utils/writeExpoVersion.ts
+++ b/plugin/src/utils/writeExpoVersion.ts
@@ -1,0 +1,62 @@
+import fs from 'fs';
+import type { ConfigPlugin } from '@expo/config-plugins';
+
+import { logger } from './logger';
+import { getPluginVersion } from './plugin';
+import { tryResolveRNSDK } from './resolveRNSDK';
+
+// Writes the plugin's version into customerio-reactnative/package.json under
+// the `expoVersion` key. The RN SDK reads this at runtime (customerio-cdp.ts)
+// to set its User-Agent `packageSource` to "Expo" instead of "ReactNative".
+//
+// We rely on the postinstall hook (postInstallHelper.js) for the same write
+// at install time, but call this from the plugin entry as a fallback for
+// installs where postinstall does not run cleanly — most notably pnpm
+// monorepos and any CI that uses --ignore-scripts.
+//
+// The write is idempotent: we no-op when the value is already correct.
+export function writeExpoVersion(projectRoot: string): void {
+  let resolved;
+  try {
+    resolved = tryResolveRNSDK(projectRoot);
+  } catch (error) {
+    logger.warn(
+      `Could not locate customerio-reactnative to write expoVersion. ` +
+      `User-Agent attribution may be incorrect. Original error: ${error}`
+    );
+    return;
+  }
+
+  if (!resolved) {
+    return;
+  }
+
+  try {
+    const pluginVersion = getPluginVersion();
+    const pkg = JSON.parse(fs.readFileSync(resolved.packageJsonPath, 'utf8'));
+    if (pkg.expoVersion === pluginVersion) {
+      return;
+    }
+    pkg.expoVersion = pluginVersion;
+    fs.writeFileSync(
+      resolved.packageJsonPath,
+      JSON.stringify(pkg, null, 2)
+    );
+  } catch (error) {
+    logger.warn(
+      `Failed to write expoVersion into ${resolved.packageJsonPath}. ` +
+      `User-Agent attribution may be incorrect. Original error: ${error}`
+    );
+  }
+}
+
+export const withExpoVersion: ConfigPlugin = (config) => {
+  // _internal.projectRoot is set by Expo when running through prebuild;
+  // fall back to process.cwd() for any path that calls the plugin in
+  // a non-prebuild context.
+  const projectRoot =
+    (config as unknown as { _internal?: { projectRoot?: string } })._internal?.projectRoot ||
+    process.cwd();
+  writeExpoVersion(projectRoot);
+  return config;
+};

--- a/scripts/verify-pnpm-dev-apps.sh
+++ b/scripts/verify-pnpm-dev-apps.sh
@@ -5,24 +5,19 @@
 #
 # Two regression dimensions:
 #
-#   1. The Podfile must emit the install-time `customerio_reactnative_path`
-#      Ruby lambda, and every `pod 'customerio-reactnative...', :path =>`
-#      line must reference the variable rather than a baked path string.
-#      This is what guarantees the plugin's path agrees with whatever path
-#      React Native autolinking emits in the same Podfile, regardless of
-#      pnpm/yarn/symlink behavior.
-#
-#      The actual path validity is enforced by `pod install` succeeding in
-#      the setup-test-app-pnpm{,-monorepo}.sh steps that ran before this
-#      script — those would already have failed if the resolved path were
-#      bogus. This script's job is to catch plugin bugs that re-introduce
-#      a baked-path :path => before pod install runs.
+#   1. Every customerio-reactnative pod line in the Podfile must use the
+#      same :path => value. CocoaPods rejects "multiple dependencies with
+#      different sources" when our plugin and React Native autolinking
+#      emit different paths for the same package, which is the customer-
+#      reported failure under pnpm. The actual validity of the path is
+#      verified by `pod install` succeeding in the setup-test-app-pnpm{,
+#      -monorepo}.sh steps that ran before this script.
 #
 #   2. `expoVersion` must be present in the installed customerio-reactnative
 #      package.json. The RN SDK reads this at runtime to set User-Agent
 #      attribution to "Expo" instead of "ReactNative". Under pnpm the
 #      postinstall hook can be silently skipped, so the plugin's prebuild-
-#      time fallback must land the field reliably.
+#      time write must land the field reliably.
 
 set -e
 
@@ -66,7 +61,7 @@ find_cio_pkg_json() {
 }
 
 echo
-print_blue "Checking install-time path-resolver lambda is emitted..."
+print_blue "Checking customerio-reactnative pod :path consistency..."
 for podfile in "${PODFILES[@]}"; do
   if [ ! -f "$podfile" ]; then
     echo "::error::$podfile does not exist — did the prebuild step run?"
@@ -74,33 +69,32 @@ for podfile in "${PODFILES[@]}"; do
     continue
   fi
 
-  if ! grep -q "customerio_reactnative_path = (lambda do" "$podfile"; then
-    echo "::error::$podfile is missing the customerio_reactnative_path lambda."
-    echo "         The plugin should emit a Ruby block that resolves the SDK path"
-    echo "         at pod install time via Node's require.resolve."
+  # Extract every distinct :path => value across customerio-reactnative pod
+  # lines (host app + NSE target). All such values must be identical for
+  # CocoaPods to accept the install. The plugin uses one resolved path per
+  # prebuild run, so a divergence here would mean either a bug in the
+  # snippet builder or autolinking emitting a path the plugin didn't match.
+  paths=$(grep -E "^\s*pod 'customerio-reactnative" "$podfile" \
+            | sed -E "s/.*:path *=> *'([^']*)'.*/\1/" \
+            | grep -v "^pod " \
+            | sort -u || true)
+  count=$(echo -n "$paths" | grep -c '^' || true)
+
+  if [ "$count" -eq 0 ]; then
+    echo "::error::$podfile has no customerio-reactnative pod lines with a baked :path."
     failures=$((failures + 1))
     continue
   fi
 
-  if ! grep -q "node --print \"require.resolve('customerio-reactnative/package.json')\"" "$podfile"; then
-    echo "::error::$podfile lambda is missing the node --print require.resolve call."
+  if [ "$count" -gt 1 ]; then
+    echo "::error::$podfile has $count differing :path values for customerio-reactnative pods:"
+    echo "$paths" | sed 's/^/    /'
+    echo "         Every line must agree, otherwise CocoaPods rejects the install."
     failures=$((failures + 1))
     continue
   fi
 
-  # Every customerio-reactnative pod line must reference the variable, not a
-  # baked path string. A baked-path regression looks like
-  # `:path => '../node_modules/...'` instead of `:path => customerio_reactnative_path`.
-  baked=$(grep -E "^\s*pod 'customerio-reactnative.*':path *=> *'" "$podfile" || true)
-  if [ -n "$baked" ]; then
-    echo "::error::$podfile contains a customerio-reactnative pod line with a baked :path => string:"
-    echo "$baked"
-    echo "         Expected every such line to use ':path => customerio_reactnative_path'."
-    failures=$((failures + 1))
-    continue
-  fi
-
-  echo "  OK: $podfile"
+  echo "  OK: $podfile (:path => '$paths')"
 done
 
 echo

--- a/scripts/verify-pnpm-dev-apps.sh
+++ b/scripts/verify-pnpm-dev-apps.sh
@@ -32,10 +32,11 @@ PODFILES=(
   "test-app-pnpm-monorepo/apps/mobile/ios/Podfile"
 )
 
-# Apps whose customerio-reactnative install we need to inspect. The package
-# may live at the leaf app's node_modules (default pnpm isolated layout) OR
-# at a parent's node_modules (pnpm hoisted layout, or yarn-classic-style
-# hoisting in workspaces). We walk up from each app and use the first match.
+# Apps whose customerio-reactnative install we need to inspect. The actual
+# package.json may land at the leaf app's node_modules (default pnpm
+# isolated layout) OR at a parent's node_modules (pnpm hoisted layout, or
+# yarn-classic-style hoisting in workspaces) — so we walk up from each app
+# and use the first match.
 APP_DIRS=(
   "test-app-pnpm"
   "test-app-pnpm-monorepo/apps/mobile"
@@ -75,8 +76,8 @@ for podfile in "${PODFILES[@]}"; do
   # prebuild run, so a divergence here would mean either a bug in the
   # snippet builder or autolinking emitting a path the plugin didn't match.
   paths=$(grep -E "^\s*pod 'customerio-reactnative" "$podfile" \
+            | grep -E ":path *=> *'[^']*'" \
             | sed -E "s/.*:path *=> *'([^']*)'.*/\1/" \
-            | grep -v "^pod " \
             | sort -u || true)
   count=$(echo -n "$paths" | grep -c '^' || true)
 

--- a/scripts/verify-pnpm-dev-apps.sh
+++ b/scripts/verify-pnpm-dev-apps.sh
@@ -1,19 +1,28 @@
 #!/bin/bash
 
-# Asserts that the pnpm dev apps are built with portable, correct artifacts.
+# Asserts that the pnpm dev apps are built with correct artifacts.
 # Run after both setup-test-app-pnpm.sh and setup-test-app-pnpm-monorepo.sh.
 #
 # Two regression dimensions:
 #
-#   1. Podfile :path values must not contain `.pnpm/` — the plugin must emit
-#      the symlinked node_modules path that React Native autolinking expects,
-#      not the realpath inside pnpm's virtual store.
+#   1. The Podfile must emit the install-time `customerio_reactnative_path`
+#      Ruby lambda, and every `pod 'customerio-reactnative...', :path =>`
+#      line must reference the variable rather than a baked path string.
+#      This is what guarantees the plugin's path agrees with whatever path
+#      React Native autolinking emits in the same Podfile, regardless of
+#      pnpm/yarn/symlink behavior.
+#
+#      The actual path validity is enforced by `pod install` succeeding in
+#      the setup-test-app-pnpm{,-monorepo}.sh steps that ran before this
+#      script — those would already have failed if the resolved path were
+#      bogus. This script's job is to catch plugin bugs that re-introduce
+#      a baked-path :path => before pod install runs.
 #
 #   2. `expoVersion` must be present in the installed customerio-reactnative
 #      package.json. The RN SDK reads this at runtime to set User-Agent
 #      attribution to "Expo" instead of "ReactNative". Under pnpm the
-#      postinstall hook can be silently skipped, so the plugin must also
-#      write this at expo-prebuild time.
+#      postinstall hook can be silently skipped, so the plugin's prebuild-
+#      time fallback must land the field reliably.
 
 set -e
 
@@ -57,7 +66,7 @@ find_cio_pkg_json() {
 }
 
 echo
-print_blue "Checking Podfile :path values..."
+print_blue "Checking install-time path-resolver lambda is emitted..."
 for podfile in "${PODFILES[@]}"; do
   if [ ! -f "$podfile" ]; then
     echo "::error::$podfile does not exist — did the prebuild step run?"
@@ -65,15 +74,33 @@ for podfile in "${PODFILES[@]}"; do
     continue
   fi
 
-  offending=$(grep -E "^\s*pod .* :path =>" "$podfile" | grep "\.pnpm/" || true)
-  if [ -n "$offending" ]; then
-    echo "::error::$podfile contains .pnpm/ in a :path => line."
-    echo "Plugin emitted the pnpm realpath instead of the symlink path that React Native autolinking expects."
-    echo "$offending"
+  if ! grep -q "customerio_reactnative_path = (lambda do" "$podfile"; then
+    echo "::error::$podfile is missing the customerio_reactnative_path lambda."
+    echo "         The plugin should emit a Ruby block that resolves the SDK path"
+    echo "         at pod install time via Node's require.resolve."
     failures=$((failures + 1))
-  else
-    echo "  OK: $podfile"
+    continue
   fi
+
+  if ! grep -q "node --print \"require.resolve('customerio-reactnative/package.json')\"" "$podfile"; then
+    echo "::error::$podfile lambda is missing the node --print require.resolve call."
+    failures=$((failures + 1))
+    continue
+  fi
+
+  # Every customerio-reactnative pod line must reference the variable, not a
+  # baked path string. A baked-path regression looks like
+  # `:path => '../node_modules/...'` instead of `:path => customerio_reactnative_path`.
+  baked=$(grep -E "^\s*pod 'customerio-reactnative.*':path *=> *'" "$podfile" || true)
+  if [ -n "$baked" ]; then
+    echo "::error::$podfile contains a customerio-reactnative pod line with a baked :path => string:"
+    echo "$baked"
+    echo "         Expected every such line to use ':path => customerio_reactnative_path'."
+    failures=$((failures + 1))
+    continue
+  fi
+
+  echo "  OK: $podfile"
 done
 
 echo


### PR DESCRIPTION
## Summary

Resolves the Podfile `:path` for `customerio-reactnative` at **prebuild time** in TypeScript and bakes the result directly into `:path => '<resolved>'`. The resolver dispatches on the installed React Native version (via `semver.lt(rnVersion, '0.80.0')`) so it always produces the exact path React Native pod autolinking will emit for the same package:

- **RN <0.80** (`@react-native-community/cli`): keeps the lexical / symlink-preserving path. Matches autolinking's lexical `node_modules` walk.
- **RN >=0.80** (`expo-modules-autolinking`): realpaths the resolved package directory. Matches autolinking's deliberate `realpath` behavior on iOS.
- **Unknown RN**: defaults to realpath (the working path on every recent Expo SDK).

Every decision point logs to stdout under a `[CustomerIO Plugin]` prefix so the trail is visible in `expo prebuild` output without needing to opt into a verbose-mode flag — useful for triage from a customer's prebuild log alone.

This PR also fixes a related User-Agent attribution gap on iOS: under pnpm, the plugin's postinstall hook silently fails to write `expoVersion` into the SDK's `package.json`, causing every iOS API request to be tagged as `ReactNative` instead of `Expo`. The hook now uses `INIT_CWD` (set by every supported package manager) and a prebuild-time backstop ensures the field lands even if postinstall is skipped (pnpm 10+ blocks lifecycle scripts by default; CI cache and `--ignore-scripts` paths can also drop it).

## Context

The bug stemmed from path resolution disagreeing between two processes that look up the same package: `expo prebuild` (Node, our process) and `pod install` (Ruby, CocoaPods, also shells to Node for autolinking). Under pnpm, `node_modules/customerio-reactnative` is a symlink into `node_modules/.pnpm/<hash>/...`, and the two resolvers disagreed on whether to realpath through it. CocoaPods rejected the install with `"multiple dependencies with different sources for 'customerio-reactnative'"`.

The two RN autolinking implementations also disagree with **each other** on path shape:

- `@react-native-community/cli` (RN <=0.79) walks `node_modules` lexically and emits the symlink path.
- `expo-modules-autolinking` (RN >=0.80) deliberately realpaths and emits the underlying `.pnpm/...` path.

Co-locating resolution at install time via a Ruby lambda would only match one of them. Resolving at prebuild *with the right algorithm for the detected RN version* matches whichever flavor will run later — without any install-time machinery.

Both branches converge on the same string under flat npm (no symlinks to disagree about), so the dominant install layout is unaffected — there's a regression test in `getRelativePathToRNSDK.test.ts` that locks this in for both RN dispatch branches.

## Test plan

### Automated (this PR)

- [ ] `Test pnpm Compatibility` workflow (`macos-15`, both isolated and hoisted phases from the parent PR) goes green. Each phase runs `expo prebuild --clean` + `pod install` against both pnpm dev apps.
- [ ] `npm test` — full Jest suite passes. Includes:
  - New on-disk fixture tests in `__tests__/ios/getRelativePathToRNSDK.test.ts` covering both autolinking flavors (RN <0.80 lexical, RN >=0.80 realpath) across npm flat / pnpm / yarn-workspace / unknown-RN layouts, plus an explicit flat-npm regression test that asserts identical output on both dispatch branches.
  - Updated `__tests__/ios/injectCIOPodfileCode.test.ts` for the lambda-less Podfile shape.
- [ ] `npm run typescript` — clean.
- [ ] `npm run lint` — clean.
- [ ] `npm run verify-pnpm-dev-apps` — asserts that every `customerio-reactnative` pod entry in each generated Podfile shares a single `:path => '<value>'` (consistency check; CocoaPods rejects on divergence) and that `expoVersion` is present in the resolved `customerio-reactnative/package.json`. The package.json check walks up from each app dir so it works under both pnpm-isolated (leaf) and hoisted (workspace-root) layouts.
- [ ] `Validate Plugin Compatibility` matrix continues to pass on every Expo version × push provider × platform cell — proves no regression for the existing flat-npm path.

### Manual (recommended before final review)

- [ ] On a real device or simulator, confirm the iOS User-Agent header on outgoing API requests reads `Expo Client/<plugin-version>` (HTTP proxy, or breakpoint in the SDK's `UserAgentUtil.swift`).
- [ ] Smoke-test push registration and a campaign delivery on iOS with a pnpm install to confirm the `NativeCustomerIO` TurboModule links correctly.
- [ ] Quick check on the existing npm `test-app/` to confirm prebuild-time resolution doesn't change behavior there. The emitted `:path => '../node_modules/customerio-reactnative'` is identical to what main produces today (no symlinks → realpath is a no-op → both dispatch branches converge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how iOS Podfile snippets compute `:path` (including realpath vs symlink behavior by RN version) and adds logic that mutates the installed `customerio-reactnative/package.json` during postinstall/prebuild, which could affect installs across different package manager layouts.
> 
> **Overview**
> Fixes CocoaPods "multiple dependencies with different sources" failures by changing iOS Podfile injection to **pre-resolve** the `customerio-reactnative` location and bake a single `:path => '...'` string, dispatching on detected React Native version (**RN <0.80 keeps symlink/lexical paths; RN >=0.80 or unknown uses realpath**) and logging the decision path.
> 
> Hardens Expo User-Agent attribution by making the postinstall helper locate the SDK via `INIT_CWD`/workspace fallbacks, making the write idempotent, and adding a prebuild-time backstop (`withExpoVersion`) that writes the plugin version into `customerio-reactnative/package.json`. Tests and pnpm verification scripts are updated/added to cover pnpm/yarn/flat layouts and to assert Podfile path-shape/consistency rather than exact literals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d134403c8064754a3f8d74c3784a7a5bf435f04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->