### PR TITLE
chore: inject killed-state deep link workaround before factory.startReactNative

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,4 +76,4 @@ jobs:
         run: npm ci
 
       - name: Run utils tests
-        run: npm test -- __tests__/utils
+        run: npm test -- __tests__/utils __tests__/ios/withCIOIos.test.ts __tests__/ios/withCIOIosSwift.test.ts

--- a/__tests__/ios/__snapshots__/withCIOIosSwift.test.ts.snap
+++ b/__tests__/ios/__snapshots__/withCIOIosSwift.test.ts.snap
@@ -1,0 +1,141 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`withCIOIosSwift handleDeeplinkInKilledState placement injects deeplink workaround BEFORE factory.startReactNative on modern Expo Swift templates 1`] = `
+"import Expo
+import React
+import ReactAppDependencyProvider
+
+@UIApplicationMain
+public class AppDelegate: ExpoAppDelegate {
+  let cioSdkHandler = CioSdkAppDelegateHandler()
+
+  var window: UIWindow?
+
+  var reactNativeDelegate: ExpoReactNativeFactoryDelegate?
+  var reactNativeFactory: RCTReactNativeFactory?
+
+  public override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    let delegate = ReactNativeDelegate()
+    let factory = ExpoReactNativeFactory(delegate: delegate)
+    delegate.dependencyProvider = RCTAppDependencyProvider()
+
+    reactNativeDelegate = delegate
+    reactNativeFactory = factory
+    bindReactNativeFactory(factory)
+
+    // Deep link workaround for app killed state start
+    var modifiedLaunchOptions = launchOptions
+    if let launchOptions = launchOptions,
+       let pushContent = launchOptions[UIApplication.LaunchOptionsKey.remoteNotification] as? [AnyHashable: Any],
+       let cio = pushContent["CIO"] as? [String: Any],
+       let push = cio["push"] as? [String: Any],
+       let link = push["link"] as? String,
+       !launchOptions.keys.contains(UIApplication.LaunchOptionsKey.url) {
+        
+        var mutableLaunchOptions = launchOptions
+        mutableLaunchOptions[UIApplication.LaunchOptionsKey.url] = URL(string: link)
+        modifiedLaunchOptions = mutableLaunchOptions
+    }
+    // Deep link workaround for app killed state ends
+
+#if os(iOS) || os(tvOS)
+    window = UIWindow(frame: UIScreen.main.bounds)
+    factory.startReactNative(
+      withModuleName: "main",
+      in: window,
+      launchOptions: modifiedLaunchOptions)
+#endif
+
+      cioSdkHandler.application(application, didFinishLaunchingWithOptions: launchOptions)
+
+    return super.application(application, didFinishLaunchingWithOptions: modifiedLaunchOptions)
+  }
+
+  // Handle device token registration
+  public override func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+    // Call CustomerIO SDK handler
+    cioSdkHandler.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+    super.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+  }
+
+  // Handle remote notification registration errors
+  public override func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+    // Call CustomerIO SDK handler
+    cioSdkHandler.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+    super.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+  }
+}"
+`;
+
+exports[`withCIOIosSwift handleDeeplinkInKilledState placement routes modifiedLaunchOptions into factory.startReactNative on modern templates 1`] = `
+"import Expo
+import React
+import ReactAppDependencyProvider
+
+@UIApplicationMain
+public class AppDelegate: ExpoAppDelegate {
+  let cioSdkHandler = CioSdkAppDelegateHandler()
+
+  var window: UIWindow?
+
+  var reactNativeDelegate: ExpoReactNativeFactoryDelegate?
+  var reactNativeFactory: RCTReactNativeFactory?
+
+  public override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    let delegate = ReactNativeDelegate()
+    let factory = ExpoReactNativeFactory(delegate: delegate)
+    delegate.dependencyProvider = RCTAppDependencyProvider()
+
+    reactNativeDelegate = delegate
+    reactNativeFactory = factory
+    bindReactNativeFactory(factory)
+
+    // Deep link workaround for app killed state start
+    var modifiedLaunchOptions = launchOptions
+    if let launchOptions = launchOptions,
+       let pushContent = launchOptions[UIApplication.LaunchOptionsKey.remoteNotification] as? [AnyHashable: Any],
+       let cio = pushContent["CIO"] as? [String: Any],
+       let push = cio["push"] as? [String: Any],
+       let link = push["link"] as? String,
+       !launchOptions.keys.contains(UIApplication.LaunchOptionsKey.url) {
+        
+        var mutableLaunchOptions = launchOptions
+        mutableLaunchOptions[UIApplication.LaunchOptionsKey.url] = URL(string: link)
+        modifiedLaunchOptions = mutableLaunchOptions
+    }
+    // Deep link workaround for app killed state ends
+
+#if os(iOS) || os(tvOS)
+    window = UIWindow(frame: UIScreen.main.bounds)
+    factory.startReactNative(
+      withModuleName: "main",
+      in: window,
+      launchOptions: modifiedLaunchOptions)
+#endif
+
+      cioSdkHandler.application(application, didFinishLaunchingWithOptions: launchOptions)
+
+    return super.application(application, didFinishLaunchingWithOptions: modifiedLaunchOptions)
+  }
+
+  // Handle device token registration
+  public override func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+    // Call CustomerIO SDK handler
+    cioSdkHandler.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+    super.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+  }
+
+  // Handle remote notification registration errors
+  public override func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+    // Call CustomerIO SDK handler
+    cioSdkHandler.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+    super.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+  }
+}"
+`;

--- a/__tests__/ios/apn/__snapshots__/AppDelegate-swift.test.js.snap
+++ b/__tests__/ios/apn/__snapshots__/AppDelegate-swift.test.js.snap
@@ -26,17 +26,32 @@ public class AppDelegate: ExpoAppDelegate {
     reactNativeFactory = factory
     bindReactNativeFactory(factory)
 
+    // Deep link workaround for app killed state start
+    var modifiedLaunchOptions = launchOptions
+    if let launchOptions = launchOptions,
+       let pushContent = launchOptions[UIApplication.LaunchOptionsKey.remoteNotification] as? [AnyHashable: Any],
+       let cio = pushContent["CIO"] as? [String: Any],
+       let push = cio["push"] as? [String: Any],
+       let link = push["link"] as? String,
+       !launchOptions.keys.contains(UIApplication.LaunchOptionsKey.url) {
+        
+        var mutableLaunchOptions = launchOptions
+        mutableLaunchOptions[UIApplication.LaunchOptionsKey.url] = URL(string: link)
+        modifiedLaunchOptions = mutableLaunchOptions
+    }
+    // Deep link workaround for app killed state ends
+
 #if os(iOS) || os(tvOS)
     window = UIWindow(frame: UIScreen.main.bounds)
     factory.startReactNative(
       withModuleName: "main",
       in: window,
-      launchOptions: launchOptions)
+      launchOptions: modifiedLaunchOptions)
 #endif
 
       cioSdkHandler.application(application, didFinishLaunchingWithOptions: launchOptions)
 
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    return super.application(application, didFinishLaunchingWithOptions: modifiedLaunchOptions)
   }
 
   // Linking API

--- a/__tests__/ios/fcm/__snapshots__/AppDelegate-swift.test.js.snap
+++ b/__tests__/ios/fcm/__snapshots__/AppDelegate-swift.test.js.snap
@@ -26,17 +26,32 @@ public class AppDelegate: ExpoAppDelegate {
     reactNativeFactory = factory
     bindReactNativeFactory(factory)
 
+    // Deep link workaround for app killed state start
+    var modifiedLaunchOptions = launchOptions
+    if let launchOptions = launchOptions,
+       let pushContent = launchOptions[UIApplication.LaunchOptionsKey.remoteNotification] as? [AnyHashable: Any],
+       let cio = pushContent["CIO"] as? [String: Any],
+       let push = cio["push"] as? [String: Any],
+       let link = push["link"] as? String,
+       !launchOptions.keys.contains(UIApplication.LaunchOptionsKey.url) {
+        
+        var mutableLaunchOptions = launchOptions
+        mutableLaunchOptions[UIApplication.LaunchOptionsKey.url] = URL(string: link)
+        modifiedLaunchOptions = mutableLaunchOptions
+    }
+    // Deep link workaround for app killed state ends
+
 #if os(iOS) || os(tvOS)
     window = UIWindow(frame: UIScreen.main.bounds)
     factory.startReactNative(
       withModuleName: "main",
       in: window,
-      launchOptions: launchOptions)
+      launchOptions: modifiedLaunchOptions)
 #endif
 
       cioSdkHandler.application(application, didFinishLaunchingWithOptions: launchOptions)
 
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    return super.application(application, didFinishLaunchingWithOptions: modifiedLaunchOptions)
   }
 
   // Linking API

--- a/__tests__/ios/withCIOIosSwift.test.ts
+++ b/__tests__/ios/withCIOIosSwift.test.ts
@@ -253,4 +253,143 @@ public class AppDelegate: ExpoAppDelegate {
       expect(writtenContent).not.toContain('.appGroupId(');
     });
   });
+
+  describe('handleDeeplinkInKilledState placement', () => {
+    const modernAppDelegateFixture = `import Expo
+import React
+import ReactAppDependencyProvider
+
+@UIApplicationMain
+public class AppDelegate: ExpoAppDelegate {
+  var window: UIWindow?
+
+  var reactNativeDelegate: ExpoReactNativeFactoryDelegate?
+  var reactNativeFactory: RCTReactNativeFactory?
+
+  public override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    let delegate = ReactNativeDelegate()
+    let factory = ExpoReactNativeFactory(delegate: delegate)
+    delegate.dependencyProvider = RCTAppDependencyProvider()
+
+    reactNativeDelegate = delegate
+    reactNativeFactory = factory
+    bindReactNativeFactory(factory)
+
+#if os(iOS) || os(tvOS)
+    window = UIWindow(frame: UIScreen.main.bounds)
+    factory.startReactNative(
+      withModuleName: "main",
+      in: window,
+      launchOptions: launchOptions)
+#endif
+
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+}`;
+
+    const legacyAppDelegateFixture = `@UIApplicationMain
+public class AppDelegate: ExpoAppDelegate {
+  public override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+}`;
+
+    const propsWithDeeplink: CustomerIOPluginOptionsIOS = {
+      iosPath: '/test/ios',
+      pushNotification: {
+        provider: 'apn',
+        handleDeeplinkInKilledState: true,
+      },
+    };
+
+    it('injects deeplink workaround BEFORE factory.startReactNative on modern Expo Swift templates', async () => {
+      const { withAppDelegate } = require('@expo/config-plugins');
+
+      withCIOIosSwift(mockConfig, undefined, propsWithDeeplink);
+
+      const appDelegateCallback = withAppDelegate.mock.calls[0][1];
+      const result = await appDelegateCallback({
+        modResults: { contents: modernAppDelegateFixture },
+      });
+      const out: string = result.modResults.contents;
+
+      const snippetIdx = out.indexOf('Deep link workaround for app killed state start');
+      const factoryIdx = out.indexOf('factory.startReactNative');
+      const ifGuardIdx = out.indexOf('#if os(iOS) || os(tvOS)');
+
+      expect(snippetIdx).toBeGreaterThan(-1);
+      expect(factoryIdx).toBeGreaterThan(-1);
+      // Snippet must precede both the #if guard and the factory.startReactNative call,
+      // otherwise the workaround runs after RN has already bootstrapped.
+      expect(snippetIdx).toBeLessThan(ifGuardIdx);
+      expect(snippetIdx).toBeLessThan(factoryIdx);
+      // Snapshot the full transformed AppDelegate so unintended drift in the snippet content
+      // (whitespace, comments, the keys we read from the push payload) is also surfaced.
+      expect(out).toMatchSnapshot();
+    });
+
+    it('routes modifiedLaunchOptions into factory.startReactNative on modern templates', async () => {
+      const { withAppDelegate } = require('@expo/config-plugins');
+
+      withCIOIosSwift(mockConfig, undefined, propsWithDeeplink);
+
+      const appDelegateCallback = withAppDelegate.mock.calls[0][1];
+      const result = await appDelegateCallback({
+        modResults: { contents: modernAppDelegateFixture },
+      });
+      const out: string = result.modResults.contents;
+
+      // The factory.startReactNative call must consume modifiedLaunchOptions, not the original.
+      expect(out).toMatch(/factory\.startReactNative\([\s\S]*?launchOptions:\s*modifiedLaunchOptions\s*\)/);
+      expect(out).not.toMatch(/factory\.startReactNative\([\s\S]*?launchOptions:\s*launchOptions\s*\)/);
+      // Trailing super.application is also rewritten for backward compatibility with older templates
+      // where it was the call that bootstrapped RN.
+      expect(out).toContain(
+        'return super.application(application, didFinishLaunchingWithOptions: modifiedLaunchOptions)'
+      );
+      expect(out).toMatchSnapshot();
+    });
+
+    it('falls back to rewriting the return statement on legacy templates without factory.startReactNative', async () => {
+      const { withAppDelegate } = require('@expo/config-plugins');
+
+      withCIOIosSwift(mockConfig, undefined, propsWithDeeplink);
+
+      const appDelegateCallback = withAppDelegate.mock.calls[0][1];
+      const result = await appDelegateCallback({
+        modResults: { contents: legacyAppDelegateFixture },
+      });
+      const out: string = result.modResults.contents;
+
+      const snippetIdx = out.indexOf('Deep link workaround for app killed state start');
+      const returnIdx = out.indexOf('return super.application');
+
+      expect(snippetIdx).toBeGreaterThan(-1);
+      expect(snippetIdx).toBeLessThan(returnIdx);
+      expect(out).toContain(
+        'return super.application(application, didFinishLaunchingWithOptions: modifiedLaunchOptions)'
+      );
+    });
+
+    it('is idempotent — repeated invocations do not stack the snippet', async () => {
+      const { withAppDelegate } = require('@expo/config-plugins');
+
+      withCIOIosSwift(mockConfig, undefined, propsWithDeeplink);
+
+      const appDelegateCallback = withAppDelegate.mock.calls[0][1];
+      const first = await appDelegateCallback({
+        modResults: { contents: modernAppDelegateFixture },
+      });
+      const second = await appDelegateCallback({
+        modResults: { contents: first.modResults.contents },
+      });
+      const out: string = second.modResults.contents;
+
+      const occurrences = (out.match(/Deep link workaround for app killed state start/g) || []).length;
+      expect(occurrences).toBe(1);
+    });
+  });
 });

--- a/plugin/src/ios/withCIOIosSwift.ts
+++ b/plugin/src/ios/withCIOIosSwift.ts
@@ -500,34 +500,47 @@ const addDidFailToRegisterForRemoteNotificationsWithError = (
 
 /**
  * Add deep link handling for killed state
- * This replaces the return statement with deep link handling code
- * and a modified return statement that uses modifiedLaunchOptions
+ *
+ * On modern Expo Swift templates, RN is bootstrapped by `factory.startReactNative(...)`
+ * inside an `#if os(iOS) || os(tvOS)` guard, *before* the trailing `return super.application(...)`.
+ * The deep-link block must run before that call so `modifiedLaunchOptions` flows into RN's
+ * initial launchOptions; otherwise the workaround is a no-op.
+ *
+ * For older templates (no `factory.startReactNative` — `super.application(...)` is what
+ * starts RN), the snippet is injected before the return statement as before.
  */
 const addHandleDeeplinkInKilledState = (content: string): string => {
-  // Check if deep link code snippet is already present
   const deepLinkMarker = 'Deep link workaround for app killed state start';
   if (content.includes(deepLinkMarker)) {
     return content;
   }
 
-  // Find the return statement with launchOptions
   const returnStatementRegex =
     /return\s+super\.application\s*\(\s*application\s*,\s*didFinishLaunchingWithOptions\s*:\s*launchOptions\s*\)/;
-  const returnStatementMatch = content.match(returnStatementRegex);
+  const modifiedReturnStatement =
+    'return super.application(application, didFinishLaunchingWithOptions: modifiedLaunchOptions)';
 
-  if (!returnStatementMatch) {
+  const factoryStartRegex =
+    /(\s*)#if\s+os\(iOS\)\s*\|\|\s*os\(tvOS\)([\s\S]*?factory\.startReactNative\s*\([\s\S]*?launchOptions:\s*)launchOptions(\s*\)[\s\S]*?#endif)/;
+
+  if (factoryStartRegex.test(content)) {
+    let result = content.replace(
+      factoryStartRegex,
+      `\n${CIO_CONFIGUREDEEPLINK_KILLEDSTATE_SWIFT_SNIPPET}\n#if os(iOS) || os(tvOS)$2modifiedLaunchOptions$3`
+    );
+    if (returnStatementRegex.test(result)) {
+      result = result.replace(returnStatementRegex, modifiedReturnStatement);
+    }
+    return result;
+  }
+
+  if (!returnStatementRegex.test(content)) {
     logger.warn('Could not find return statement with launchOptions');
     return content;
   }
-
-  // Create the replacement code with deep link handling and modified return statement
-  const modifiedReturnStatement =
-    'return super.application(application, didFinishLaunchingWithOptions: modifiedLaunchOptions)';
   const replacementCode =
     CIO_CONFIGUREDEEPLINK_KILLEDSTATE_SWIFT_SNIPPET +
     '\n\n    ' +
     modifiedReturnStatement;
-
-  // Replace the return statement with deep link handling code and modified return statement
   return content.replace(returnStatementRegex, replacementCode);
 };

--- a/scripts/compatibility/configure-plugin.js
+++ b/scripts/compatibility/configure-plugin.js
@@ -118,6 +118,7 @@ function execute() {
       pushNotification: {
         useRichPush: true,
         appGroupId: "group.io.customer.testbed.expo.apn.cio",
+        handleDeeplinkInKilledState: true,
       },
     };
 

--- a/test-app/app.json
+++ b/test-app/app.json
@@ -107,7 +107,8 @@
             "pushNotification": {
               "provider": "apn",
               "useRichPush": true,
-              "appGroupId": "group.io.customer.testbed.expo.apn.cio"
+              "appGroupId": "group.io.customer.testbed.expo.apn.cio",
+              "handleDeeplinkInKilledState": true
             }
           },
           "location": {


### PR DESCRIPTION
## Summary

- On modern Expo Swift `AppDelegate.swift` templates, RN is bootstrapped by `factory.startReactNative(...)` *inside* the `#if os(iOS) || os(tvOS)` guard — *before* the trailing `return super.application(...)`. The previous injection placed the deep-link extraction block before the return statement, so on the new template it ran after RN had already been initialized, making `handleDeeplinkInKilledState` a silent no-op.
- Inject the snippet before the `#if` guard and route `modifiedLaunchOptions` into `factory.startReactNative` so RN sees the URL on cold start. The trailing `super.application(...)` is still rewritten to consume `modifiedLaunchOptions` for backward compatibility with older templates where `super` was the call that bootstrapped RN.
- Backfill the previously-untested option with positional regression tests, a snapshot, and prebuild snapshot updates so this regression can't recur silently.

## Why this slipped through

The `handleDeeplinkInKilledState` flag had **zero** automated coverage on either the Swift or Objective-C path — `__tests__/` contained no references to it. When the Expo Swift template moved RN bootstrap from `super.application(...)` to `factory.startReactNative(...)`, no snapshot diffed and no assertion fired, so the workaround quietly became a no-op without anyone noticing. (The deep link still routes correctly today via the CIO native SDK's `UNUserNotificationCenterDelegate` click handler — that path runs regardless of this option — but the flag itself was no longer doing anything.)

## What changed

| File | Change |
| --- | --- |
| `plugin/src/ios/withCIOIosSwift.ts` | `addHandleDeeplinkInKilledState` now detects modern templates (with `factory.startReactNative` inside an `#if os(iOS) \|\| os(tvOS)` guard), inserts the snippet before that guard, and rewrites the factory call's `launchOptions:` argument. Falls back to the previous behavior for legacy templates without `factory.startReactNative`. |
| `__tests__/ios/withCIOIosSwift.test.ts` | New `handleDeeplinkInKilledState placement` describe block: 4 tests covering position invariants, the `modifiedLaunchOptions` rewrite, the legacy fallback path, and idempotency. Two also snapshot the full transformed AppDelegate to surface content drift in the injected snippet itself. |
| `__tests__/ios/__snapshots__/withCIOIosSwift.test.ts.snap` | New (auto-generated). |
| `__tests__/ios/{apn,fcm}/__snapshots__/AppDelegate-swift.test.js.snap` | Updated to reflect the prebuild output now that the flag is enabled in `test-app/app.json`. |
| `test-app/app.json` | Set `pushNotification.handleDeeplinkInKilledState: true` so the prebuild-driven snapshot tests cover this code path going forward. |
| `.github/workflows/test.yml` | Wire `withCIOIos.test.ts` and `withCIOIosSwift.test.ts` into the `test-utils` job — they were previously orphaned (not matched by the `test-plugin-ios` path filter) and silently not running. |

## Test plan

- [x] `npx jest __tests__/utils __tests__/ios/withCIOIos.test.ts __tests__/ios/withCIOIosSwift.test.ts` — 7 suites, 111 tests, 6 snapshots, all green locally. This is the exact command the `test-utils` CI job will run.
- [x] Snapshot diffs eyeballed: `factory.startReactNative` consumes `modifiedLaunchOptions`; deep-link block sits before `#if os(iOS) \|\| os(tvOS)`; trailing `super.application(...)` also rewritten.
- [ ] CI `test-plugin-ios` (apn + fcm matrix) — should pass now that the APN/FCM `AppDelegate-swift` snapshots reflect the post-fix output. If a CI run regenerates a slightly different prebuild artifact (e.g., Expo template formatting drift), the snapshot diff will be visible in the failing job and easy to update.
- [ ] CI `test-utils` — should pick up the 4 new positional/snapshot tests + 7 existing tests in `withCIOIosSwift.test.ts` and the existing `withCIOIos.test.ts` cases.
- [ ] Cold-start manual verification on a physical device with `handleDeeplinkInKilledState: true`: tap a CIO push containing a deep link from killed state, confirm `Linking.getInitialURL()` returns the URL (Path 1 functioning) rather than `null` (Path 2 fallback only).

## Notes

- No changes to `plugin/src/ios/withAppDelegateModifications.ts` (Objective-C path) — verified that path already routes `modifiedLaunchOptions` into `createBridgeWithDelegate:launchOptions:` correctly.
- No changes to `plugin/src/helpers/constants/ios.ts` — the snippet itself is reused as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes native code generation for iOS `AppDelegate.swift` via regex-based injection; incorrect matching could break app startup, but the change is scoped and now covered by targeted snapshots/tests.
> 
> **Overview**
> Fixes the iOS Swift `handleDeeplinkInKilledState` injection so it works on modern Expo templates by inserting the deep-link workaround *before* the `#if os(iOS) || os(tvOS)` block and rewriting `factory.startReactNative(... launchOptions:)` (and the trailing `super.application(...)`) to use `modifiedLaunchOptions`.
> 
> Adds regression coverage with new Swift placement/idempotency tests plus snapshots, updates APN/FCM AppDelegate snapshots accordingly, and enables `handleDeeplinkInKilledState: true` in the sample app/default compatibility config. CI `test-utils` is updated to actually run the previously-orphaned `__tests__/ios/withCIOIos*.test.ts` suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8dcb051251c86716fbe7ffa613036dd5c41fb13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->