### PR TITLE
feat: pnpm support

### DIFF
--- a/.github/workflows/test-pnpm-compatibility.yml
+++ b/.github/workflows/test-pnpm-compatibility.yml
@@ -1,0 +1,69 @@
+name: Test pnpm Compatibility
+
+on:
+  pull_request:
+  push:
+    branches: [main, beta, feature/*]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pnpm-dev-apps:
+    name: Build pnpm dev apps (isolated + hoisted) and verify artifacts
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install root dependencies
+        run: npm ci
+
+      # Phase A — default pnpm (isolated) mode.
+      # Each setup script runs `expo prebuild --clean`, which on macOS
+      # automatically runs `pod install` against the generated Podfile.
+      # That's the step that fails with the customer's "multiple
+      # dependencies with different sources" error if the resolver
+      # regresses to emitting the .pnpm/ realpath.
+      - name: 'Phase A — set up test-app-pnpm (flat) — includes pod install'
+        run: npm run setup-test-app-pnpm
+
+      - name: 'Phase A — set up test-app-pnpm-monorepo (workspace) — includes pod install'
+        run: npm run setup-test-app-pnpm-monorepo
+
+      - name: 'Phase A — verify Podfile :path values and expoVersion attribution'
+        run: npm run verify-pnpm-dev-apps
+
+      # Phase B — hoisted mode.
+      # Customers who can't wait for a release are advised to add a
+      # node-linker=hoisted .npmrc as a workaround. This phase exercises
+      # that workaround so a future change can't silently break the path
+      # we recommend customers take.
+      - name: 'Phase B — wipe monorepo install and write hoisted .npmrc'
+        run: |
+          set -euo pipefail
+          rm -rf \
+            test-app-pnpm-monorepo/node_modules \
+            test-app-pnpm-monorepo/pnpm-lock.yaml \
+            test-app-pnpm-monorepo/apps/*/node_modules \
+            test-app-pnpm-monorepo/apps/*/ios \
+            test-app-pnpm-monorepo/apps/*/android \
+            test-app-pnpm-monorepo/packages/*/node_modules
+
+          cat > test-app-pnpm-monorepo/.npmrc <<'EOF'
+          node-linker=hoisted
+          shamefully-hoist=true
+          public-hoist-pattern[]=*customerio*
+          EOF
+
+      - name: 'Phase B — set up test-app-pnpm-monorepo under hoisted mode'
+        run: npm run setup-test-app-pnpm-monorepo
+
+      - name: 'Phase B — verify Podfile :path values and expoVersion attribution under hoisted mode'
+        run: npm run verify-pnpm-dev-apps

--- a/__tests__/ios/apn/PodFile.test.js
+++ b/__tests__/ios/apn/PodFile.test.js
@@ -9,28 +9,28 @@ const podFilePath = path.join(iosPath, "Podfile");
 test("Plugin injects expected customerio-reactnative/apn and customerio-reactnative-richpush/apn in Podfile", async () => {
     const content = await fs.readFile(podFilePath, "utf8");
 
-    // Ensure CustomerIO Host App block exists and APN pod is added (single-subspec or :subspecs including 'apn')
+    // Path is resolved at prebuild time and baked directly into :path => '...'.
+    // The exact string can vary by RN version (lexical for RN <0.80, realpath
+    // for RN >=0.80) so we assert the shape, not the literal string.
     expect(content).toContain("# --- CustomerIO Host App START ---");
     expect(content).toContain("# --- CustomerIO Host App END ---");
-    const hasSingleSubspec = content.includes("pod 'customerio-reactnative/apn', :path => '../node_modules/customerio-reactnative'");
-    const hasMultiSubspecWithApn = content.includes("customerio-reactnative") && content.includes("'apn'") && content.includes(":subspecs =>");
+
+    const hasSingleSubspec = /pod 'customerio-reactnative\/apn', :path => '[^']+'/.test(content);
+    const hasMultiSubspecWithApn = content.includes(":subspecs =>") && content.includes("'apn'") && /:path => '[^']+'/.test(content);
     expect(hasSingleSubspec || hasMultiSubspecWithApn).toBe(true);
 
-    // Ensure NotificationService target is added with rich push pod
+    // Ensure NotificationService target is added with the rich push pod
+    // pointing at the same baked path.
     const podFileAsLines = content.split('\n').map(line => line.trim());
     const startIndex = podFileAsLines.indexOf("# --- CustomerIO Notification START ---");
     const endIndex = podFileAsLines.indexOf("# --- CustomerIO Notification END ---", startIndex);
     expect(startIndex).toBeGreaterThan(-1);
     expect(endIndex).toBeGreaterThan(startIndex);
     const targetBlock = podFileAsLines.slice(startIndex, endIndex + 1).filter(line => line.length > 0);
-    const expectedLines = [
-      "# --- CustomerIO Notification START ---",
-      "target 'NotificationService' do",
-      "use_frameworks! :linkage => :static",
-      "pod 'customerio-reactnative-richpush/apn', :path => '../node_modules/customerio-reactnative'",
-      "end",
-      "# --- CustomerIO Notification END ---"
-    ];
-
-    expect(targetBlock).toEqual(expectedLines);
+    expect(targetBlock[0]).toBe("# --- CustomerIO Notification START ---");
+    expect(targetBlock[1]).toBe("target 'NotificationService' do");
+    expect(targetBlock[2]).toBe("use_frameworks! :linkage => :static");
+    expect(targetBlock[3]).toMatch(/^pod 'customerio-reactnative-richpush\/apn', :path => '[^']+'$/);
+    expect(targetBlock[4]).toBe("end");
+    expect(targetBlock[5]).toBe("# --- CustomerIO Notification END ---");
 });

--- a/__tests__/ios/fcm/PodFile.test.js
+++ b/__tests__/ios/fcm/PodFile.test.js
@@ -1,4 +1,4 @@
-const { testAppPath, isExpoVersion53OrHigher } = require("../../utils");
+const { testAppPath } = require("../../utils");
 const fs = require("fs-extra");
 const path = require("path");
 
@@ -9,28 +9,28 @@ const podFilePath = path.join(iosPath, "Podfile");
 test("Plugin injects expected customerio-reactnative/fcm and customerio-reactnative-richpush/fcm in Podfile", async () => {
     const content = await fs.readFile(podFilePath, "utf8");
 
-    // Ensure CustomerIO Host App block exists and FCM pod is added (single-subspec or :subspecs including 'fcm')
+    // Path is resolved at prebuild time and baked directly into :path => '...'.
+    // The exact string can vary by RN version (lexical for RN <0.80, realpath
+    // for RN >=0.80) so we assert the shape, not the literal string.
     expect(content).toContain("# --- CustomerIO Host App START ---");
     expect(content).toContain("# --- CustomerIO Host App END ---");
-    const hasSingleSubspec = content.includes("pod 'customerio-reactnative/fcm', :path => '../node_modules/customerio-reactnative'");
-    const hasMultiSubspecWithFcm = content.includes("customerio-reactnative") && content.includes("'fcm'") && content.includes(":subspecs =>");
+
+    const hasSingleSubspec = /pod 'customerio-reactnative\/fcm', :path => '[^']+'/.test(content);
+    const hasMultiSubspecWithFcm = content.includes(":subspecs =>") && content.includes("'fcm'") && /:path => '[^']+'/.test(content);
     expect(hasSingleSubspec || hasMultiSubspecWithFcm).toBe(true);
 
-    // Ensure NotificationService target is added with rich push pod
+    // Ensure NotificationService target is added with the rich push pod
+    // pointing at the same baked path.
     const podFileAsLines = content.split('\n').map(line => line.trim());
     const startIndex = podFileAsLines.indexOf("# --- CustomerIO Notification START ---");
     const endIndex = podFileAsLines.indexOf("# --- CustomerIO Notification END ---", startIndex);
     expect(startIndex).toBeGreaterThan(-1);
     expect(endIndex).toBeGreaterThan(startIndex);
     const targetBlock = podFileAsLines.slice(startIndex, endIndex + 1).filter(line => line.length > 0);
-    const expectedLines = [
-      "# --- CustomerIO Notification START ---",
-      "target 'NotificationService' do",
-      "use_frameworks! :linkage => :static",
-      "pod 'customerio-reactnative-richpush/fcm', :path => '../node_modules/customerio-reactnative'",
-      "end",
-      "# --- CustomerIO Notification END ---"
-    ];
-
-    expect(targetBlock).toEqual(expectedLines);
+    expect(targetBlock[0]).toBe("# --- CustomerIO Notification START ---");
+    expect(targetBlock[1]).toBe("target 'NotificationService' do");
+    expect(targetBlock[2]).toBe("use_frameworks! :linkage => :static");
+    expect(targetBlock[3]).toMatch(/^pod 'customerio-reactnative-richpush\/fcm', :path => '[^']+'$/);
+    expect(targetBlock[4]).toBe("end");
+    expect(targetBlock[5]).toBe("# --- CustomerIO Notification END ---");
 });

--- a/__tests__/ios/getRelativePathToRNSDK.test.ts
+++ b/__tests__/ios/getRelativePathToRNSDK.test.ts
@@ -1,0 +1,194 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { getRelativePathToRNSDK } from '../../plugin/src/helpers/constants/ios';
+
+// These tests build real on-disk fixture trees (including symlinks for the
+// pnpm case) and exercise the resolver against them. The behaviour we care
+// about is that the returned :path agrees with what React Native autolinking
+// emits, which depends on both layout and RN version (see the dispatch in
+// `getRelativePathToRNSDK`).
+
+const CIO_PKG_JSON = JSON.stringify({
+  name: 'customerio-reactnative',
+  version: '6.4.0',
+});
+
+function makeCioPkg(dir: string) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'package.json'), CIO_PKG_JSON);
+}
+
+function makeRnPkg(rootDir: string, version: string) {
+  const dir = path.join(rootDir, 'node_modules', 'react-native');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: 'react-native', version })
+  );
+}
+
+let logSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  // Silence the always-on plugin logs so test output stays readable.
+  logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+});
+
+describe('getRelativePathToRNSDK fixtures', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    // realpath because os.tmpdir() goes through /var → /private/var symlinks
+    // on macOS, and the modern (RN >=0.80) branch realpath()s the resolved
+    // dir; tests need to compare against the resolved form to avoid
+    // spurious mismatches from that base-path indirection.
+    tmpRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'cio-resolve-'))
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('flat npm + RN >=0.80: resolves to ../node_modules/customerio-reactnative', () => {
+    const projectRoot = path.join(tmpRoot, 'flat-npm-rn81');
+    const iosPath = path.join(projectRoot, 'ios');
+    fs.mkdirSync(iosPath, { recursive: true });
+    makeCioPkg(path.join(projectRoot, 'node_modules', 'customerio-reactnative'));
+    makeRnPkg(projectRoot, '0.81.4');
+
+    expect(getRelativePathToRNSDK(iosPath)).toBe(
+      path.join('..', 'node_modules', 'customerio-reactnative')
+    );
+  });
+
+  it('flat npm + RN <0.80: resolves to ../node_modules/customerio-reactnative (no regression)', () => {
+    // The dominant install layout (regular npm, no monorepo, no symlinks)
+    // must emit the same string regardless of which RN version pins the
+    // dispatch branch. This locks in the no-regression guarantee for the
+    // overwhelming majority of users when we changed the resolver.
+    const projectRoot = path.join(tmpRoot, 'flat-npm-rn79');
+    const iosPath = path.join(projectRoot, 'ios');
+    fs.mkdirSync(iosPath, { recursive: true });
+    makeCioPkg(path.join(projectRoot, 'node_modules', 'customerio-reactnative'));
+    makeRnPkg(projectRoot, '0.79.5');
+
+    expect(getRelativePathToRNSDK(iosPath)).toBe(
+      path.join('..', 'node_modules', 'customerio-reactnative')
+    );
+  });
+
+  it('pnpm + RN <0.80: returns the symlink path (matches @react-native-community/cli)', () => {
+    const projectRoot = path.join(tmpRoot, 'pnpm-rn79');
+    const iosPath = path.join(projectRoot, 'ios');
+    fs.mkdirSync(iosPath, { recursive: true });
+
+    const realDir = path.join(
+      projectRoot,
+      'node_modules',
+      '.pnpm',
+      'customerio-reactnative@6.4.0_abc',
+      'node_modules',
+      'customerio-reactnative'
+    );
+    makeCioPkg(realDir);
+
+    const symlinkDir = path.join(projectRoot, 'node_modules', 'customerio-reactnative');
+    fs.symlinkSync(realDir, symlinkDir, 'dir');
+    makeRnPkg(projectRoot, '0.79.5');
+
+    const resolved = getRelativePathToRNSDK(iosPath);
+
+    // The fix the plan was originally designed for: under RN 0.79 community
+    // CLI, autolinking emits the symlink path. We must too.
+    expect(resolved).toBe(
+      path.join('..', 'node_modules', 'customerio-reactnative')
+    );
+    expect(resolved).not.toContain('.pnpm');
+  });
+
+  it('pnpm + RN >=0.80: returns the .pnpm realpath (matches expo-modules-autolinking)', () => {
+    const projectRoot = path.join(tmpRoot, 'pnpm-rn81');
+    const iosPath = path.join(projectRoot, 'ios');
+    fs.mkdirSync(iosPath, { recursive: true });
+
+    const realDir = path.join(
+      projectRoot,
+      'node_modules',
+      '.pnpm',
+      'customerio-reactnative@6.4.0_abc',
+      'node_modules',
+      'customerio-reactnative'
+    );
+    makeCioPkg(realDir);
+
+    const symlinkDir = path.join(projectRoot, 'node_modules', 'customerio-reactnative');
+    fs.symlinkSync(realDir, symlinkDir, 'dir');
+    makeRnPkg(projectRoot, '0.81.4');
+
+    const resolved = getRelativePathToRNSDK(iosPath);
+
+    // Modern expo-modules-autolinking realpaths; we must too, otherwise
+    // CocoaPods sees two :path values for the same pod.
+    expect(resolved).toContain('.pnpm');
+    expect(resolved).toBe(path.relative(iosPath, realDir));
+  });
+
+  it('yarn classic workspace: resolves to the hoisted parent node_modules', () => {
+    const wsRoot = path.join(tmpRoot, 'yarn-ws');
+    const appPath = path.join(wsRoot, 'apps', 'mobile');
+    const iosPath = path.join(appPath, 'ios');
+    fs.mkdirSync(iosPath, { recursive: true });
+
+    makeCioPkg(path.join(wsRoot, 'node_modules', 'customerio-reactnative'));
+    fs.mkdirSync(path.join(appPath, 'node_modules'), { recursive: true });
+    // RN hoisted to ws root too; modern Expo path here.
+    makeRnPkg(wsRoot, '0.81.4');
+
+    expect(getRelativePathToRNSDK(iosPath)).toBe(
+      path.join('..', '..', '..', 'node_modules', 'customerio-reactnative')
+    );
+  });
+
+  it('RN version unknown: defaults to realpath (modern behavior)', () => {
+    const projectRoot = path.join(tmpRoot, 'no-rn');
+    const iosPath = path.join(projectRoot, 'ios');
+    fs.mkdirSync(iosPath, { recursive: true });
+
+    const realDir = path.join(
+      projectRoot,
+      'node_modules',
+      '.pnpm',
+      'customerio-reactnative@6.4.0_abc',
+      'node_modules',
+      'customerio-reactnative'
+    );
+    makeCioPkg(realDir);
+    fs.symlinkSync(
+      realDir,
+      path.join(projectRoot, 'node_modules', 'customerio-reactnative'),
+      'dir'
+    );
+    // Deliberately no react-native fixture.
+
+    const resolved = getRelativePathToRNSDK(iosPath);
+    expect(resolved).toContain('.pnpm');
+  });
+
+  it('throws a clear error when customerio-reactnative is missing', () => {
+    const projectRoot = path.join(tmpRoot, 'no-dep');
+    const iosPath = path.join(projectRoot, 'ios');
+    fs.mkdirSync(iosPath, { recursive: true });
+
+    expect(() => getRelativePathToRNSDK(iosPath)).toThrow(
+      /customerio-reactnative was not found/
+    );
+  });
+});

--- a/__tests__/ios/injectCIOPodfileCode.test.ts
+++ b/__tests__/ios/injectCIOPodfileCode.test.ts
@@ -16,59 +16,86 @@ jest.mock('../../plugin/src/helpers/utils/fileManagement', () => ({
 
 const IOS_PATH = '/fake/project/ios';
 
+// The snippet bakes the prebuild-resolved relative path directly into
+// :path => '...'. The choice of lexical vs realpath happens earlier, in
+// `getRelativePathToRNSDK`, which dispatches on the installed React Native
+// version. These tests cover the snippet shape and the subspec matrix.
+
+const RESOLVED_PATH = '../node_modules/customerio-reactnative';
+
+function expectsPodLine(snippet: string, line: string) {
+  expect(snippet).toBe(line);
+}
+
 describe('buildHostAppPodSnippet', () => {
-  it('returns single-subspec pod line when locationEnabled is false', () => {
-    expect(
-      buildHostAppPodSnippet(IOS_PATH, false, { locationEnabled: false })
-    ).toBe(
-      "pod 'customerio-reactnative/apn', :path => '../node_modules/customerio-reactnative'"
-    );
-    expect(
-      buildHostAppPodSnippet(IOS_PATH, true, { locationEnabled: false })
-    ).toBe(
-      "pod 'customerio-reactnative/fcm', :path => '../node_modules/customerio-reactnative'"
+  it('emits the apn subspec line with a baked :path', () => {
+    const snippet = buildHostAppPodSnippet(IOS_PATH, false, {
+      locationEnabled: false,
+    });
+    expectsPodLine(
+      snippet,
+      `pod 'customerio-reactnative/apn', :path => '${RESOLVED_PATH}'`
     );
   });
 
-  it('returns single-subspec pod line when options are omitted', () => {
-    expect(buildHostAppPodSnippet(IOS_PATH, false)).toBe(
-      "pod 'customerio-reactnative/apn', :path => '../node_modules/customerio-reactnative'"
-    );
-    expect(buildHostAppPodSnippet(IOS_PATH, true)).toBe(
-      "pod 'customerio-reactnative/fcm', :path => '../node_modules/customerio-reactnative'"
+  it('emits the fcm subspec line with a baked :path', () => {
+    const snippet = buildHostAppPodSnippet(IOS_PATH, true, {
+      locationEnabled: false,
+    });
+    expectsPodLine(
+      snippet,
+      `pod 'customerio-reactnative/fcm', :path => '${RESOLVED_PATH}'`
     );
   });
 
-  it('returns subspecs with fcm and location when locationEnabled and hasPush', () => {
+  it('defaults to single subspec when options are omitted', () => {
+    const apnSnippet = buildHostAppPodSnippet(IOS_PATH, false);
+    expectsPodLine(
+      apnSnippet,
+      `pod 'customerio-reactnative/apn', :path => '${RESOLVED_PATH}'`
+    );
+
+    const fcmSnippet = buildHostAppPodSnippet(IOS_PATH, true);
+    expectsPodLine(
+      fcmSnippet,
+      `pod 'customerio-reactnative/fcm', :path => '${RESOLVED_PATH}'`
+    );
+  });
+
+  it('uses :subspecs => with push + location when both enabled', () => {
     const options: InjectCIOPodfileOptions = {
       locationEnabled: true,
       hasPush: true,
     };
-    expect(buildHostAppPodSnippet(IOS_PATH, true, options)).toBe(
-      "pod 'customerio-reactnative', :subspecs => ['fcm', 'location'], :path => '../node_modules/customerio-reactnative'"
+    const fcmSnippet = buildHostAppPodSnippet(IOS_PATH, true, options);
+    expectsPodLine(
+      fcmSnippet,
+      `pod 'customerio-reactnative', :subspecs => ['fcm', 'location'], :path => '${RESOLVED_PATH}'`
+    );
+
+    const apnSnippet = buildHostAppPodSnippet(IOS_PATH, false, options);
+    expectsPodLine(
+      apnSnippet,
+      `pod 'customerio-reactnative', :subspecs => ['apn', 'location'], :path => '${RESOLVED_PATH}'`
     );
   });
 
-  it('returns subspecs with apn and location when locationEnabled and hasPush', () => {
-    const options: InjectCIOPodfileOptions = {
-      locationEnabled: true,
-      hasPush: true,
-    };
-    expect(buildHostAppPodSnippet(IOS_PATH, false, options)).toBe(
-      "pod 'customerio-reactnative', :subspecs => ['apn', 'location'], :path => '../node_modules/customerio-reactnative'"
-    );
-  });
-
-  it('returns only location subspec when locationEnabled and no push', () => {
+  it('emits only the location subspec line when locationEnabled and !hasPush', () => {
     const options: InjectCIOPodfileOptions = {
       locationEnabled: true,
       hasPush: false,
     };
-    expect(buildHostAppPodSnippet(IOS_PATH, true, options)).toBe(
-      "pod 'customerio-reactnative', :subspecs => ['location'], :path => '../node_modules/customerio-reactnative'"
+    const snippet = buildHostAppPodSnippet(IOS_PATH, true, options);
+    expectsPodLine(
+      snippet,
+      `pod 'customerio-reactnative', :subspecs => ['location'], :path => '${RESOLVED_PATH}'`
     );
-    expect(buildHostAppPodSnippet(IOS_PATH, false, options)).toBe(
-      "pod 'customerio-reactnative', :subspecs => ['location'], :path => '../node_modules/customerio-reactnative'"
-    );
+  });
+
+  it('does not emit any Ruby lambda or install-time resolver block', () => {
+    const snippet = buildHostAppPodSnippet(IOS_PATH, false);
+    // Lambda was the previous shape; we resolve at prebuild now and bake.
+    expect(snippet).not.toContain('lambda do');
+    expect(snippet).not.toContain('require.resolve');
   });
 });

--- a/__tests__/postInstallHelper.test.ts
+++ b/__tests__/postInstallHelper.test.ts
@@ -1,0 +1,146 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// The postinstall helper is plain CommonJS that reads INIT_CWD and writes
+// expoVersion into customerio-reactnative/package.json. These tests build
+// real fixture trees and verify the value lands in the right file under
+// flat-npm, pnpm, and yarn-workspace layouts — and that no exception escapes
+// when the package is missing.
+
+const HELPER_PATH = '../plugin/src/postInstallHelper';
+
+const INITIAL_RN_PKG = {
+  name: 'customerio-reactnative',
+  version: '6.4.0',
+};
+
+function makeRNPkgJson(dir: string) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify(INITIAL_RN_PKG, null, 2)
+  );
+}
+
+function readRNPkgJson(dir: string): { name: string; version: string; expoVersion?: string } {
+  return JSON.parse(
+    fs.readFileSync(path.join(dir, 'package.json'), 'utf8')
+  );
+}
+
+describe('postInstallHelper.runPostInstall', () => {
+  let tmpRoot: string;
+  let pluginVersion: string;
+  let originalInitCwd: string | undefined;
+
+  beforeAll(() => {
+    pluginVersion = require('../package.json').version;
+  });
+
+  beforeEach(() => {
+    // realpath needed on macOS because os.tmpdir() symlinks /var to /private/var.
+    tmpRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'cio-postinstall-'))
+    );
+    originalInitCwd = process.env.INIT_CWD;
+    // Reload helper between tests so it picks up the new INIT_CWD.
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    if (originalInitCwd === undefined) {
+      delete process.env.INIT_CWD;
+    } else {
+      process.env.INIT_CWD = originalInitCwd;
+    }
+  });
+
+  it('flat npm: writes expoVersion into <consumer>/node_modules/customerio-reactnative/package.json', () => {
+    const consumerRoot = path.join(tmpRoot, 'flat-npm');
+    const rnDir = path.join(consumerRoot, 'node_modules', 'customerio-reactnative');
+    makeRNPkgJson(rnDir);
+
+    process.env.INIT_CWD = consumerRoot;
+    const { runPostInstall } = require(HELPER_PATH);
+    runPostInstall();
+
+    expect(readRNPkgJson(rnDir).expoVersion).toBe(pluginVersion);
+  });
+
+  it('pnpm: writes through the symlinked path (real file ends up updated)', () => {
+    const consumerRoot = path.join(tmpRoot, 'pnpm-app');
+    const realDir = path.join(
+      consumerRoot,
+      'node_modules',
+      '.pnpm',
+      'customerio-reactnative@6.4.0_abc',
+      'node_modules',
+      'customerio-reactnative'
+    );
+    makeRNPkgJson(realDir);
+
+    const symlinkDir = path.join(
+      consumerRoot,
+      'node_modules',
+      'customerio-reactnative'
+    );
+    fs.mkdirSync(path.dirname(symlinkDir), { recursive: true });
+    fs.symlinkSync(realDir, symlinkDir, 'dir');
+
+    process.env.INIT_CWD = consumerRoot;
+    const { runPostInstall } = require(HELPER_PATH);
+    runPostInstall();
+
+    // Writing through the symlink updates the real file.
+    expect(readRNPkgJson(realDir).expoVersion).toBe(pluginVersion);
+    expect(readRNPkgJson(symlinkDir).expoVersion).toBe(pluginVersion);
+  });
+
+  it('yarn classic workspace: walks up to the hoisted node_modules', () => {
+    const wsRoot = path.join(tmpRoot, 'yarn-ws');
+    const appPath = path.join(wsRoot, 'apps', 'mobile');
+    fs.mkdirSync(path.join(appPath, 'node_modules'), { recursive: true });
+    const rnDir = path.join(wsRoot, 'node_modules', 'customerio-reactnative');
+    makeRNPkgJson(rnDir);
+
+    process.env.INIT_CWD = appPath;
+    const { runPostInstall } = require(HELPER_PATH);
+    runPostInstall();
+
+    expect(readRNPkgJson(rnDir).expoVersion).toBe(pluginVersion);
+  });
+
+  it('does not throw when customerio-reactnative is not installed', () => {
+    const consumerRoot = path.join(tmpRoot, 'no-dep');
+    fs.mkdirSync(consumerRoot, { recursive: true });
+
+    process.env.INIT_CWD = consumerRoot;
+    const { runPostInstall } = require(HELPER_PATH);
+
+    expect(() => runPostInstall()).not.toThrow();
+  });
+
+  it('is idempotent — repeated runs do not rewrite when value matches', () => {
+    const consumerRoot = path.join(tmpRoot, 'idem');
+    const rnDir = path.join(consumerRoot, 'node_modules', 'customerio-reactnative');
+    makeRNPkgJson(rnDir);
+
+    process.env.INIT_CWD = consumerRoot;
+    const { runPostInstall } = require(HELPER_PATH);
+    runPostInstall();
+
+    const pkgPath = path.join(rnDir, 'package.json');
+    const firstMtime = fs.statSync(pkgPath).mtimeMs;
+
+    // Spin briefly so a rewrite would be detectable via mtime.
+    const start = Date.now();
+    while (Date.now() - start < 20) { /* noop */ }
+
+    runPostInstall();
+    const secondMtime = fs.statSync(pkgPath).mtimeMs;
+
+    expect(secondMtime).toBe(firstMtime);
+  });
+});

--- a/local-development-readme.md
+++ b/local-development-readme.md
@@ -43,6 +43,48 @@ We use tarball dependency to ensure our expo plugin is installed as if it was pu
 npm run preinstall
 ``` 
 
+## Testing pnpm and monorepo layouts locally
+
+Two additional dev apps live at the repo root for verifying the plugin under
+pnpm and pnpm workspace layouts. They are intentionally minimal — single
+screen, no fastlane, no env loader — and exist so that `expo prebuild` and
+`pod install` can be exercised end-to-end against the layouts that surfaced
+the duplicate-pod bug fixed in this plugin.
+
+These are a side dev-loop, not part of the default flow. The standard
+`npm run buildAll` / `cleanAll` continue to operate only on `test-app/`.
+
+Prerequisites: `pnpm` on your PATH (`npm install -g pnpm`).
+
+Set up either app individually:
+
+```bash
+# Flat pnpm install
+npm run setup-test-app-pnpm
+
+# pnpm workspace where apps/mobile shares customerio-reactnative with packages/shared-cio-utils
+npm run setup-test-app-pnpm-monorepo
+```
+
+Or use the all-in-one convenience commands (parallel to `cleanAll` / `buildAll`):
+
+```bash
+npm run buildAllPnpm           # rebuild plugin + set up both pnpm dev apps
+npm run cleanAllPnpm           # clean both pnpm dev apps + drop the cached tarball
+npm run cleanAndBuildAllPnpm   # clean + rebuild
+```
+
+Each setup regenerates the plugin tarball at the repo root, runs `pnpm install`,
+and runs `expo prebuild`. After setup, drop into the app dir and run as usual:
+
+```bash
+cd test-app-pnpm && pnpm exec expo run:ios
+cd test-app-pnpm-monorepo && npm run ios
+```
+
+When iterating on the plugin, re-run the matching `setup-test-app-pnpm*` script
+or `npm run buildAllPnpm` to rebuild and reinstall the tarball into the dev apps.
+
 ## Convenience scripts
 
 Sometimes when you are making changes to the plugin, it's helpful to clear out dependencies or rebuild the plugin. There are a couple of convenience scripts that you can use.

--- a/package.json
+++ b/package.json
@@ -34,10 +34,16 @@
     "compatibility:validate-plugin": "node scripts/compatibility/validate-plugin.js",
     "compatibility:run-compatibility-tests": "node scripts/compatibility/run-compatibility-tests.js",
     "setup-test-app": "bash scripts/setup-test-app.sh",
+    "setup-test-app-pnpm": "bash scripts/setup-test-app-pnpm.sh",
+    "setup-test-app-pnpm-monorepo": "bash scripts/setup-test-app-pnpm-monorepo.sh",
     "test-plugin": "bash scripts/test-plugin.sh",
     "cleanAll": "bash scripts/clean-all.sh",
     "buildAll": "bash scripts/build-all.sh",
     "cleanAndBuildAll": "npm run cleanAll && npm run buildAll",
+    "cleanAllPnpm": "bash scripts/clean-all-pnpm.sh",
+    "buildAllPnpm": "bash scripts/build-all-pnpm.sh",
+    "cleanAndBuildAllPnpm": "npm run cleanAllPnpm && npm run buildAllPnpm",
+    "verify-pnpm-dev-apps": "bash scripts/verify-pnpm-dev-apps.sh",
     "generate-api-docs": "bash scripts/generate-api-docs.sh"
   },
   "keywords": [

--- a/plugin/src/helpers/constants/ios.ts
+++ b/plugin/src/helpers/constants/ios.ts
@@ -1,18 +1,97 @@
+import fs from 'fs';
+import * as semver from 'semver';
+
 const path = require('path');
-const resolveFrom = require('resolve-from');
+import { resolveRNSDK, tryReadRNVersion } from '../../utils/resolveRNSDK';
 
+// Threshold at which React Native pod autolinking moves from
+// @react-native-community/cli (lexical, symlink-preserving) to
+// expo-modules-autolinking (realpath). The two flavors emit different
+// :path strings on pnpm/yarn-symlink layouts, so to keep CocoaPods happy
+// we must match whichever flavor will resolve the same package later.
+const RN_REALPATH_AUTOLINKING_MIN_VERSION = '0.80.0';
+
+const PLUGIN_LOG_PREFIX = '[CustomerIO Plugin]';
+
+// Always-on so the trail shows up in customer-shared `expo prebuild`
+// output without needing a separate verbose-mode opt-in.
+function pluginLog(message: string): void {
+  // eslint-disable-next-line no-console
+  console.log(`${PLUGIN_LOG_PREFIX} ${message}`);
+}
+
+/**
+ * Returns the relative path from the iOS project dir to the installed
+ * customerio-reactnative directory, in the exact form React Native pod
+ * autolinking will emit for the same package. The two autolinking
+ * flavors disagree on path shape under pnpm/yarn symlinks:
+ *
+ *   - RN <0.80 (`@react-native-community/cli`): walks node_modules
+ *     lexically, preserves symlinks. We keep the symlink path too —
+ *     `tryResolveRNSDK` already does this without calling realpath.
+ *
+ *   - RN >=0.80 (`expo-modules-autolinking`): realpaths the package
+ *     via Node, emitting the underlying `.pnpm/...` (or yarn-classic)
+ *     path. We match by realpath'ing the resolved directory.
+ *
+ * Decision points are logged so a customer's prebuild output is enough
+ * to triage path-resolution issues without a follow-up "set
+ * CUSTOMERIO_DEBUG_MODE and rerun" round-trip.
+ */
 export function getRelativePathToRNSDK(iosPath: string) {
-  // Root path of the Expo project
   const rootAppPath = path.dirname(iosPath);
-
-  // Path of the cio RN package.json file. Example: test-app/node_modules/customerio-reactnative/package.json
-  const pluginPackageJsonPath = resolveFrom.silent(
-    rootAppPath,
-    `customerio-reactnative/package.json`
+  pluginLog(
+    `Resolving customerio-reactnative for Podfile (iosPath=${iosPath}, projectRoot=${rootAppPath})`
   );
 
-  // Example: ../node_modules/customerio-reactnative
-  return path.relative(iosPath, path.dirname(pluginPackageJsonPath));
+  const { packageDir } = resolveRNSDK(rootAppPath);
+  pluginLog(`customerio-reactnative resolved to: ${packageDir}`);
+
+  const rnVersion = tryReadRNVersion(rootAppPath);
+  pluginLog(`Detected react-native version: ${rnVersion ?? 'unknown'}`);
+
+  const useLexical = shouldUseLexicalPath(rnVersion);
+  pluginLog(
+    useLexical
+      ? `RN <${RN_REALPATH_AUTOLINKING_MIN_VERSION} — using lexical/symlink path to match @react-native-community/cli autolinking`
+      : `RN >=${RN_REALPATH_AUTOLINKING_MIN_VERSION} or unknown — using realpath to match expo-modules-autolinking`
+  );
+
+  let absolutePath: string;
+  if (useLexical) {
+    absolutePath = packageDir;
+  } else {
+    try {
+      absolutePath = fs.realpathSync(packageDir);
+      if (absolutePath !== packageDir) {
+        pluginLog(`Realpath differs from resolved dir: ${absolutePath}`);
+      }
+    } catch (err) {
+      pluginLog(
+        `realpathSync failed (${
+          err instanceof Error ? err.message : String(err)
+        }); falling back to symlink path`
+      );
+      absolutePath = packageDir;
+    }
+  }
+
+  const relativePath = path.relative(iosPath, absolutePath);
+  pluginLog(`Final Podfile :path => '${relativePath}'`);
+  return relativePath;
+}
+
+function shouldUseLexicalPath(rnVersion: string | null): boolean {
+  if (!rnVersion) {
+    // Modern Expo (realpath) has been the working path for the last few
+    // SDKs, so it's the safer default when RN can't be detected.
+    return false;
+  }
+  const coerced = semver.valid(rnVersion) || semver.coerce(rnVersion);
+  if (!coerced) {
+    return false;
+  }
+  return semver.lt(coerced, RN_REALPATH_AUTOLINKING_MIN_VERSION);
 }
 
 export const IOS_DEPLOYMENT_TARGET = '13.0';

--- a/plugin/src/helpers/utils/injectCIOPodfileCode.ts
+++ b/plugin/src/helpers/utils/injectCIOPodfileCode.ts
@@ -11,27 +11,35 @@ export type InjectCIOPodfileOptions = {
   hasPush?: boolean;
 };
 
-/** Builds the host app pod line for the Podfile (single subspec or :subspecs with location). Exported for tests. */
+/** Builds the host-app pod snippet for the Podfile.
+ *
+ * The :path is resolved at prebuild time by `getRelativePathToRNSDK`,
+ * which dispatches on the installed React Native version so the path
+ * matches what RN pod autolinking will emit (lexical for RN <0.80,
+ * realpath for RN >=0.80). Baking the resolved string directly avoids
+ * any Ruby/install-time logic in the Podfile and keeps the snippet
+ * trivially diff-able.
+ *
+ * Exported for tests.
+ */
 export function buildHostAppPodSnippet(
   iosPath: string,
   isFcmPushProvider: boolean,
   options?: InjectCIOPodfileOptions
 ): string {
-  const path = getRelativePathToRNSDK(iosPath);
+  const resolvedPath = getRelativePathToRNSDK(iosPath);
   const locationEnabled = options?.locationEnabled === true;
   const hasPush = options?.hasPush !== false;
 
   if (!locationEnabled) {
     const subspec = isFcmPushProvider ? 'fcm' : 'apn';
-    return `pod 'customerio-reactnative/${subspec}', :path => '${path}'`;
+    return `pod 'customerio-reactnative/${subspec}', :path => '${resolvedPath}'`;
   }
-
   if (!hasPush) {
-    return `pod 'customerio-reactnative', :subspecs => ['location'], :path => '${path}'`;
+    return `pod 'customerio-reactnative', :subspecs => ['location'], :path => '${resolvedPath}'`;
   }
-
   const pushSubspec = isFcmPushProvider ? 'fcm' : 'apn';
-  return `pod 'customerio-reactnative', :subspecs => ['${pushSubspec}', 'location'], :path => '${path}'`;
+  return `pod 'customerio-reactnative', :subspecs => ['${pushSubspec}', 'location'], :path => '${resolvedPath}'`;
 }
 
 export async function injectCIOPodfileCode(
@@ -87,12 +95,16 @@ export async function injectCIONotificationPodfileCode(
   const matches = podfile.match(new RegExp(blockStart));
 
   if (!matches) {
+    const resolvedPath = getRelativePathToRNSDK(iosPath);
+    const subspec = isFcmPushProvider ? 'fcm' : 'apn';
+    const useFrameworksLine =
+      useFrameworks === 'static' ? 'use_frameworks! :linkage => :static' : '';
+
     const snippetToInjectInPodfile = `
 ${blockStart}
 target 'NotificationService' do
-  ${useFrameworks === 'static' ? 'use_frameworks! :linkage => :static' : ''}
-  pod 'customerio-reactnative-richpush/${isFcmPushProvider ? 'fcm' : 'apn'
-      }', :path => '${getRelativePathToRNSDK(iosPath)}'
+  ${useFrameworksLine}
+  pod 'customerio-reactnative-richpush/${subspec}', :path => '${resolvedPath}'
 end
 ${blockEnd}
 `.trim();

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -8,6 +8,7 @@ import type {
   LocationTrackingMode,
   NativeSDKConfig,
 } from './types/cio-types';
+import { withExpoVersion } from './utils/writeExpoVersion';
 
 export type { LocationTrackingMode, NativeSDKConfig };
 
@@ -24,6 +25,12 @@ function withCustomerIOPlugin(
       'See documentation for manual setup instructions.'
     );
   }
+
+  // Belt-and-suspenders write of the plugin version into the RN SDK's
+  // package.json. The postinstall hook does the same write at install time;
+  // this covers installs where postinstall didn't run cleanly (pnpm with
+  // strict store layouts, --ignore-scripts, cached CI installs, etc).
+  config = withExpoVersion(config);
 
   // Apply platform specific modifications
   config = withCIOIos(config, props.config, props.ios, props.location);

--- a/plugin/src/postInstallHelper.js
+++ b/plugin/src/postInstallHelper.js
@@ -1,32 +1,90 @@
 const fs = require('fs');
+const path = require('path');
+
+const RN_SDK_PACKAGE = 'customerio-reactnative';
+
+// Locate customerio-reactnative/package.json from a postinstall context.
+//
+// `INIT_CWD` is set by npm, pnpm, and yarn during lifecycle scripts to point
+// at the consumer's project root. That makes it the most reliable starting
+// point — the plugin's own __dirname can be deep inside `.pnpm/...` under pnpm.
+//
+// We probe `${INIT_CWD}/node_modules/customerio-reactnative/package.json` first
+// so we agree with the symlinked layout React Native autolinking expects, then
+// fall back to resolve-from from the consumer root, then to the legacy
+// __dirname-relative walk-up for environments where INIT_CWD is missing.
+function findRNSDKPackageJson() {
+  const candidates = [];
+
+  if (process.env.INIT_CWD) {
+    candidates.push(
+      path.join(process.env.INIT_CWD, 'node_modules', RN_SDK_PACKAGE, 'package.json')
+    );
+  }
+
+  // Legacy flat-npm layout fallback: plugin lives at
+  // <consumer>/node_modules/customerio-expo-plugin/plugin/src and the SDK at
+  // <consumer>/node_modules/customerio-reactnative.
+  candidates.push(path.join(__dirname, '..', '..', '..', RN_SDK_PACKAGE, 'package.json'));
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Final fallback: resolve-from from INIT_CWD. This walks up node_modules
+  // and handles yarn classic workspaces where the dep is hoisted.
+  if (process.env.INIT_CWD) {
+    try {
+      const resolveFrom = require('resolve-from');
+      const resolved = resolveFrom.silent(
+        process.env.INIT_CWD,
+        `${RN_SDK_PACKAGE}/package.json`
+      );
+      if (resolved) return resolved;
+    } catch (_) {
+      // resolve-from missing or unable to resolve — fall through to null.
+    }
+  }
+
+  return null;
+}
 
 function runPostInstall() {
-  // react native SDK package.json path
-  const reactNativePackageJsonFile = `${__dirname}/../../../customerio-reactnative/package.json`;
-  const expoPackageJsonFile = `${__dirname}/../../package.json`;
+  const expoPackageJsonFile = path.join(__dirname, '..', '..', 'package.json');
+
   try {
-    // if react native SDK is installed
-    if (fs.existsSync(reactNativePackageJsonFile)) {
-      const reactNativePackageJson = fs.readFileSync(
-        reactNativePackageJsonFile,
-        'utf8'
-      );
-      const expoPackageJson = require(expoPackageJsonFile);
-
-      const reactNativePackage = JSON.parse(reactNativePackageJson);
-      reactNativePackage.expoVersion = expoPackageJson.version;
-
-      fs.writeFileSync(
-        reactNativePackageJsonFile,
-        JSON.stringify(reactNativePackage, null, 2)
-      );
+    const reactNativePackageJsonFile = findRNSDKPackageJson();
+    if (!reactNativePackageJsonFile) {
+      // Not necessarily an error: the plugin may be installed without the RN
+      // SDK (e.g., during a tooling-only install). The prebuild-time write
+      // covers the common case anyway.
+      return;
     }
+
+    const expoPackageJson = require(expoPackageJsonFile);
+    const reactNativePackage = JSON.parse(
+      fs.readFileSync(reactNativePackageJsonFile, 'utf8')
+    );
+
+    if (reactNativePackage.expoVersion === expoPackageJson.version) {
+      return;
+    }
+
+    reactNativePackage.expoVersion = expoPackageJson.version;
+    fs.writeFileSync(
+      reactNativePackageJsonFile,
+      JSON.stringify(reactNativePackage, null, 2)
+    );
   } catch (error) {
     console.warn(
-      'Unable to find customerio-reactnative package.json file. Please make sure you have installed the customerio-reactnative package.',
+      'customerio-expo-plugin postinstall: failed to write expoVersion into customerio-reactnative/package.json. ' +
+        'The expo prebuild step will retry this. Original error:',
       error
     );
   }
 }
 
 exports.runPostInstall = runPostInstall;
+exports.findRNSDKPackageJson = findRNSDKPackageJson;

--- a/plugin/src/utils/resolveRNSDK.ts
+++ b/plugin/src/utils/resolveRNSDK.ts
@@ -1,0 +1,118 @@
+import fs from 'fs';
+import path from 'path';
+
+const RN_SDK_PACKAGE = 'customerio-reactnative';
+const REACT_NATIVE_PACKAGE = 'react-native';
+
+export type ResolvedRNSDK = {
+  // Absolute path to the package directory.
+  packageDir: string;
+  // Absolute path to package.json inside that directory.
+  packageJsonPath: string;
+};
+
+// Reads the installed react-native package's version starting from `fromDir`.
+// Used to decide which autolinking flavor will resolve customerio-reactnative
+// at pod install time, so our :path agrees with what autolinking emits:
+//   - RN <0.80 ships @react-native-community/cli, which uses a lexical
+//     resolution (no realpath following).
+//   - RN >=0.80 routes pod autolinking through expo-modules-autolinking,
+//     which realpaths.
+// Returns null if react-native cannot be located or its package.json cannot
+// be read; callers should default to the modern (realpath) behavior in that
+// case since it has been the working path for the last several Expo SDKs.
+export function tryReadRNVersion(fromDir: string): string | null {
+  try {
+    const direct = path.join(
+      fromDir,
+      'node_modules',
+      REACT_NATIVE_PACKAGE,
+      'package.json'
+    );
+    if (fs.existsSync(direct)) {
+      return readVersion(direct);
+    }
+    const resolveFrom = require('resolve-from');
+    const fallback = resolveFrom.silent(
+      fromDir,
+      `${REACT_NATIVE_PACKAGE}/package.json`
+    );
+    if (fallback) {
+      return readVersion(fallback);
+    }
+  } catch {
+    // Fall through to null.
+  }
+  return null;
+}
+
+function readVersion(pkgJsonPath: string): string | null {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+    return typeof pkg.version === 'string' ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
+// Resolves the customerio-reactnative SDK location starting from `fromDir`.
+//
+// Probe-then-fallback so the result agrees with React Native autolinking
+// across npm flat, pnpm, and yarn-workspace layouts:
+//   1. `fromDir/node_modules/customerio-reactnative/package.json` — preferred.
+//      Works for npm flat, pnpm (the symlinked path; we never realpath it),
+//      and yarn workspaces with leaf node_modules. Matches what RN
+//      autolinking emits for its pod entry, so CocoaPods sees one
+//      consistent :path.
+//   2. `resolve-from` walking up from `fromDir` — only used when (1) misses.
+//      Handles yarn classic workspaces where the dep is hoisted to a parent
+//      node_modules. yarn classic has no symlinks, so the realpath is fine.
+//
+// Returns null if neither finds the package, including the case where
+// `resolve-from` itself can't be required (mirrors tryReadRNVersion's
+// graceful-failure shape so callers can rely on the documented contract).
+export function tryResolveRNSDK(fromDir: string): ResolvedRNSDK | null {
+  try {
+    const directPkgJson = path.join(
+      fromDir,
+      'node_modules',
+      RN_SDK_PACKAGE,
+      'package.json'
+    );
+    if (fs.existsSync(directPkgJson)) {
+      return {
+        packageDir: path.dirname(directPkgJson),
+        packageJsonPath: directPkgJson,
+      };
+    }
+
+    const resolveFrom = require('resolve-from');
+    const fallbackPkgJson = resolveFrom.silent(
+      fromDir,
+      `${RN_SDK_PACKAGE}/package.json`
+    );
+    if (fallbackPkgJson) {
+      return {
+        packageDir: path.dirname(fallbackPkgJson),
+        packageJsonPath: fallbackPkgJson,
+      };
+    }
+  } catch {
+    // Fall through to null. resolveRNSDK() turns this into a clear
+    // "customerio-reactnative was not found" error for the caller.
+  }
+
+  return null;
+}
+
+// Same as tryResolveRNSDK but throws a clear error when the package is missing.
+export function resolveRNSDK(fromDir: string): ResolvedRNSDK {
+  const resolved = tryResolveRNSDK(fromDir);
+  if (!resolved) {
+    throw new Error(
+      `${RN_SDK_PACKAGE} was not found relative to ${fromDir}. ` +
+      `Ensure it is installed in your project (or in a parent workspace's node_modules).`
+    );
+  }
+  return resolved;
+}

--- a/plugin/src/utils/writeExpoVersion.ts
+++ b/plugin/src/utils/writeExpoVersion.ts
@@ -1,0 +1,62 @@
+import fs from 'fs';
+import type { ConfigPlugin } from '@expo/config-plugins';
+
+import { logger } from './logger';
+import { getPluginVersion } from './plugin';
+import { tryResolveRNSDK } from './resolveRNSDK';
+
+// Writes the plugin's version into customerio-reactnative/package.json under
+// the `expoVersion` key. The RN SDK reads this at runtime (customerio-cdp.ts)
+// to set its User-Agent `packageSource` to "Expo" instead of "ReactNative".
+//
+// We rely on the postinstall hook (postInstallHelper.js) for the same write
+// at install time, but call this from the plugin entry as a fallback for
+// installs where postinstall does not run cleanly — most notably pnpm
+// monorepos and any CI that uses --ignore-scripts.
+//
+// The write is idempotent: we no-op when the value is already correct.
+export function writeExpoVersion(projectRoot: string): void {
+  let resolved;
+  try {
+    resolved = tryResolveRNSDK(projectRoot);
+  } catch (error) {
+    logger.warn(
+      `Could not locate customerio-reactnative to write expoVersion. ` +
+      `User-Agent attribution may be incorrect. Original error: ${error}`
+    );
+    return;
+  }
+
+  if (!resolved) {
+    return;
+  }
+
+  try {
+    const pluginVersion = getPluginVersion();
+    const pkg = JSON.parse(fs.readFileSync(resolved.packageJsonPath, 'utf8'));
+    if (pkg.expoVersion === pluginVersion) {
+      return;
+    }
+    pkg.expoVersion = pluginVersion;
+    fs.writeFileSync(
+      resolved.packageJsonPath,
+      JSON.stringify(pkg, null, 2)
+    );
+  } catch (error) {
+    logger.warn(
+      `Failed to write expoVersion into ${resolved.packageJsonPath}. ` +
+      `User-Agent attribution may be incorrect. Original error: ${error}`
+    );
+  }
+}
+
+export const withExpoVersion: ConfigPlugin = (config) => {
+  // _internal.projectRoot is set by Expo when running through prebuild;
+  // fall back to process.cwd() for any path that calls the plugin in
+  // a non-prebuild context.
+  const projectRoot =
+    (config as unknown as { _internal?: { projectRoot?: string } })._internal?.projectRoot ||
+    process.cwd();
+  writeExpoVersion(projectRoot);
+  return config;
+};

--- a/scripts/build-all-pnpm.sh
+++ b/scripts/build-all-pnpm.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Sets up both pnpm dev apps end-to-end: rebuilds the plugin, regenerates
+# the tarball, installs into each pnpm dev app, and runs expo prebuild.
+# Does not touch the npm test-app/ — see build-all.sh for that.
+
+source scripts/utils.sh
+set -e
+
+print_heading "Building plugin and setting up pnpm dev apps..."
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "pnpm is required for this script. Install it first: npm install -g pnpm"
+  exit 1
+fi
+
+print_blue "\nInstalling root dependencies for plugin...\n"
+npm install
+
+print_blue "\nSetting up test-app-pnpm...\n"
+bash scripts/setup-test-app-pnpm.sh
+
+print_blue "\nSetting up test-app-pnpm-monorepo...\n"
+bash scripts/setup-test-app-pnpm-monorepo.sh
+
+print_success "✅ Plugin and pnpm dev apps built successfully!"

--- a/scripts/clean-all-pnpm.sh
+++ b/scripts/clean-all-pnpm.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Cleans the pnpm dev apps and the cached plugin tarball at the repo root.
+# Does not touch the npm test-app/ — see clean-all.sh for that.
+
+source scripts/utils.sh
+set -e
+
+print_heading "Cleaning pnpm dev apps..."
+
+for pnpm_app in test-app-pnpm test-app-pnpm-monorepo; do
+  if [ -d "$pnpm_app" ]; then
+    echo -e "\nCleaning $pnpm_app..."
+    rm -rf "$pnpm_app/node_modules" "$pnpm_app/pnpm-lock.yaml" "$pnpm_app/.expo"
+    rm -rf "$pnpm_app/ios" "$pnpm_app/android"
+    # Workspace variant has its node_modules inside apps/* and packages/*
+    rm -rf "$pnpm_app"/apps/*/node_modules "$pnpm_app"/apps/*/.expo
+    rm -rf "$pnpm_app"/apps/*/ios "$pnpm_app"/apps/*/android
+    rm -rf "$pnpm_app"/packages/*/node_modules
+    echo "Cleaned $pnpm_app!"
+  fi
+done
+
+# Remove the cached plugin tarball at the repo root so the next setup picks
+# up a fresh build.
+rm -f customerio-expo-plugin-latest.tgz
+
+print_success "✅ pnpm dev app cleanup done!"

--- a/scripts/setup-test-app-pnpm-monorepo.sh
+++ b/scripts/setup-test-app-pnpm-monorepo.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Sets up test-app-pnpm-monorepo: produces the plugin tarball at the repo
+# root, then `pnpm install` inside the workspace. The mobile app at
+# apps/mobile/ depends on customerio-reactnative alongside packages/shared-cio-utils
+# so that pnpm has to deduplicate and symlink the SDK across packages — the
+# exact shape that surfaced the duplicate-pod bug in real customer monorepos.
+
+set -e
+
+SCRIPT_DIR="$(dirname "$0")"
+source "$SCRIPT_DIR/utils.sh"
+
+print_heading "Setting up test-app-pnpm-monorepo..."
+
+print_blue "\nGenerating plugin tarball at repo root..."
+"$SCRIPT_DIR/create-plugin-tarball.sh" "."
+
+cd test-app-pnpm-monorepo
+
+print_blue "\nInstalling dependencies with pnpm (workspace)..."
+pnpm install
+
+print_blue "\nRunning expo prebuild in apps/mobile..."
+pnpm --filter @cio-test/mobile exec expo prebuild --clean
+
+cd ..
+
+print_success "✅ test-app-pnpm-monorepo setup complete."

--- a/scripts/setup-test-app-pnpm.sh
+++ b/scripts/setup-test-app-pnpm.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Sets up test-app-pnpm: produces the plugin tarball at the repo root, then
+# `pnpm install` inside the dev app. This is the pnpm equivalent of
+# setup-test-app.sh for the npm test-app/.
+
+set -e
+
+SCRIPT_DIR="$(dirname "$0")"
+source "$SCRIPT_DIR/utils.sh"
+
+print_heading "Setting up test-app-pnpm..."
+
+print_blue "\nGenerating plugin tarball at repo root..."
+"$SCRIPT_DIR/create-plugin-tarball.sh" "."
+
+cd test-app-pnpm
+
+print_blue "\nInstalling dependencies with pnpm..."
+pnpm install
+
+print_blue "\nRunning expo prebuild..."
+pnpm exec expo prebuild --clean
+
+cd ..
+
+print_success "✅ test-app-pnpm setup complete."

--- a/scripts/verify-pnpm-dev-apps.sh
+++ b/scripts/verify-pnpm-dev-apps.sh
@@ -1,19 +1,23 @@
 #!/bin/bash
 
-# Asserts that the pnpm dev apps are built with portable, correct artifacts.
+# Asserts that the pnpm dev apps are built with correct artifacts.
 # Run after both setup-test-app-pnpm.sh and setup-test-app-pnpm-monorepo.sh.
 #
 # Two regression dimensions:
 #
-#   1. Podfile :path values must not contain `.pnpm/` — the plugin must emit
-#      the symlinked node_modules path that React Native autolinking expects,
-#      not the realpath inside pnpm's virtual store.
+#   1. Every customerio-reactnative pod line in the Podfile must use the
+#      same :path => value. CocoaPods rejects "multiple dependencies with
+#      different sources" when our plugin and React Native autolinking
+#      emit different paths for the same package, which is the customer-
+#      reported failure under pnpm. The actual validity of the path is
+#      verified by `pod install` succeeding in the setup-test-app-pnpm{,
+#      -monorepo}.sh steps that ran before this script.
 #
 #   2. `expoVersion` must be present in the installed customerio-reactnative
 #      package.json. The RN SDK reads this at runtime to set User-Agent
 #      attribution to "Expo" instead of "ReactNative". Under pnpm the
-#      postinstall hook can be silently skipped, so the plugin must also
-#      write this at expo-prebuild time.
+#      postinstall hook can be silently skipped, so the plugin's prebuild-
+#      time write must land the field reliably.
 
 set -e
 
@@ -28,10 +32,11 @@ PODFILES=(
   "test-app-pnpm-monorepo/apps/mobile/ios/Podfile"
 )
 
-# Apps whose customerio-reactnative install we need to inspect. The package
-# may live at the leaf app's node_modules (default pnpm isolated layout) OR
-# at a parent's node_modules (pnpm hoisted layout, or yarn-classic-style
-# hoisting in workspaces). We walk up from each app and use the first match.
+# Apps whose customerio-reactnative install we need to inspect. The actual
+# package.json may land at the leaf app's node_modules (default pnpm
+# isolated layout) OR at a parent's node_modules (pnpm hoisted layout, or
+# yarn-classic-style hoisting in workspaces) — so we walk up from each app
+# and use the first match.
 APP_DIRS=(
   "test-app-pnpm"
   "test-app-pnpm-monorepo/apps/mobile"
@@ -57,7 +62,7 @@ find_cio_pkg_json() {
 }
 
 echo
-print_blue "Checking Podfile :path values..."
+print_blue "Checking customerio-reactnative pod :path consistency..."
 for podfile in "${PODFILES[@]}"; do
   if [ ! -f "$podfile" ]; then
     echo "::error::$podfile does not exist — did the prebuild step run?"
@@ -65,15 +70,32 @@ for podfile in "${PODFILES[@]}"; do
     continue
   fi
 
-  offending=$(grep -E "^\s*pod .* :path =>" "$podfile" | grep "\.pnpm/" || true)
-  if [ -n "$offending" ]; then
-    echo "::error::$podfile contains .pnpm/ in a :path => line."
-    echo "Plugin emitted the pnpm realpath instead of the symlink path that React Native autolinking expects."
-    echo "$offending"
+  # Extract every distinct :path => value across customerio-reactnative pod
+  # lines (host app + NSE target). All such values must be identical for
+  # CocoaPods to accept the install. The plugin uses one resolved path per
+  # prebuild run, so a divergence here would mean either a bug in the
+  # snippet builder or autolinking emitting a path the plugin didn't match.
+  paths=$(grep -E "^\s*pod 'customerio-reactnative" "$podfile" \
+            | grep -E ":path *=> *'[^']*'" \
+            | sed -E "s/.*:path *=> *'([^']*)'.*/\1/" \
+            | sort -u || true)
+  count=$(echo -n "$paths" | grep -c '^' || true)
+
+  if [ "$count" -eq 0 ]; then
+    echo "::error::$podfile has no customerio-reactnative pod lines with a baked :path."
     failures=$((failures + 1))
-  else
-    echo "  OK: $podfile"
+    continue
   fi
+
+  if [ "$count" -gt 1 ]; then
+    echo "::error::$podfile has $count differing :path values for customerio-reactnative pods:"
+    echo "$paths" | sed 's/^/    /'
+    echo "         Every line must agree, otherwise CocoaPods rejects the install."
+    failures=$((failures + 1))
+    continue
+  fi
+
+  echo "  OK: $podfile (:path => '$paths')"
 done
 
 echo

--- a/scripts/verify-pnpm-dev-apps.sh
+++ b/scripts/verify-pnpm-dev-apps.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# Asserts that the pnpm dev apps are built with portable, correct artifacts.
+# Run after both setup-test-app-pnpm.sh and setup-test-app-pnpm-monorepo.sh.
+#
+# Two regression dimensions:
+#
+#   1. Podfile :path values must not contain `.pnpm/` — the plugin must emit
+#      the symlinked node_modules path that React Native autolinking expects,
+#      not the realpath inside pnpm's virtual store.
+#
+#   2. `expoVersion` must be present in the installed customerio-reactnative
+#      package.json. The RN SDK reads this at runtime to set User-Agent
+#      attribution to "Expo" instead of "ReactNative". Under pnpm the
+#      postinstall hook can be silently skipped, so the plugin must also
+#      write this at expo-prebuild time.
+
+set -e
+
+source "$(dirname "$0")/utils.sh"
+
+print_heading "Verifying pnpm dev apps..."
+
+failures=0
+
+PODFILES=(
+  "test-app-pnpm/ios/Podfile"
+  "test-app-pnpm-monorepo/apps/mobile/ios/Podfile"
+)
+
+# Apps whose customerio-reactnative install we need to inspect. The package
+# may live at the leaf app's node_modules (default pnpm isolated layout) OR
+# at a parent's node_modules (pnpm hoisted layout, or yarn-classic-style
+# hoisting in workspaces). We walk up from each app and use the first match.
+APP_DIRS=(
+  "test-app-pnpm"
+  "test-app-pnpm-monorepo/apps/mobile"
+)
+
+# Echoes the path to customerio-reactnative/package.json reachable from
+# $1 by walking up directories, or returns 1 if none is found.
+find_cio_pkg_json() {
+  local dir="$1"
+  while :; do
+    local candidate="$dir/node_modules/customerio-reactnative/package.json"
+    if [ -f "$candidate" ]; then
+      echo "$candidate"
+      return 0
+    fi
+    local parent
+    parent=$(dirname "$dir")
+    if [ "$parent" = "$dir" ]; then
+      return 1
+    fi
+    dir="$parent"
+  done
+}
+
+echo
+print_blue "Checking Podfile :path values..."
+for podfile in "${PODFILES[@]}"; do
+  if [ ! -f "$podfile" ]; then
+    echo "::error::$podfile does not exist — did the prebuild step run?"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  offending=$(grep -E "^\s*pod .* :path =>" "$podfile" | grep "\.pnpm/" || true)
+  if [ -n "$offending" ]; then
+    echo "::error::$podfile contains .pnpm/ in a :path => line."
+    echo "Plugin emitted the pnpm realpath instead of the symlink path that React Native autolinking expects."
+    echo "$offending"
+    failures=$((failures + 1))
+  else
+    echo "  OK: $podfile"
+  fi
+done
+
+echo
+print_blue "Checking expoVersion in customerio-reactnative/package.json..."
+for app_dir in "${APP_DIRS[@]}"; do
+  if ! pkg=$(find_cio_pkg_json "$app_dir"); then
+    echo "::error::could not find customerio-reactnative/package.json reachable from $app_dir — did pnpm install run?"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  if grep -q '"expoVersion"' "$pkg"; then
+    echo "  OK: $pkg"
+  else
+    echo "::error::$pkg is missing expoVersion."
+    echo "User-Agent attribution will report ReactNative instead of Expo."
+    failures=$((failures + 1))
+  fi
+done
+
+echo
+if [ "$failures" -ne 0 ]; then
+  echo "::error::pnpm dev app verification failed: $failures issue(s)."
+  exit 1
+fi
+
+print_success "✅ pnpm dev apps verified."

--- a/test-app-pnpm-monorepo/.gitignore
+++ b/test-app-pnpm-monorepo/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+**/ios/
+**/android/
+.expo/
+pnpm-lock.yaml

--- a/test-app-pnpm-monorepo/apps/mobile/app.json
+++ b/test-app-pnpm-monorepo/apps/mobile/app.json
@@ -1,0 +1,46 @@
+{
+  "expo": {
+    "name": "Test App pnpm monorepo",
+    "slug": "test-app-pnpm-monorepo",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "scheme": "test-app-pnpm-monorepo",
+    "newArchEnabled": true,
+    "ios": {
+      "supportsTablet": true,
+      "bundleIdentifier": "io.customer.testbed.expo.pnpm.monorepo",
+      "entitlements": {
+        "aps-environment": "development"
+      }
+    },
+    "android": {
+      "package": "io.customer.testbed.expo.pnpm.monorepo"
+    },
+    "plugins": [
+      [
+        "customerio-expo-plugin",
+        {
+          "config": {
+            "cdpApiKey": "REPLACE_WITH_REAL_KEY_OR_LEAVE_FOR_PREBUILD_ONLY",
+            "region": "us",
+            "logLevel": "debug"
+          },
+          "ios": {
+            "useFrameworks": "static",
+            "pushNotification": {
+              "provider": "apn"
+            }
+          }
+        }
+      ],
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "useFrameworks": "static"
+          }
+        }
+      ]
+    ]
+  }
+}

--- a/test-app-pnpm-monorepo/apps/mobile/index.tsx
+++ b/test-app-pnpm-monorepo/apps/mobile/index.tsx
@@ -1,0 +1,93 @@
+import {
+  CioConfig,
+  CioLogLevel,
+  CioRegion,
+  CustomerIO,
+} from 'customerio-reactnative';
+import { registerRootComponent } from 'expo';
+import { useEffect } from 'react';
+import { StatusBar } from 'expo-status-bar';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { describeWorkspace } from '@cio-test/shared-cio-utils';
+
+const SMOKE_TAG = '[CioSmoke pnpm-monorepo]';
+
+function App() {
+  useEffect(() => {
+    const config: CioConfig = {
+      cdpApiKey: 'REPLACE_WITH_REAL_KEY',
+      region: CioRegion.US,
+      logLevel: CioLogLevel.Debug,
+    };
+
+    // Each call below routes through the NativeCustomerIO TurboModule. If
+    // pod linkage is broken under pnpm, any of them throws "NativeCustomerIO
+    // could not be found" — which is the bug we're guarding against. We
+    // don't care whether the data lands in a workspace; we care that the
+    // bridge is callable.
+    try {
+      CustomerIO.initialize(config);
+      console.log(`${SMOKE_TAG} initialize OK`);
+
+      CustomerIO.identify({
+        userId: 'pnpm-monorepo-dev-smoke',
+        traits: { source: 'pnpm-monorepo-dev-app' },
+      });
+      console.log(`${SMOKE_TAG} identify OK`);
+
+      CustomerIO.track('pnpm_dev_smoke_event', { ts: Date.now() });
+      console.log(`${SMOKE_TAG} track OK`);
+
+      const inAppListener = CustomerIO.inAppMessaging.registerEventsListener(
+        (event) => console.log(`${SMOKE_TAG} inApp event:`, event)
+      );
+      console.log(`${SMOKE_TAG} in-app listener registered`);
+
+      CustomerIO.pushMessaging
+        .showPromptForPushNotifications({ ios: { sound: true, badge: true } })
+        .then((status) => console.log(`${SMOKE_TAG} push permission:`, status))
+        .catch((err) => console.warn(`${SMOKE_TAG} push permission error:`, err));
+
+      return () => {
+        inAppListener?.remove?.();
+      };
+    } catch (err) {
+      console.error(`${SMOKE_TAG} FAILED — native module not linked?`, err);
+    }
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>customerio-expo-plugin pnpm monorepo dev app</Text>
+      <Text style={styles.subtitle}>{describeWorkspace()}</Text>
+      <Text style={styles.subtitle}>
+        Smoke-tests SDK bridge on launch. Watch the console for {SMOKE_TAG} lines.
+      </Text>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  subtitle: {
+    marginTop: 12,
+    fontSize: 14,
+    color: '#555',
+    textAlign: 'center',
+  },
+});
+
+registerRootComponent(App);

--- a/test-app-pnpm-monorepo/apps/mobile/package.json
+++ b/test-app-pnpm-monorepo/apps/mobile/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@cio-test/mobile",
+  "main": "index.tsx",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "eas-build-post-install": "echo 'eas-build-post-install: running expo prebuild --no-install' && expo prebuild --no-install"
+  },
+  "dependencies": {
+    "@cio-test/shared-cio-utils": "workspace:*",
+    "customerio-expo-plugin": "file:../../../customerio-expo-plugin-latest.tgz",
+    "customerio-reactnative": "^6.4.0",
+    "expo": "~54.0.2",
+    "expo-build-properties": "^1.0.8",
+    "expo-status-bar": "~3.0.8",
+    "react": "19.1.0",
+    "react-native": "0.81.4"
+  },
+  "devDependencies": {
+    "@types/react": "~19.1.0",
+    "typescript": "~5.9.2"
+  }
+}

--- a/test-app-pnpm-monorepo/apps/mobile/tsconfig.json
+++ b/test-app-pnpm-monorepo/apps/mobile/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx"
+  ]
+}

--- a/test-app-pnpm-monorepo/package.json
+++ b/test-app-pnpm-monorepo/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-app-pnpm-monorepo",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "prebuild:ios": "pnpm --filter @cio-test/mobile exec expo prebuild --platform ios --clean",
+    "prebuild:android": "pnpm --filter @cio-test/mobile exec expo prebuild --platform android --clean",
+    "ios": "pnpm --filter @cio-test/mobile exec expo run:ios",
+    "android": "pnpm --filter @cio-test/mobile exec expo run:android"
+  }
+}

--- a/test-app-pnpm-monorepo/packages/shared-cio-utils/index.ts
+++ b/test-app-pnpm-monorepo/packages/shared-cio-utils/index.ts
@@ -1,0 +1,7 @@
+// This package exists solely so that customerio-reactnative is depended on
+// from more than one workspace package. That's what triggers pnpm's
+// deduplication and symlinking behavior — the exact shape that surfaced the
+// duplicate-pod bug in the Good Neighbor support case.
+export function describeWorkspace(): string {
+  return 'Shared package depends on customerio-reactnative — exercises pnpm symlink/dedupe.';
+}

--- a/test-app-pnpm-monorepo/packages/shared-cio-utils/package.json
+++ b/test-app-pnpm-monorepo/packages/shared-cio-utils/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@cio-test/shared-cio-utils",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.ts",
+  "types": "index.ts",
+  "dependencies": {
+    "customerio-reactnative": "^6.4.0"
+  }
+}

--- a/test-app-pnpm-monorepo/pnpm-workspace.yaml
+++ b/test-app-pnpm-monorepo/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"

--- a/test-app-pnpm/.gitignore
+++ b/test-app-pnpm/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+ios/
+android/
+.expo/
+pnpm-lock.yaml

--- a/test-app-pnpm/app.json
+++ b/test-app-pnpm/app.json
@@ -1,0 +1,46 @@
+{
+  "expo": {
+    "name": "Test App pnpm",
+    "slug": "test-app-pnpm",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "scheme": "test-app-pnpm",
+    "newArchEnabled": true,
+    "ios": {
+      "supportsTablet": true,
+      "bundleIdentifier": "io.customer.testbed.expo.pnpm",
+      "entitlements": {
+        "aps-environment": "development"
+      }
+    },
+    "android": {
+      "package": "io.customer.testbed.expo.pnpm"
+    },
+    "plugins": [
+      [
+        "customerio-expo-plugin",
+        {
+          "config": {
+            "cdpApiKey": "REPLACE_WITH_REAL_KEY_OR_LEAVE_FOR_PREBUILD_ONLY",
+            "region": "us",
+            "logLevel": "debug"
+          },
+          "ios": {
+            "useFrameworks": "static",
+            "pushNotification": {
+              "provider": "apn"
+            }
+          }
+        }
+      ],
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "useFrameworks": "static"
+          }
+        }
+      ]
+    ]
+  }
+}

--- a/test-app-pnpm/index.tsx
+++ b/test-app-pnpm/index.tsx
@@ -1,0 +1,90 @@
+import {
+  CioConfig,
+  CioLogLevel,
+  CioRegion,
+  CustomerIO,
+} from 'customerio-reactnative';
+import { registerRootComponent } from 'expo';
+import { useEffect } from 'react';
+import { StatusBar } from 'expo-status-bar';
+import { StyleSheet, Text, View } from 'react-native';
+
+const SMOKE_TAG = '[CioSmoke pnpm-flat]';
+
+function App() {
+  useEffect(() => {
+    const config: CioConfig = {
+      cdpApiKey: 'REPLACE_WITH_REAL_KEY',
+      region: CioRegion.US,
+      logLevel: CioLogLevel.Debug,
+    };
+
+    // Each call below routes through the NativeCustomerIO TurboModule. If
+    // pod linkage is broken under pnpm, any of them throws "NativeCustomerIO
+    // could not be found" — which is the bug we're guarding against. We
+    // don't care whether the data lands in a workspace; we care that the
+    // bridge is callable.
+    try {
+      CustomerIO.initialize(config);
+      console.log(`${SMOKE_TAG} initialize OK`);
+
+      CustomerIO.identify({
+        userId: 'pnpm-flat-dev-smoke',
+        traits: { source: 'pnpm-flat-dev-app' },
+      });
+      console.log(`${SMOKE_TAG} identify OK`);
+
+      CustomerIO.track('pnpm_dev_smoke_event', { ts: Date.now() });
+      console.log(`${SMOKE_TAG} track OK`);
+
+      const inAppListener = CustomerIO.inAppMessaging.registerEventsListener(
+        (event) => console.log(`${SMOKE_TAG} inApp event:`, event)
+      );
+      console.log(`${SMOKE_TAG} in-app listener registered`);
+
+      CustomerIO.pushMessaging
+        .showPromptForPushNotifications({ ios: { sound: true, badge: true } })
+        .then((status) => console.log(`${SMOKE_TAG} push permission:`, status))
+        .catch((err) => console.warn(`${SMOKE_TAG} push permission error:`, err));
+
+      return () => {
+        inAppListener?.remove?.();
+      };
+    } catch (err) {
+      console.error(`${SMOKE_TAG} FAILED — native module not linked?`, err);
+    }
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>customerio-expo-plugin pnpm dev app</Text>
+      <Text style={styles.subtitle}>
+        Smoke-tests SDK bridge on launch. Watch the console for {SMOKE_TAG} lines.
+      </Text>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  subtitle: {
+    marginTop: 12,
+    fontSize: 14,
+    color: '#555',
+    textAlign: 'center',
+  },
+});
+
+registerRootComponent(App);

--- a/test-app-pnpm/package.json
+++ b/test-app-pnpm/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "test-app-pnpm",
+  "main": "index.tsx",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "prebuild": "expo prebuild --clean",
+    "eas-build-post-install": "echo 'eas-build-post-install: running expo prebuild --no-install' && expo prebuild --no-install"
+  },
+  "dependencies": {
+    "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
+    "customerio-reactnative": "^6.4.0",
+    "expo": "~54.0.2",
+    "expo-build-properties": "^1.0.8",
+    "expo-status-bar": "~3.0.8",
+    "react": "19.1.0",
+    "react-native": "0.81.4"
+  },
+  "devDependencies": {
+    "@types/react": "~19.1.0",
+    "typescript": "~5.9.2"
+  }
+}

--- a/test-app-pnpm/tsconfig.json
+++ b/test-app-pnpm/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx"
+  ]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,6 +3,8 @@
   "exclude": [
     "ci-test-apps",
     "__tests__",
-    "test-app"
+    "test-app",
+    "test-app-pnpm",
+    "test-app-pnpm-monorepo"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,10 @@
     "target": "esnext",
     "verbatimModuleSyntax": true
   },
-  "exclude": ["ci-test-apps/**", "test-app/**"]
+  "exclude": [
+    "ci-test-apps/**",
+    "test-app/**",
+    "test-app-pnpm/**",
+    "test-app-pnpm-monorepo/**"
+  ]
 }


### PR DESCRIPTION
Collection of approved PRs that enable support for apps using PNPM
- https://github.com/customerio/customerio-expo-plugin/pull/334
- https://github.com/customerio/customerio-expo-plugin/pull/335

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies iOS Podfile path resolution and writes to `customerio-reactnative/package.json` during prebuild/postinstall, which can affect CocoaPods installs and consumer dependency trees if resolution is wrong.
> 
> **Overview**
> Improves pnpm/monorepo compatibility by changing iOS Podfile injection to **bake a prebuild-resolved `:path`** that matches React Native autolinking behavior (lexical vs realpath based on RN version) via new `resolveRNSDK` utilities and expanded tests.
> 
> Adds a fallback mechanism to ensure `expoVersion` is written into `customerio-reactnative/package.json` during `expo prebuild` (in addition to postinstall), and updates the postinstall helper to locate the RN SDK reliably under pnpm/yarn layouts.
> 
> Introduces new pnpm dev apps (flat + workspace), local setup/clean/verify scripts, TypeScript excludes, and a macOS CI workflow that builds both pnpm layouts (isolated and hoisted) and validates Podfile `:path` consistency plus `expoVersion` attribution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 426b5e4361d2901e0322697746ae5da39a7c050b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->