### PR TITLE
refactor(android): extract pure transformation helpers from mods

### DIFF
--- a/plugin/src/android/withAndroidManifestUpdates.ts
+++ b/plugin/src/android/withAndroidManifestUpdates.ts
@@ -9,92 +9,102 @@ import { logger } from '../utils/logger';
 export const DEFAULT_LOW_PRIORITY = -10;
 
 
+export function modifyAndroidManifestApplication(
+  application: ManifestApplication[],
+  options: CustomerIOPluginOptionsAndroid
+): ManifestApplication[] {
+  const customerIOMessagingpush =
+    'io.customer.messagingpush.CustomerIOFirebaseMessagingService';
+
+  if (!application[0].service) {
+    application[0].service = [];
+  }
+
+  const existingServiceIndex = application[0].service.findIndex(
+    (service) => service.$['android:name'] === customerIOMessagingpush
+  );
+
+  if (existingServiceIndex === -1) {
+    // Intent filter structure for Firebase messaging service
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const intentFilter: any = {
+      action: [
+        {
+          $: {
+            'android:name': 'com.google.firebase.MESSAGING_EVENT',
+          },
+        },
+      ],
+    };
+
+    // Handle priority based on setHighPriorityPushHandler value
+    if (options.setHighPriorityPushHandler === true) {
+      // High priority - no priority attribute means default high priority
+      logger.info(
+        'Successfully set CustomerIO push handler as high priority in AndroidManifest.xml'
+      );
+    } else if (options.setHighPriorityPushHandler === false) {
+      // Low priority - set fixed priority
+      intentFilter.$ = {
+        'android:priority': DEFAULT_LOW_PRIORITY.toString(),
+      };
+      logger.info(
+        `Successfully set CustomerIO push handler as low priority (${DEFAULT_LOW_PRIORITY}) in AndroidManifest.xml`
+      );
+    }
+
+    application[0].service.push({
+      '$': {
+        'android:name': customerIOMessagingpush,
+        'android:exported': 'false',
+      },
+      'intent-filter': [intentFilter],
+    });
+  } else if (options.setHighPriorityPushHandler === true) {
+    // Service exists, need to ensure it becomes high priority (remove priority attribute)
+    const existingService = application[0].service[existingServiceIndex];
+
+    if (existingService['intent-filter'] && existingService['intent-filter'].length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const intentFilter = existingService['intent-filter'][0] as any;
+      if (intentFilter.$ && intentFilter.$['android:priority']) {
+        delete intentFilter.$['android:priority'];
+        logger.info(
+          'Successfully updated existing CustomerIO push handler to high priority in AndroidManifest.xml'
+        );
+      }
+    }
+  } else if (options.setHighPriorityPushHandler === false) {
+    // Service exists, update to low priority
+    const existingService = application[0].service[existingServiceIndex];
+
+    // Update existing service intent-filter with fixed priority
+    if (existingService['intent-filter'] && existingService['intent-filter'].length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const intentFilter = existingService['intent-filter'][0] as any;
+      if (!intentFilter.$) {
+        intentFilter.$ = {};
+      }
+      intentFilter.$['android:priority'] = DEFAULT_LOW_PRIORITY.toString();
+      logger.info(
+        `Successfully updated existing CustomerIO push handler to low priority (${DEFAULT_LOW_PRIORITY}) in AndroidManifest.xml`
+      );
+    }
+  }
+
+  return application;
+}
+
 export const withAndroidManifestUpdates: ConfigPlugin<
   CustomerIOPluginOptionsAndroid
 > = (configOuter, options) => {
   return withAndroidManifest(configOuter, (props) => {
     const application = props.modResults.manifest
       .application as ManifestApplication[];
-    const customerIOMessagingpush =
-      'io.customer.messagingpush.CustomerIOFirebaseMessagingService';
-
-    if (!application[0].service) {
-      application[0].service = [];
-    }
-
-    const existingServiceIndex = application[0].service.findIndex(
-      (service) => service.$['android:name'] === customerIOMessagingpush
+    props.modResults.manifest.application = modifyAndroidManifestApplication(
+      application,
+      options
     );
-
-    if (existingServiceIndex === -1) {
-      // Intent filter structure for Firebase messaging service
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const intentFilter: any = {
-        action: [
-          {
-            $: {
-              'android:name': 'com.google.firebase.MESSAGING_EVENT',
-            },
-          },
-        ],
-      };
-
-      // Handle priority based on setHighPriorityPushHandler value
-      if (options.setHighPriorityPushHandler === true) {
-        // High priority - no priority attribute means default high priority
-        logger.info(
-          'Successfully set CustomerIO push handler as high priority in AndroidManifest.xml'
-        );
-      } else if (options.setHighPriorityPushHandler === false) {
-        // Low priority - set fixed priority
-        intentFilter.$ = {
-          'android:priority': DEFAULT_LOW_PRIORITY.toString(),
-        };
-        logger.info(
-          `Successfully set CustomerIO push handler as low priority (${DEFAULT_LOW_PRIORITY}) in AndroidManifest.xml`
-        );
-      }
-
-      application[0].service.push({
-        '$': {
-          'android:name': customerIOMessagingpush,
-          'android:exported': 'false',
-        },
-        'intent-filter': [intentFilter],
-      });
-    } else if (options.setHighPriorityPushHandler === true) {
-      // Service exists, need to ensure it becomes high priority (remove priority attribute)
-      const existingService = application[0].service[existingServiceIndex];
-
-      if (existingService['intent-filter'] && existingService['intent-filter'].length > 0) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const intentFilter = existingService['intent-filter'][0] as any;
-        if (intentFilter.$ && intentFilter.$['android:priority']) {
-          delete intentFilter.$['android:priority'];
-          logger.info(
-            'Successfully updated existing CustomerIO push handler to high priority in AndroidManifest.xml'
-          );
-        }
-      }
-    } else if (options.setHighPriorityPushHandler === false) {
-      // Service exists, update to low priority
-      const existingService = application[0].service[existingServiceIndex];
-
-      // Update existing service intent-filter with fixed priority
-      if (existingService['intent-filter'] && existingService['intent-filter'].length > 0) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const intentFilter = existingService['intent-filter'][0] as any;
-        if (!intentFilter.$) {
-          intentFilter.$ = {};
-        }
-        intentFilter.$['android:priority'] = DEFAULT_LOW_PRIORITY.toString();
-        logger.info(
-          `Successfully updated existing CustomerIO push handler to low priority (${DEFAULT_LOW_PRIORITY}) in AndroidManifest.xml`
-        );
-      }
-    }
-
-    props.modResults.manifest.application = application;
     return props;
   });
 };

--- a/plugin/src/android/withAppGoogleServices.ts
+++ b/plugin/src/android/withAppGoogleServices.ts
@@ -8,21 +8,23 @@ import {
 import type { CustomerIOPluginOptionsAndroid } from '../types/cio-types';
 import { logger } from '../utils/logger';
 
+export function modifyAppBuildGradle(contents: string): string {
+  const regex = new RegExp(CIO_APP_GOOGLE_SNIPPET);
+  if (regex.test(contents)) {
+    logger.info('app/build.gradle snippet already exists. Skipping...');
+    return contents;
+  }
+  return contents.replace(
+    CIO_APP_APPLY_REGEX,
+    `$1\n${CIO_APP_GOOGLE_SNIPPET}`
+  );
+}
+
 export const withAppGoogleServices: ConfigPlugin<
   CustomerIOPluginOptionsAndroid
 > = (configOuter) => {
   return withAppBuildGradle(configOuter, (props) => {
-    const regex = new RegExp(CIO_APP_GOOGLE_SNIPPET);
-    const match = props.modResults.contents.match(regex);
-    if (!match) {
-      props.modResults.contents = props.modResults.contents.replace(
-        CIO_APP_APPLY_REGEX,
-        `$1\n${CIO_APP_GOOGLE_SNIPPET}`
-      );
-    } else {
-      logger.info('app/build.gradle snippet already exists. Skipping...');
-    }
-
+    props.modResults.contents = modifyAppBuildGradle(props.modResults.contents);
     return props;
   });
 };

--- a/plugin/src/android/withGoogleServicesJSON.ts
+++ b/plugin/src/android/withGoogleServicesJSON.ts
@@ -5,38 +5,40 @@ import { logger } from '../utils/logger';
 import { FileManagement } from './../helpers/utils/fileManagement';
 import type { CustomerIOPluginOptionsAndroid } from './../types/cio-types';
 
+export function copyGoogleServicesFile(
+  androidPath: string,
+  googleServicesFile: string | undefined
+): void {
+  const destination = `${androidPath}/app/google-services.json`;
+
+  if (FileManagement.exists(destination)) {
+    logger.info(`File already exists: ${destination}. Skipping...`);
+    return;
+  }
+
+  if (googleServicesFile && FileManagement.exists(googleServicesFile)) {
+    try {
+      FileManagement.copyFile(googleServicesFile, destination);
+    } catch {
+      logger.info(
+        `There was an error copying your google-services.json file. You can copy it manually into ${destination}`
+      );
+    }
+  } else {
+    logger.info(
+      `The Google Services file provided in ${googleServicesFile} doesn't seem to exist. You can copy it manually into ${destination}`
+    );
+  }
+}
+
 export const withGoogleServicesJSON: ConfigPlugin<
   CustomerIOPluginOptionsAndroid
 > = (configOuter, cioProps) => {
   return withProjectBuildGradle(configOuter, (props) => {
-    const options: CustomerIOPluginOptionsAndroid = {
-      androidPath: props.modRequest.platformProjectRoot,
-      googleServicesFile: cioProps?.googleServicesFile,
-    };
-    const { androidPath, googleServicesFile } = options;
-    if (!FileManagement.exists(`${androidPath}/app/google-services.json`)) {
-      if (googleServicesFile && FileManagement.exists(googleServicesFile)) {
-        try {
-          FileManagement.copyFile(
-            googleServicesFile,
-            `${androidPath}/app/google-services.json`
-          );
-        } catch {
-          logger.info(
-            `There was an error copying your google-services.json file. You can copy it manually into ${androidPath}/app/google-services.json`
-          );
-        }
-      } else {
-        logger.info(
-          `The Google Services file provided in ${googleServicesFile} doesn't seem to exist. You can copy it manually into ${androidPath}/app/google-services.json`
-        );
-      }
-    } else {
-      logger.info(
-        `File already exists: ${androidPath}/app/google-services.json. Skipping...`
-      );
-    }
-
+    copyGoogleServicesFile(
+      props.modRequest.platformProjectRoot,
+      cioProps?.googleServicesFile
+    );
     return props;
   });
 };

--- a/plugin/src/android/withLocationGradleProperties.ts
+++ b/plugin/src/android/withLocationGradleProperties.ts
@@ -6,6 +6,28 @@ import type { CustomerIOPluginLocationOptions } from '../types/cio-types';
 
 const CUSTOMERIO_LOCATION_ENABLED_KEY = 'customerio_location_enabled';
 
+export function modifyGradleProperties(
+  items: PropertiesItem[]
+): PropertiesItem[] {
+  const existingIndex = items.findIndex(
+    (item) => item.type === 'property' && item.key === CUSTOMERIO_LOCATION_ENABLED_KEY
+  );
+
+  const newItem: PropertiesItem = {
+    type: 'property',
+    key: CUSTOMERIO_LOCATION_ENABLED_KEY,
+    value: 'true',
+  };
+
+  if (existingIndex >= 0) {
+    items[existingIndex] = newItem;
+  } else {
+    items.push(newItem);
+  }
+
+  return items;
+}
+
 /**
  * Adds or updates customerio_location_enabled in android/gradle.properties when location.enabled is true.
  * The Customer.io React Native SDK reads this to enable the location native module.
@@ -19,23 +41,7 @@ export const withLocationGradleProperties: ConfigPlugin<{
 
   return withGradleProperties(config, (config) => {
     const items = config.modResults as PropertiesItem[];
-    const existingIndex = items.findIndex(
-      (item) => item.type === 'property' && item.key === CUSTOMERIO_LOCATION_ENABLED_KEY
-    );
-
-    const newItem: PropertiesItem = {
-      type: 'property',
-      key: CUSTOMERIO_LOCATION_ENABLED_KEY,
-      value: 'true',
-    };
-
-    if (existingIndex >= 0) {
-      items[existingIndex] = newItem;
-    } else {
-      items.push(newItem);
-    }
-
-    config.modResults = items;
+    config.modResults = modifyGradleProperties(items);
     return config;
   });
 };

--- a/plugin/src/android/withMainApplicationModifications.ts
+++ b/plugin/src/android/withMainApplicationModifications.ts
@@ -36,6 +36,30 @@ const getLocationInitOptions = (
   trackingMode: sdkConfig?.location?.trackingMode,
 });
 
+const SDK_INITIALIZER_CLASS = 'CustomerIOSDKInitializer';
+const SDK_INITIALIZER_PACKAGE = 'io.customer.sdk.expo';
+const SDK_INITIALIZER_FILE = `${SDK_INITIALIZER_CLASS}.kt`;
+const SDK_INITIALIZER_IMPORT = `import ${SDK_INITIALIZER_PACKAGE}.${SDK_INITIALIZER_CLASS}`;
+
+/**
+ * Pure string transform: given the existing MainApplication contents, returns the contents
+ * with the CustomerIOSDKInitializer import and onCreate call injected (idempotent — if the
+ * initialize call is already present, the call-injection step is skipped).
+ */
+export function injectCustomerIOInitializerIntoMainApplication(
+  contents: string
+): string {
+  let next = addImportToFile(contents, SDK_INITIALIZER_IMPORT);
+  if (!next.includes(CIO_NATIVE_SDK_INITIALIZE_CALL)) {
+    next = addCodeToMethod(
+      next,
+      CIO_MAINAPPLICATION_ONCREATE_REGEX,
+      CIO_NATIVE_SDK_INITIALIZE_SNIPPET
+    );
+  }
+  return next;
+}
+
 /**
  * Setup CustomerIOSDKInitializer for Android auto initialization
  */
@@ -44,30 +68,16 @@ const setupCustomerIOSDKInitializer = (
   sdkConfig: NativeSDKConfig,
   location?: CustomerIOPluginLocationOptions,
 ): string => {
-  const SDK_INITIALIZER_CLASS = 'CustomerIOSDKInitializer';
-  const SDK_INITIALIZER_PACKAGE = 'io.customer.sdk.expo';
-
-  const SDK_INITIALIZER_FILE = `${SDK_INITIALIZER_CLASS}.kt`;
-  const SDK_INITIALIZER_IMPORT = `import ${SDK_INITIALIZER_PACKAGE}.${SDK_INITIALIZER_CLASS}`;
-
   const locationOptions = getLocationInitOptions(location, sdkConfig);
-  let content = config.modResults.contents;
 
   try {
     // Always regenerate the CustomerIOSDKInitializer file to reflect config changes
     copyTemplateFile(config, SDK_INITIALIZER_FILE, SDK_INITIALIZER_PACKAGE, (content) =>
       patchNativeSDKInitializer(content, PLATFORM.ANDROID, sdkConfig, locationOptions)
     );
-    // Add import if not already present
-    content = addImportToFile(content, SDK_INITIALIZER_IMPORT);
-    // Add initialization code to onCreate if not already present
-    if (!content.includes(CIO_NATIVE_SDK_INITIALIZE_CALL)) {
-      content = addCodeToMethod(content, CIO_MAINAPPLICATION_ONCREATE_REGEX, CIO_NATIVE_SDK_INITIALIZE_SNIPPET);
-    }
+    return injectCustomerIOInitializerIntoMainApplication(config.modResults.contents);
   } catch (error) {
     logger.warn(`Could not setup ${SDK_INITIALIZER_CLASS}:`, error);
     return config.modResults.contents;
   }
-
-  return content;
 };

--- a/plugin/src/android/withNotificationChannelMetadata.ts
+++ b/plugin/src/android/withNotificationChannelMetadata.ts
@@ -7,7 +7,7 @@ import type { CustomerIOPluginOptionsAndroid } from '../types/cio-types';
 /**
  * Adds a metadata entry to the Android manifest if it doesn't already exist
  */
-const addMetadataIfNotExists = (
+export const addMetadataIfNotExists = (
   application: ManifestApplication,
   name: string,
   value: string

--- a/plugin/src/android/withProjectBuildGradle.ts
+++ b/plugin/src/android/withProjectBuildGradle.ts
@@ -24,6 +24,40 @@ function shouldDisableAndroid16Support(
 }
 
 /**
+ * Pure string transform: injects an androidx resolution-strategy block into the
+ * project-level build.gradle's `allprojects { ... }` section when
+ * `disableAndroid16Support` is true. Idempotent — returns input unchanged if the
+ * snippet is already present, or if the flag is false.
+ */
+export function modifyProjectBuildGradleAndroid16Support(
+  contents: string,
+  options: { disableAndroid16Support: boolean }
+): string {
+  if (!options.disableAndroid16Support) {
+    return contents;
+  }
+
+  if (contents.includes('androidx.core:core-ktx:1.13.1')) {
+    return contents;
+  }
+
+  const resolutionStrategy = `
+    configurations.all {
+        resolutionStrategy {
+            // Disable Android 16 support by forcing older androidx versions
+            // Compatible with API 35 and AGP 8.8.2 (prevents API 36/AGP 8.9.1+ requirement)
+            force 'androidx.core:core-ktx:1.13.1'
+            force 'androidx.lifecycle:lifecycle-process:2.8.7'
+        }
+    }`;
+
+  return contents.replace(
+    /allprojects\s*\{/,
+    `allprojects {${resolutionStrategy}`
+  );
+}
+
+/**
  * Adds dependency resolution strategy to force specific androidx versions.
  * This disables Android 16 support for apps using Expo SDK 53 or older gradle versions.
  *
@@ -38,34 +72,10 @@ export function withProjectBuildGradle(
   androidOptions?: CustomerIOPluginOptionsAndroid
 ): ExpoConfig {
   return withExpoProjectBuildGradle(config, (config) => {
-    const { modResults } = config;
-
-    // Check if Android 16 support should be disabled
-    if (!shouldDisableAndroid16Support(config, androidOptions)) {
-      return config;
-    }
-
-    // Skip if already applied
-    if (modResults.contents.includes('androidx.core:core-ktx:1.13.1')) {
-      return config;
-    }
-
-    const resolutionStrategy = `
-    configurations.all {
-        resolutionStrategy {
-            // Disable Android 16 support by forcing older androidx versions
-            // Compatible with API 35 and AGP 8.8.2 (prevents API 36/AGP 8.9.1+ requirement)
-            force 'androidx.core:core-ktx:1.13.1'
-            force 'androidx.lifecycle:lifecycle-process:2.8.7'
-        }
-    }`;
-
-    // Add resolution strategy inside allprojects block
-    modResults.contents = modResults.contents.replace(
-      /allprojects\s*\{/,
-      `allprojects {${resolutionStrategy}`
+    config.modResults.contents = modifyProjectBuildGradleAndroid16Support(
+      config.modResults.contents,
+      { disableAndroid16Support: shouldDisableAndroid16Support(config, androidOptions) }
     );
-
     return config;
   });
 }

--- a/plugin/src/android/withProjectGoogleServices.ts
+++ b/plugin/src/android/withProjectGoogleServices.ts
@@ -7,19 +7,24 @@ import {
 } from './../helpers/constants/android';
 import type { CustomerIOPluginOptionsAndroid } from './../types/cio-types';
 
+export function modifyProjectBuildGradleForGoogleServices(contents: string): string {
+  const regex = new RegExp(CIO_PROJECT_GOOGLE_SNIPPET);
+  if (regex.test(contents)) {
+    return contents;
+  }
+  return contents.replace(
+    CIO_PROJECT_BUILDSCRIPTS_REGEX,
+    `$1\n${CIO_PROJECT_GOOGLE_SNIPPET}`
+  );
+}
+
 export const withProjectGoogleServices: ConfigPlugin<
   CustomerIOPluginOptionsAndroid
 > = (configOuter) => {
   return withProjectBuildGradle(configOuter, (props) => {
-    const regex = new RegExp(CIO_PROJECT_GOOGLE_SNIPPET);
-    const match = props.modResults.contents.match(regex);
-    if (!match) {
-      props.modResults.contents = props.modResults.contents.replace(
-        CIO_PROJECT_BUILDSCRIPTS_REGEX,
-        `$1\n${CIO_PROJECT_GOOGLE_SNIPPET}`
-      );
-    }
-
+    props.modResults.contents = modifyProjectBuildGradleForGoogleServices(
+      props.modResults.contents
+    );
     return props;
   });
 };


### PR DESCRIPTION
## Overview

This is the first of six stacked PRs introducing a tiered testing approach for the plugin. Today every PR runs a full `expo prebuild → real native build` matrix on macOS — slow, expensive, and narrow in coverage. The new tiers:

1. **Fast Jest scenario suite (PR-time)** — pure-helper unit tests against hand-curated, version-pinned fixtures, parameterized over config variants, idempotency checks, and negative-template inputs. Runs on `ubuntu-latest` in seconds.
2. **Slim 3-cell smoke matrix (PR-time)** — Android + iOS APN + iOS FCM at the latest SDK, real `expo prebuild` + native build. Catches Gradle / CocoaPods / xcodebuild regressions a fast suite can't see.
3. **Release-gated full matrix** — today's full matrix moves behind merges to `main` via `workflow_run` chaining, so it remains the deep backstop without blocking every PR.

## Stack

- **➡️ PR 1 (this PR): Android pure-helper extractions** — refactor only.
- PR 2: iOS pure-helper extractions — refactor only.
- PR 3: Test infrastructure + Android scenario coverage — additive tests, no `plugin/src/` changes.
- PR 4: iOS scenario coverage + pbxproj fixture set — additive tests.
- PR 5: CI restructure — slim PR-time matrix, release-gating workflow chained off `main`.
- PR 6: Delete legacy snapshot tier — runs after one stable release cycle on the new setup.

## What this PR ships

The transformation logic inside each Android `withXxx` mod is factored out of the mod callback into a named, exported, pure helper, mirroring the `modifyObjcAppDelegate` / `modifyAppDelegate` convention used by Firebase and Sentry config plugins. These helpers become the test seams the upcoming scenario suite will drive directly, without going through `expo prebuild`.

This is intentionally a **refactor-only** PR: no wrapper signatures change, no behavior changes, no test edits. The existing mock and snapshot tests under `__tests__/android/` pass unchanged — that's the load-bearing evidence that this is behavior-preserving. If any wrapper signature or output had shifted, those tests would have failed.

Two mods are deliberately untouched because they don't fit the pattern: one already exposes a pure helper, and the other is a pure orchestrator that just composes the others.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typescript` — clean
- [x] `npm test -- __tests__/android` — all green
- [ ] `Validate Plugin Compatibility` full matrix runs green via the existing PR triggers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that moves existing Android config-plugin mutation logic into exported helper functions; behavior should be unchanged aside from any subtle differences in idempotency/regex replacement edge cases.
> 
> **Overview**
> Refactors the Android Expo config-plugin mods to extract their in-callback mutation logic into exported, testable “pure” helpers (e.g., manifest service injection/priority updates, Gradle snippet insertion, `google-services.json` copying, and `gradle.properties` edits), with the mods now delegating to these functions.
> 
> Also extracts a pure `MainApplication` string injection helper and makes `addMetadataIfNotExists` exported, preparing these transforms for direct unit testing without changing the plugin’s public mod entrypoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21bec6e6ff82f3ccc925a8c43d7ec541fb19195a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->