### PR TITLE
refactor(ios): extract pure transformation helpers from mods

### DIFF
--- a/plugin/src/ios/withAppDelegateModifications.ts
+++ b/plugin/src/ios/withAppDelegateModifications.ts
@@ -153,9 +153,12 @@ const addFirebaseDelegateForwardDeclarationIfNeeded = (
   return stringContents;
 };
 
-const addAppdelegateHeaderModification = (stringContents: string) => {
-  // Add UNUserNotificationCenterDelegate if needed
-  stringContents = stringContents.replace(
+/**
+ * Pure string transform: ensures the AppDelegate header (Objective-C path) declares
+ * `UNUserNotificationCenterDelegate` and imports `UserNotifications`. Idempotent.
+ */
+export function modifyAppDelegateHeader(headerContent: string): string {
+  return headerContent.replace(
     CIO_APPDELEGATEHEADER_REGEX,
     (match, interfaceDeclaration, _groupedDelegates, existingDelegates) => {
       if (
@@ -179,9 +182,7 @@ ${interfaceDeclaration.trim()} <${CIO_APPDELEGATEHEADER_USER_NOTIFICATION_CENTER
       }
     }
   );
-
-  return stringContents;
-};
+}
 
 const addHandleDeeplinkInKilledState = (stringContents: string) => {
   // Find if the deep link code snippet is already present
@@ -219,58 +220,70 @@ const addHandleDeeplinkInKilledState = (stringContents: string) => {
   return stringContents;
 };
 
+/**
+ * Pure string transform: produces the modified Objective-C AppDelegate.m / AppDelegate.mm
+ * contents wired with the Customer.io push pipeline (imports, declarations, notification
+ * configuration, registration callbacks, optional killed-state deep-link, FCM forward decl,
+ * Expo notifications header). The caller is responsible for the AppDelegate header file
+ * (.h) — see `modifyAppDelegateHeader`.
+ */
+export function modifyAppDelegateContents(
+  contents: string,
+  projectName: string,
+  props: CustomerIOPluginOptionsIOS
+): string {
+  let next = addImport(contents, projectName);
+  next = addNotificationHandlerDeclaration(next);
+
+  // unless this property is explicity set to true, push notification
+  // registration will be added to the AppDelegate
+  if (props.pushNotification?.disableNotificationRegistration !== true) {
+    next = addNotificationConfiguration(next);
+  }
+
+  next = addInitializeNativeCioSdk(next);
+
+  if (props.pushNotification?.handleDeeplinkInKilledState === true) {
+    next = addHandleDeeplinkInKilledState(next);
+  }
+
+  next = addDidFailToRegisterForRemoteNotificationsWithError(next);
+  next = addDidRegisterForRemoteNotificationsWithDeviceToken(next);
+
+  if (isFcmPushProvider(props)) {
+    next = addFirebaseDelegateForwardDeclarationIfNeeded(next);
+  }
+
+  next = addExpoNotificationsHeaderModification(next);
+
+  return next;
+}
+
 export const withAppDelegateModifications: ConfigPlugin<
   CustomerIOPluginOptionsIOS
 > = (configOuter, props) => {
   return withAppDelegate(configOuter, async (config) => {
-    let stringContents = config.modResults.contents;
+    const stringContents = config.modResults.contents;
     const regex = new RegExp(
       `#import <${config.modRequest.projectName}-Swift.h>`
     );
-    const match = stringContents.match(regex);
 
-    if (!match) {
-      const headerPath = getAppDelegateHeaderFilePath(
-        config.modRequest.projectRoot
-      );
-      let headerContent = await FileManagement.read(headerPath);
-      headerContent = addAppdelegateHeaderModification(headerContent);
-      FileManagement.write(headerPath, headerContent);
-
-      stringContents = addImport(
-        stringContents,
-        config.modRequest.projectName as string
-      );
-      stringContents = addNotificationHandlerDeclaration(stringContents);
-
-      // unless this property is explicity set to true, push notification
-      // registration will be added to the AppDelegate
-      if (props.pushNotification?.disableNotificationRegistration !== true) {
-        stringContents = addNotificationConfiguration(stringContents);
-      }
-
-      stringContents = addInitializeNativeCioSdk(stringContents);
-
-      if (props.pushNotification?.handleDeeplinkInKilledState === true) {
-        stringContents = addHandleDeeplinkInKilledState(stringContents);
-      }
-
-      stringContents =
-        addDidFailToRegisterForRemoteNotificationsWithError(stringContents);
-      stringContents =
-        addDidRegisterForRemoteNotificationsWithDeviceToken(stringContents);
-
-      if (isFcmPushProvider(props)) {
-        stringContents =
-          addFirebaseDelegateForwardDeclarationIfNeeded(stringContents);
-      }
-
-      stringContents = addExpoNotificationsHeaderModification(stringContents);
-
-      config.modResults.contents = stringContents;
-    } else {
+    if (stringContents.match(regex)) {
       logger.info('Customerio AppDelegate changes already exist. Skipping...');
+      return config;
     }
+
+    const headerPath = getAppDelegateHeaderFilePath(
+      config.modRequest.projectRoot
+    );
+    const headerContent = await FileManagement.read(headerPath);
+    FileManagement.write(headerPath, modifyAppDelegateHeader(headerContent));
+
+    config.modResults.contents = modifyAppDelegateContents(
+      stringContents,
+      config.modRequest.projectName as string,
+      props
+    );
 
     return config;
   });

--- a/plugin/src/ios/withCIOIosSwift.ts
+++ b/plugin/src/ios/withCIOIosSwift.ts
@@ -232,12 +232,19 @@ export const withCIOIosSwift = (
   if (props?.pushNotification) {
     // With push notifications: delegate to CioSdkAppDelegateHandler for both push and auto-init
     return withAppDelegate(configOuter, async (config) => {
-      return modifyAppDelegateWithPushAppDelegateHandler(config, props);
+      config.modResults.contents = modifyAppDelegateForPushHandler(
+        config.modResults.contents,
+        props
+      );
+      return config;
     });
   } else if (sdkConfig) {
     // Without push notifications: directly inject auto initialization into AppDelegate
     return withAppDelegate(configOuter, async (config) => {
-      return modifyAppDelegateWithNativeSDKInitializer(config);
+      config.modResults.contents = modifyAppDelegateForNativeSDKInitializer(
+        config.modResults.contents
+      );
+      return config;
     });
   } else {
     return configOuter;
@@ -245,77 +252,53 @@ export const withCIOIosSwift = (
 };
 
 /**
- * Modify the AppDelegate to integrate with Customer.io SDK
+ * Pure string transform: produces the Swift AppDelegate contents wired to delegate to
+ * `CioSdkAppDelegateHandler` for both push notifications and (when configured) auto-init.
+ * Idempotent — returns `contents` unchanged when the handler is already present.
  */
-const modifyAppDelegateWithPushAppDelegateHandler = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  config: any,
+export function modifyAppDelegateForPushHandler(
+  contents: string,
   props: CustomerIOPluginOptionsIOS
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): any => {
-  const appDelegateContent = config.modResults.contents;
-
-  // Check if modifications have already been applied
-  if (appDelegateContent.includes(CIO_SDK_APP_DELEGATE_HANDLER_CLASS)) {
+): string {
+  if (contents.includes(CIO_SDK_APP_DELEGATE_HANDLER_CLASS)) {
     logger.info(
       'CustomerIO Swift AppDelegate changes already exist. Skipping...'
     );
-    return config;
+    return contents;
   }
 
-  // Add the handler property declaration
-  let modifiedContent = addHandlerPropertyDeclaration(appDelegateContent);
-
-  // Modify didFinishLaunchingWithOptions to initialize and call the handler
-  modifiedContent = modifyDidFinishLaunchingWithOptions(
-    modifiedContent,
+  let next = addHandlerPropertyDeclaration(contents);
+  next = modifyDidFinishLaunchingWithOptions(
+    next,
     `  cioSdkHandler.application(application, didFinishLaunchingWithOptions: launchOptions)\n\n    `
   );
+  next = addDidRegisterForRemoteNotificationsWithDeviceToken(next);
+  next = addDidFailToRegisterForRemoteNotificationsWithError(next);
 
-  // Add didRegisterForRemoteNotificationsWithDeviceToken implementation
-  modifiedContent =
-    addDidRegisterForRemoteNotificationsWithDeviceToken(modifiedContent);
-
-  // Add didFailToRegisterForRemoteNotificationsWithError implementation
-  modifiedContent =
-    addDidFailToRegisterForRemoteNotificationsWithError(modifiedContent);
-
-  // Add deep link handling for killed state if enabled
   if (props.pushNotification?.handleDeeplinkInKilledState === true) {
-    modifiedContent = addHandleDeeplinkInKilledState(modifiedContent);
+    next = addHandleDeeplinkInKilledState(next);
   }
 
-  config.modResults.contents = modifiedContent;
-  return config;
-};
+  return next;
+}
 
 /**
- * Modify the AppDelegate to integrate with Customer.io SDK
+ * Pure string transform: injects the auto-init snippet into the Swift AppDelegate's
+ * didFinishLaunchingWithOptions for the no-push path. Idempotent.
  */
-const modifyAppDelegateWithNativeSDKInitializer = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  config: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): any => {
-  const appDelegateContent = config.modResults.contents;
-
-  // Check if modifications have already been applied
-  if (appDelegateContent.includes(CIO_NATIVE_SDK_INITIALIZE_CALL)) {
+export function modifyAppDelegateForNativeSDKInitializer(contents: string): string {
+  if (contents.includes(CIO_NATIVE_SDK_INITIALIZE_CALL)) {
     logger.info(
       'CustomerIO Swift AppDelegate changes already exist. Skipping...'
     );
-    return config;
+    return contents;
   }
 
-  // Modify didFinishLaunchingWithOptions to initialize and call the handler
-  const modifiedContent = modifyDidFinishLaunchingWithOptions(
-    appDelegateContent,
+  return modifyDidFinishLaunchingWithOptions(
+    contents,
     CIO_NATIVE_SDK_INITIALIZE_SNIPPET,
   );
-
-  config.modResults.contents = modifiedContent;
-  return config;
-};
+}
 
 /**
  * Check if a method exists in the AppDelegate content

--- a/plugin/src/ios/withGoogleServicesJsonFile.ts
+++ b/plugin/src/ios/withGoogleServicesJsonFile.ts
@@ -6,6 +6,65 @@ import { logger } from '../utils/logger';
 import { FileManagement } from './../helpers/utils/fileManagement';
 import { isFcmPushProvider } from './utils';
 
+export type CopyGoogleServicePlistOptions = {
+  iosPath: string;
+  appName: string | undefined;
+  googleServicesFile: string | undefined;
+  expoIosGoogleServicesFileSet: boolean;
+  xcodeProject: XcodeProject;
+};
+
+/**
+ * Copies the FCM GoogleService-Info.plist into the iOS project (when needed) and registers it
+ * in the Xcode project's Resources group. Idempotent — no-ops if a plist is already present
+ * at either of the two well-known locations Expo / RN Firebase use.
+ */
+export function copyGoogleServicePlistFile({
+  iosPath,
+  appName,
+  googleServicesFile,
+  expoIosGoogleServicesFileSet,
+  xcodeProject,
+}: CopyGoogleServicePlistOptions): void {
+  const destination = `${iosPath}/GoogleService-Info.plist`;
+
+  if (FileManagement.exists(destination)) {
+    logger.info(`File already exists: ${destination}. Skipping...`);
+    return;
+  }
+
+  if (appName && FileManagement.exists(`${iosPath}/${appName}/GoogleService-Info.plist`)) {
+    // This is where RN Firebase potentially copies GoogleService-Info.plist
+    // Do not copy if it's already done by Firebase to avoid conflict in Resources
+    logger.info(
+      `File already exists: ${iosPath}/${appName}/GoogleService-Info.plist. Skipping...`
+    );
+    return;
+  }
+
+  if (googleServicesFile && FileManagement.exists(googleServicesFile)) {
+    if (expoIosGoogleServicesFileSet) {
+      logger.warn(
+        'Specifying both Expo ios.googleServicesFile and Customer.io ios.pushNotification.googleServicesFile can cause a conflict' +
+        ' duplicating GoogleService-Info.plist in the iOS project resources. Please remove Customer.io ios.pushNotification.googleServicesFile'
+      );
+    }
+
+    try {
+      FileManagement.copyFile(googleServicesFile, destination);
+      addFileToXcodeProject(xcodeProject, 'GoogleService-Info.plist');
+    } catch {
+      logger.error(
+        `There was an error copying your GoogleService-Info.plist file. You can copy it manually into ${destination}`
+      );
+    }
+  } else {
+    logger.error(
+      `The Google Services file provided in ${googleServicesFile} doesn't seem to exist. You can copy it manually into ${destination}`
+    );
+  }
+}
+
 export const withGoogleServicesJsonFile: ConfigPlugin<
   CustomerIOPluginOptionsIOS
 > = (config, cioProps) => {
@@ -21,54 +80,13 @@ export const withGoogleServicesJsonFile: ConfigPlugin<
       ' GoogleService-Info.plist as part of Firebase integration'
     );
 
-    // googleServicesFile
-    const iosPath = props.modRequest.platformProjectRoot;
-    const googleServicesFile = cioProps.pushNotification?.googleServicesFile;
-    const appName = props.modRequest.projectName;
-
-    if (FileManagement.exists(`${iosPath}/GoogleService-Info.plist`)) {
-      logger.info(
-        `File already exists: ${iosPath}/GoogleService-Info.plist. Skipping...`
-      );
-      return props;
-    }
-
-    if (
-      FileManagement.exists(`${iosPath}/${appName}/GoogleService-Info.plist`)
-    ) {
-      // This is where RN Firebase potentially copies GoogleService-Info.plist
-      // Do not copy if it's already done by Firebase to avoid conflict in Resources
-      logger.info(
-        `File already exists: ${iosPath}/${appName}/GoogleService-Info.plist. Skipping...`
-      );
-      return props;
-    }
-
-    if (googleServicesFile && FileManagement.exists(googleServicesFile)) {
-      if (config.ios?.googleServicesFile) {
-        logger.warn(
-          'Specifying both Expo ios.googleServicesFile and Customer.io ios.pushNotification.googleServicesFile can cause a conflict' +
-          ' duplicating GoogleService-Info.plist in the iOS project resources. Please remove Customer.io ios.pushNotification.googleServicesFile'
-        );
-      }
-
-      try {
-        FileManagement.copyFile(
-          googleServicesFile,
-          `${iosPath}/GoogleService-Info.plist`
-        );
-
-        addFileToXcodeProject(props.modResults, 'GoogleService-Info.plist');
-      } catch {
-        logger.error(
-          `There was an error copying your GoogleService-Info.plist file. You can copy it manually into ${iosPath}/GoogleService-Info.plist`
-        );
-      }
-    } else {
-      logger.error(
-        `The Google Services file provided in ${googleServicesFile} doesn't seem to exist. You can copy it manually into ${iosPath}/GoogleService-Info.plist`
-      );
-    }
+    copyGoogleServicePlistFile({
+      iosPath: props.modRequest.platformProjectRoot,
+      appName: props.modRequest.projectName,
+      googleServicesFile: cioProps.pushNotification?.googleServicesFile,
+      expoIosGoogleServicesFileSet: Boolean(config.ios?.googleServicesFile),
+      xcodeProject: props.modResults,
+    });
 
     return props;
   });


### PR DESCRIPTION
## Overview

This is the second of six stacked PRs introducing a tiered testing approach for the plugin. Today every PR runs a full `expo prebuild → real native build` matrix on macOS — slow, expensive, and narrow in coverage. The new tiers:

1. **Fast Jest scenario suite (PR-time)** — pure-helper unit tests against hand-curated, version-pinned fixtures, parameterized over config variants, idempotency checks, and negative-template inputs. Runs on `ubuntu-latest` in seconds.
2. **Slim 3-cell smoke matrix (PR-time)** — Android + iOS APN + iOS FCM at the latest SDK, real `expo prebuild` + native build. Catches Gradle / CocoaPods / xcodebuild regressions a fast suite can't see.
3. **Release-gated full matrix** — today's full matrix moves behind merges to `main` via `workflow_run` chaining, so it remains the deep backstop without blocking every PR.

Together with PR 1, this PR finishes the prep step for tier 1: each plugin mod's transformation logic is now addressable as a pure function that the scenario suite can drive without going through `expo prebuild`.

## Stack

- PR 1: Android pure-helper extractions — refactor only.
- **➡️ PR 2 (this PR): iOS pure-helper extractions** — refactor only. Stacked on PR 1.
- PR 3: Test infrastructure + Android scenario coverage — additive tests, no `plugin/src/` changes.
- PR 4: iOS scenario coverage + pbxproj fixture set — additive tests.
- PR 5: CI restructure — slim PR-time matrix, release-gating workflow chained off `main`.
- PR 6: Delete legacy snapshot tier — runs after one stable release cycle on the new setup.

## What this PR ships

The transformation logic inside each iOS `withXxx` mod that still inlined string manipulation in its callback is factored out into a named, exported, pure helper, mirroring PR 1's Android pattern and the `modifyObjcAppDelegate` / `modifyAppDelegate` convention used by Firebase and Sentry config plugins.

This is intentionally a **refactor-only** PR: no wrapper signatures change, no behavior changes, no test edits. The existing iOS mock tests pass unchanged — that's the load-bearing evidence that this is behavior-preserving. If any wrapper signature or output had shifted, those tests would have failed.

Of the seven iOS modules, three needed extraction (the AppDelegate Objective-C orchestrator, the Swift AppDelegate orchestrators for the push and no-push paths, and the FCM `GoogleService-Info.plist` copy step). The other four are deliberately untouched: one is a pure orchestrator, one is a thin wrapper around an already-factored helper, the utility module exports were already pure, and the notifications Xcode mod's pure-string portions already live in a dedicated helper file.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typescript` — clean
- [x] iOS mock tests (`withCIOIos`, `withCIOIosSwift`, `injectCIOPodfileCode`, `appGroupId`) — all green
- [x] Android + utils sanity tests — all green
- [ ] `Validate Plugin Compatibility` full matrix runs green via the existing PR triggers