### PR TITLE
test: add scenario suite + Android mock-test gap fills

### DIFF
--- a/__tests__/android/withAppGoogleServices.test.ts
+++ b/__tests__/android/withAppGoogleServices.test.ts
@@ -1,0 +1,46 @@
+import { withAppBuildGradle } from '@expo/config-plugins';
+import { modifyAppBuildGradle, withAppGoogleServices } from '../../plugin/src/android/withAppGoogleServices';
+
+jest.mock('@expo/config-plugins');
+
+const mockWithAppBuildGradle = withAppBuildGradle as jest.MockedFunction<
+  typeof withAppBuildGradle
+>;
+
+describe('withAppGoogleServices', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('injects the Google Services apply line into a fresh app/build.gradle', () => {
+    const before = 'apply plugin: "com.android.application"\napply plugin: "kotlin-android"\n';
+    const after = modifyAppBuildGradle(before);
+    expect(after).toMatch(
+      /apply plugin: "com\.android\.application"\napply plugin: "com\.google\.gms\.google-services"/,
+    );
+  });
+
+  it('is a no-op when the snippet is already present', () => {
+    const already =
+      'apply plugin: "com.android.application"\n' +
+      'apply plugin: "com.google.gms.google-services"  // Google Services plugin\n';
+    expect(modifyAppBuildGradle(already)).toEqual(already);
+  });
+
+  it('wires modifyAppBuildGradle through the @expo/config-plugins withAppBuildGradle wrapper', () => {
+    const mockConfig = {
+      modResults: { contents: 'apply plugin: "com.android.application"\n' },
+    };
+    mockWithAppBuildGradle.mockImplementation((config, modifier) => {
+      modifier(mockConfig as any);
+      return config;
+    });
+
+    withAppGoogleServices({} as any, { androidPath: '/test/path' });
+
+    expect(mockWithAppBuildGradle).toHaveBeenCalledTimes(1);
+    expect(mockConfig.modResults.contents).toContain(
+      'apply plugin: "com.google.gms.google-services"',
+    );
+  });
+});

--- a/__tests__/android/withNotificationChannelMetadata.test.ts
+++ b/__tests__/android/withNotificationChannelMetadata.test.ts
@@ -1,0 +1,102 @@
+import { withAndroidManifest } from '@expo/config-plugins';
+import type { ManifestApplication } from '@expo/config-plugins/build/android/Manifest';
+import {
+  addMetadataIfNotExists,
+  withNotificationChannelMetadata,
+} from '../../plugin/src/android/withNotificationChannelMetadata';
+
+jest.mock('@expo/config-plugins');
+
+const mockWithAndroidManifest = withAndroidManifest as jest.MockedFunction<
+  typeof withAndroidManifest
+>;
+
+const makeApplication = (): ManifestApplication =>
+  ({
+    $: { 'android:name': '.MainApplication' },
+  } as ManifestApplication);
+
+describe('addMetadataIfNotExists', () => {
+  it('appends a new <meta-data> entry when none exists', () => {
+    const app = makeApplication();
+    addMetadataIfNotExists(app, 'io.customer.test_key', 'value-1');
+    expect(app['meta-data']).toHaveLength(1);
+    expect(app['meta-data']![0].$).toEqual({
+      'android:name': 'io.customer.test_key',
+      'android:value': 'value-1',
+    });
+  });
+
+  it('does not duplicate when the same name is already present', () => {
+    const app = makeApplication();
+    addMetadataIfNotExists(app, 'io.customer.test_key', 'value-1');
+    addMetadataIfNotExists(app, 'io.customer.test_key', 'value-2');
+    expect(app['meta-data']).toHaveLength(1);
+    // Pre-existing value is preserved (function is "if not exists", not "upsert")
+    expect(app['meta-data']![0].$['android:value']).toEqual('value-1');
+  });
+
+  it('initializes the meta-data array when missing', () => {
+    const app = { $: {} } as ManifestApplication;
+    expect((app as { 'meta-data'?: unknown })['meta-data']).toBeUndefined();
+    addMetadataIfNotExists(app, 'io.customer.x', 'y');
+    expect(app['meta-data']).toHaveLength(1);
+  });
+});
+
+describe('withNotificationChannelMetadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const runWrapperWithChannel = (
+    channel: { id?: string; name?: string; importance?: number } | undefined,
+  ) => {
+    const application = makeApplication();
+    const mockConfig = {
+      modResults: { manifest: { application: [application] } },
+    };
+    mockWithAndroidManifest.mockImplementation((config, modifier) => {
+      modifier(mockConfig as any);
+      return config;
+    });
+
+    withNotificationChannelMetadata({} as any, {
+      androidPath: '/test',
+      pushNotification: channel ? { channel } : undefined,
+    });
+
+    return application;
+  };
+
+  it('writes id, name, and importance meta-data entries when all three are configured', () => {
+    const app = runWrapperWithChannel({
+      id: 'cio-default',
+      name: 'Customer.io',
+      importance: 4,
+    });
+    const names = (app['meta-data'] ?? []).map((m) => m.$['android:name']);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'io.customer.notification_channel_id',
+        'io.customer.notification_channel_name',
+        'io.customer.notification_channel_importance',
+      ]),
+    );
+    const importance = (app['meta-data'] ?? []).find(
+      (m) => m.$['android:name'] === 'io.customer.notification_channel_importance',
+    );
+    expect(importance?.$['android:value']).toEqual('4');
+  });
+
+  it('writes only the configured subset', () => {
+    const app = runWrapperWithChannel({ id: 'cio-default' });
+    const names = (app['meta-data'] ?? []).map((m) => m.$['android:name']);
+    expect(names).toEqual(['io.customer.notification_channel_id']);
+  });
+
+  it('is a no-op when no channel configuration is provided', () => {
+    const app = runWrapperWithChannel(undefined);
+    expect(app['meta-data']).toBeUndefined();
+  });
+});

--- a/__tests__/fixtures/README.md
+++ b/__tests__/fixtures/README.md
@@ -1,0 +1,18 @@
+# Scenario-suite fixtures
+
+Hand-curated, **version-pinned** native-project file fragments used by the Jest scenario suite under `__tests__/scenarios/`. Each fixture represents the relevant slice of an Expo prebuild output for a *frozen* SDK version.
+
+## Why pinned, not `latest`
+
+Pinned-SDK fixtures don't drift: once a fixture for SDK 54 is committed it stays valid for SDK 54 forever, because the SDK 54 template is frozen. Coverage of the *current* SDK (`latest`) comes from the real-build tiers (smoke matrix + release-gated full matrix), not from this directory.
+
+## Layout
+
+- `android/` — pinned Android fixtures. Filenames carry the SDK suffix when relevant (e.g. `MainApplication_kt_sdk54.kt`).
+- `cio-artifacts/` — vendor-supplied artifact stubs (`google-services.json`, `GoogleService-Info.plist`) used by side-effect helpers.
+- (iOS fixtures land under `ios/` in PR 4.)
+
+## When to refresh
+
+- Add a new fixture variant when an Expo SDK ships a new template shape we want to keep covering. Don't replace the old one — keep both, parameterized by SDK suffix in the filename.
+- Don't touch a frozen-SDK fixture once shipped; that breaks the pinning guarantee.

--- a/__tests__/fixtures/android/MainApplication_kt_sdk54.kt
+++ b/__tests__/fixtures/android/MainApplication_kt_sdk54.kt
@@ -1,0 +1,43 @@
+package io.customer.testbed.expo
+
+import android.app.Application
+import android.content.res.Configuration
+
+import com.facebook.react.PackageList
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactHost
+import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
+import com.facebook.react.defaults.DefaultReactNativeHost
+
+import expo.modules.ApplicationLifecycleDispatcher
+import expo.modules.ReactNativeHostWrapper
+
+class MainApplication : Application(), ReactApplication {
+
+  override val reactNativeHost: ReactNativeHost = ReactNativeHostWrapper(
+        this,
+        object : DefaultReactNativeHost(this) {
+          override fun getPackages(): List<ReactPackage> = PackageList(this).packages
+          override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"
+          override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
+          override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+          override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+        }
+  )
+
+  override val reactHost: ReactHost
+    get() = ReactNativeHostWrapper.createReactHost(applicationContext, reactNativeHost)
+
+  override fun onCreate() {
+    super.onCreate()
+    loadReactNative(this)
+    ApplicationLifecycleDispatcher.onApplicationCreate(this)
+  }
+
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+    ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
+  }
+}

--- a/__tests__/fixtures/android/app_build.gradle
+++ b/__tests__/fixtures/android/app_build.gradle
@@ -1,0 +1,50 @@
+apply plugin: "com.android.application"
+apply plugin: "org.jetbrains.kotlin.android"
+apply plugin: "com.facebook.react"
+
+react {
+    autolinkLibrariesWithApp()
+}
+
+def enableProguardInReleaseBuilds = false
+
+android {
+    ndkVersion rootProject.ext.ndkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
+    compileSdk rootProject.ext.compileSdkVersion
+
+    namespace 'io.customer.testbed.expo'
+    defaultConfig {
+        applicationId 'io.customer.testbed.expo'
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.0.0"
+    }
+
+    signingConfigs {
+        debug {
+            storeFile file('debug.keystore')
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+        }
+    }
+
+    buildTypes {
+        debug {
+            signingConfig signingConfigs.debug
+        }
+        release {
+            signingConfig signingConfigs.debug
+            minifyEnabled enableProguardInReleaseBuilds
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+        }
+    }
+}
+
+dependencies {
+    implementation("com.facebook.react:react-android")
+}
+
+apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json')"].execute(rootDir).text.trim(), "../native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/__tests__/fixtures/android/project_build.gradle
+++ b/__tests__/fixtures/android/project_build.gradle
@@ -1,0 +1,40 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+buildscript {
+    ext {
+        buildToolsVersion = findProperty('android.buildToolsVersion') ?: '35.0.0'
+        minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '24')
+        compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '35')
+        targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '34')
+        kotlinVersion = findProperty('android.kotlinVersion') ?: '2.0.21'
+
+        ndkVersion = "27.1.12297006"
+    }
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath('com.android.tools.build:gradle')
+        classpath('com.facebook.react:react-native-gradle-plugin')
+        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')
+    }
+}
+
+apply plugin: "com.facebook.react.rootproject"
+apply plugin: "expo-root-project"
+
+allprojects {
+    repositories {
+        maven {
+            url(new File(['node', '--print', "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim(), '../android'))
+        }
+        maven {
+            url(new File(['node', '--print', "require.resolve('jsc-android/package.json')"].execute(null, rootDir).text.trim(), '../dist'))
+        }
+
+        google()
+        mavenCentral()
+        maven { url 'https://www.jitpack.io' }
+    }
+}

--- a/__tests__/scenarios/android/appBuildGradle.test.ts
+++ b/__tests__/scenarios/android/appBuildGradle.test.ts
@@ -1,0 +1,25 @@
+import * as fs from 'fs';
+import { modifyAppBuildGradle } from '../../../plugin/src/android/withAppGoogleServices';
+import { getFixturePath } from '../../utils';
+
+const baseline = fs.readFileSync(getFixturePath('android', 'app_build.gradle'), 'utf8');
+
+describe('android scenarios — modifyAppBuildGradle', () => {
+  it('injects the Google Services plugin apply line under the android.application apply line', () => {
+    const result = modifyAppBuildGradle(baseline);
+    const appliedLine = result.match(/^apply plugin: "com\.google\.gms\.google-services".*$/m);
+    expect(appliedLine).not.toBeNull();
+    // It should sit immediately after the android.application apply line
+    const lines = result.split('\n');
+    const androidIdx = lines.findIndex((l) => l === 'apply plugin: "com.android.application"');
+    expect(lines[androidIdx + 1]).toMatchInlineSnapshot(
+      `"apply plugin: "com.google.gms.google-services"  // Google Services plugin"`,
+    );
+  });
+
+  it('is idempotent — applying twice equals applying once', () => {
+    const once = modifyAppBuildGradle(baseline);
+    const twice = modifyAppBuildGradle(once);
+    expect(twice).toEqual(once);
+  });
+});

--- a/__tests__/scenarios/android/mainApplication.test.ts
+++ b/__tests__/scenarios/android/mainApplication.test.ts
@@ -1,0 +1,27 @@
+import * as fs from 'fs';
+import { injectCustomerIOInitializerIntoMainApplication } from '../../../plugin/src/android/withMainApplicationModifications';
+import { getFixturePath } from '../../utils';
+
+const baseline = fs.readFileSync(getFixturePath('android', 'MainApplication_kt_sdk54.kt'), 'utf8');
+
+describe('android scenarios — injectCustomerIOInitializerIntoMainApplication (SDK 54)', () => {
+  it('adds the import and the onCreate initialize call', () => {
+    const result = injectCustomerIOInitializerIntoMainApplication(baseline);
+    expect(result).toContain('import io.customer.sdk.expo.CustomerIOSDKInitializer');
+    expect(result).toContain('CustomerIOSDKInitializer.initialize(this)');
+  });
+
+  it('places the initialize call inside override fun onCreate, after super.onCreate', () => {
+    const result = injectCustomerIOInitializerIntoMainApplication(baseline);
+    // Capture the onCreate body and assert the call is in there
+    const onCreateMatch = result.match(/override\s+fun\s+onCreate\s*\(\s*\)\s*\{([\s\S]*?)\}/);
+    expect(onCreateMatch).not.toBeNull();
+    expect(onCreateMatch![1]).toContain('CustomerIOSDKInitializer.initialize(this)');
+  });
+
+  it('is idempotent — running twice equals running once', () => {
+    const once = injectCustomerIOInitializerIntoMainApplication(baseline);
+    const twice = injectCustomerIOInitializerIntoMainApplication(once);
+    expect(twice).toEqual(once);
+  });
+});

--- a/__tests__/scenarios/android/projectBuildGradle.test.ts
+++ b/__tests__/scenarios/android/projectBuildGradle.test.ts
@@ -1,0 +1,52 @@
+import * as fs from 'fs';
+import { modifyProjectBuildGradleAndroid16Support } from '../../../plugin/src/android/withProjectBuildGradle';
+import { modifyProjectBuildGradleForGoogleServices } from '../../../plugin/src/android/withProjectGoogleServices';
+import { getFixturePath } from '../../utils';
+
+const baseline = fs.readFileSync(getFixturePath('android', 'project_build.gradle'), 'utf8');
+
+describe('android scenarios — modifyProjectBuildGradleAndroid16Support', () => {
+  it('injects the resolutionStrategy block when disableAndroid16Support is true', () => {
+    const result = modifyProjectBuildGradleAndroid16Support(baseline, {
+      disableAndroid16Support: true,
+    });
+    expect(result).toContain("force 'androidx.core:core-ktx:1.13.1'");
+    expect(result).toContain("force 'androidx.lifecycle:lifecycle-process:2.8.7'");
+    // Block lives inside the allprojects { ... } scope
+    expect(result).toMatch(/allprojects\s*\{[\s\S]*configurations\.all[\s\S]*resolutionStrategy/);
+  });
+
+  it('returns input unchanged when the flag is false', () => {
+    const result = modifyProjectBuildGradleAndroid16Support(baseline, {
+      disableAndroid16Support: false,
+    });
+    expect(result).toEqual(baseline);
+  });
+
+  it('is idempotent when the flag is true', () => {
+    const once = modifyProjectBuildGradleAndroid16Support(baseline, {
+      disableAndroid16Support: true,
+    });
+    const twice = modifyProjectBuildGradleAndroid16Support(once, {
+      disableAndroid16Support: true,
+    });
+    expect(twice).toEqual(once);
+  });
+});
+
+describe('android scenarios — modifyProjectBuildGradleForGoogleServices', () => {
+  it('injects the Google Services classpath under buildscript.dependencies', () => {
+    const result = modifyProjectBuildGradleForGoogleServices(baseline);
+    expect(result).toContain('classpath "com.google.gms:google-services:4.3.13"');
+    // It should sit inside the buildscript { ... dependencies { ... } block
+    expect(result).toMatch(
+      /buildscript\s*\{[\s\S]*dependencies\s*\{[\s\S]*com\.google\.gms:google-services/,
+    );
+  });
+
+  it('is idempotent', () => {
+    const once = modifyProjectBuildGradleForGoogleServices(baseline);
+    const twice = modifyProjectBuildGradleForGoogleServices(once);
+    expect(twice).toEqual(once);
+  });
+});

--- a/__tests__/utils.d.ts
+++ b/__tests__/utils.d.ts
@@ -1,0 +1,8 @@
+export function testAppPath(): string;
+export function testAppName(): string;
+export function getTestAppAndroidPackageName(): string;
+export function getTestAppAndroidPackagePath(): string;
+export function getTestAppAndroidJavaSourcePath(): string;
+export function getExpoVersion(): string;
+export function isExpoVersion53OrHigher(): boolean;
+export function getFixturePath(area: string, name: string): string;

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -27,6 +27,14 @@ function getTestAppAndroidJavaSourcePath() {
 }
 
 /**
+ * Resolve a path inside the scenario-suite fixtures tree.
+ * Pinned-SDK fixtures live under `__tests__/fixtures/<area>/<name>`.
+ */
+function getFixturePath(area, name) {
+  return path.join(__dirname, 'fixtures', area, name);
+}
+
+/**
  * Get the Expo version from environment variable
  * @returns {string} The Expo version
  */
@@ -59,4 +67,5 @@ module.exports = {
   getTestAppAndroidJavaSourcePath,
   getExpoVersion,
   isExpoVersion53OrHigher,
+  getFixturePath,
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,6 +24,18 @@ module.exports = {
       displayName: 'root-tests',
       rootDir: path.resolve(__dirname),
       testMatch: ['<rootDir>/__tests__/**/*.test.(js|ts)'],
+      testPathIgnorePatterns: ['<rootDir>/__tests__/scenarios/'],
+      transform: {
+        '^.+\\.(js|ts)$': ['ts-jest', {
+          tsconfig: path.resolve(__dirname, 'tsconfig.test.json'),
+        }],
+      },
+      testEnvironment: 'node',
+    },
+    {
+      displayName: 'scenarios',
+      rootDir: path.resolve(__dirname),
+      testMatch: ['<rootDir>/__tests__/scenarios/**/*.test.(js|ts)'],
       transform: {
         '^.+\\.(js|ts)$': ['ts-jest', {
           tsconfig: path.resolve(__dirname, 'tsconfig.test.json'),

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "prepare": "npm run clean && bob build",
     "postinstall": "node plugin/src/postInstall.js",
     "test": "jest",
+    "test:scenarios": "jest --selectProjects scenarios",
     "compatibility:create-test-app": "node scripts/compatibility/create-test-app.js",
     "compatibility:setup-test-app": "node scripts/compatibility/setup-test-app.js",
     "compatibility:configure-plugin": "node scripts/compatibility/configure-plugin.js",


### PR DESCRIPTION
## Overview

This is the third of six stacked PRs introducing a tiered testing approach for the plugin. Today every PR runs a full `expo prebuild → real native build` matrix on macOS — slow, expensive, and narrow in coverage. The new tiers:

1. **Fast Jest scenario suite (PR-time)** — pure-helper unit tests against hand-curated, version-pinned fixtures, parameterized over config variants, idempotency checks, and negative-template inputs. Runs on `ubuntu-latest` in seconds.
2. **Slim 3-cell smoke matrix (PR-time)** — Android + iOS APN + iOS FCM at the latest SDK, real `expo prebuild` + native build. Catches Gradle / CocoaPods / xcodebuild regressions a fast suite can't see.
3. **Release-gated full matrix** — today's full matrix moves behind merges to `main` via `workflow_run` chaining, so it remains the deep backstop without blocking every PR.

PR 1 and PR 2 prepared each plugin mod's transformation logic as a pure helper. This PR puts those helpers to work — it lands the tier 1 scenario suite (infrastructure + Android coverage) alongside the existing snapshot tier, so the two suites coexist with belt-and-suspenders coverage during the transition.

## Stack

- PR 1: Android pure-helper extractions — refactor only.
- PR 2: iOS pure-helper extractions — refactor only. Stacked on PR 1.
- **➡️ PR 3 (this PR): Test infrastructure + Android scenario coverage** — additive tests, no `plugin/src/` changes. Stacked on PR 2.
- PR 4: iOS scenario coverage + pbxproj fixture set — additive tests.
- PR 5: CI restructure — slim PR-time matrix, release-gating workflow chained off `main`.
- PR 6: Delete legacy snapshot tier — runs after one stable release cycle on the new setup.

## What this PR ships

The scenario suite is a new fourth Jest project — `displayName: 'scenarios'` — rooted at `__tests__/scenarios/`, with the existing `root-tests` project explicitly ignoring that path so each test file runs in exactly one project. A new `npm run test:scenarios` script scopes runs to it. Scenario tests call PR 1's exported pure helpers directly against hand-curated, **version-pinned** fixtures under `__tests__/fixtures/android/`. Pinning is deliberate: a fixture for SDK 54 stays valid for SDK 54 forever, so the suite can't silently go stale; coverage of the *current* SDK comes from the real-build tiers, not from fixture drift.

The initial Android coverage exercises four of the helpers PR 1 extracted (`modifyAppBuildGradle`, `modifyProjectBuildGradleAndroid16Support`, `modifyProjectBuildGradleForGoogleServices`, `injectCustomerIOInitializerIntoMainApplication`) across the standard pattern of *config-variant* and *idempotency* checks the master plan calls for. Two mock-test gap fills — for the wrapper paths the audit flagged — round out per-mod regression coverage.

The existing snapshot tier under `__tests__/android/{app-manifest, app-gradle-build, main-gradle-build, main-application-modifications}.test.js` is untouched. Both suites run on every PR through Phase 3; the legacy tier only comes out in PR 6, after the new tier has been live for a release cycle.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typescript` — clean
- [x] `npm run test:scenarios` — 10 tests, all pass
- [x] Existing Android suite + utils + iOS mock tests — all pass unchanged
- [ ] `Validate Plugin Compatibility` full matrix runs green via the existing PR triggers