### PR TITLE
refactor(ios): extract pure transformation helpers from mods

### DIFF
--- a/plugin/src/android/withAndroidManifestUpdates.ts
+++ b/plugin/src/android/withAndroidManifestUpdates.ts
@@ -9,92 +9,102 @@ import { logger } from '../utils/logger';
 export const DEFAULT_LOW_PRIORITY = -10;
 
 
+export function modifyAndroidManifestApplication(
+  application: ManifestApplication[],
+  options: CustomerIOPluginOptionsAndroid
+): ManifestApplication[] {
+  const customerIOMessagingpush =
+    'io.customer.messagingpush.CustomerIOFirebaseMessagingService';
+
+  if (!application[0].service) {
+    application[0].service = [];
+  }
+
+  const existingServiceIndex = application[0].service.findIndex(
+    (service) => service.$['android:name'] === customerIOMessagingpush
+  );
+
+  if (existingServiceIndex === -1) {
+    // Intent filter structure for Firebase messaging service
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const intentFilter: any = {
+      action: [
+        {
+          $: {
+            'android:name': 'com.google.firebase.MESSAGING_EVENT',
+          },
+        },
+      ],
+    };
+
+    // Handle priority based on setHighPriorityPushHandler value
+    if (options.setHighPriorityPushHandler === true) {
+      // High priority - no priority attribute means default high priority
+      logger.info(
+        'Successfully set CustomerIO push handler as high priority in AndroidManifest.xml'
+      );
+    } else if (options.setHighPriorityPushHandler === false) {
+      // Low priority - set fixed priority
+      intentFilter.$ = {
+        'android:priority': DEFAULT_LOW_PRIORITY.toString(),
+      };
+      logger.info(
+        `Successfully set CustomerIO push handler as low priority (${DEFAULT_LOW_PRIORITY}) in AndroidManifest.xml`
+      );
+    }
+
+    application[0].service.push({
+      '$': {
+        'android:name': customerIOMessagingpush,
+        'android:exported': 'false',
+      },
+      'intent-filter': [intentFilter],
+    });
+  } else if (options.setHighPriorityPushHandler === true) {
+    // Service exists, need to ensure it becomes high priority (remove priority attribute)
+    const existingService = application[0].service[existingServiceIndex];
+
+    if (existingService['intent-filter'] && existingService['intent-filter'].length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const intentFilter = existingService['intent-filter'][0] as any;
+      if (intentFilter.$ && intentFilter.$['android:priority']) {
+        delete intentFilter.$['android:priority'];
+        logger.info(
+          'Successfully updated existing CustomerIO push handler to high priority in AndroidManifest.xml'
+        );
+      }
+    }
+  } else if (options.setHighPriorityPushHandler === false) {
+    // Service exists, update to low priority
+    const existingService = application[0].service[existingServiceIndex];
+
+    // Update existing service intent-filter with fixed priority
+    if (existingService['intent-filter'] && existingService['intent-filter'].length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const intentFilter = existingService['intent-filter'][0] as any;
+      if (!intentFilter.$) {
+        intentFilter.$ = {};
+      }
+      intentFilter.$['android:priority'] = DEFAULT_LOW_PRIORITY.toString();
+      logger.info(
+        `Successfully updated existing CustomerIO push handler to low priority (${DEFAULT_LOW_PRIORITY}) in AndroidManifest.xml`
+      );
+    }
+  }
+
+  return application;
+}
+
 export const withAndroidManifestUpdates: ConfigPlugin<
   CustomerIOPluginOptionsAndroid
 > = (configOuter, options) => {
   return withAndroidManifest(configOuter, (props) => {
     const application = props.modResults.manifest
       .application as ManifestApplication[];
-    const customerIOMessagingpush =
-      'io.customer.messagingpush.CustomerIOFirebaseMessagingService';
-
-    if (!application[0].service) {
-      application[0].service = [];
-    }
-
-    const existingServiceIndex = application[0].service.findIndex(
-      (service) => service.$['android:name'] === customerIOMessagingpush
+    props.modResults.manifest.application = modifyAndroidManifestApplication(
+      application,
+      options
     );
-
-    if (existingServiceIndex === -1) {
-      // Intent filter structure for Firebase messaging service
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const intentFilter: any = {
-        action: [
-          {
-            $: {
-              'android:name': 'com.google.firebase.MESSAGING_EVENT',
-            },
-          },
-        ],
-      };
-
-      // Handle priority based on setHighPriorityPushHandler value
-      if (options.setHighPriorityPushHandler === true) {
-        // High priority - no priority attribute means default high priority
-        logger.info(
-          'Successfully set CustomerIO push handler as high priority in AndroidManifest.xml'
-        );
-      } else if (options.setHighPriorityPushHandler === false) {
-        // Low priority - set fixed priority
-        intentFilter.$ = {
-          'android:priority': DEFAULT_LOW_PRIORITY.toString(),
-        };
-        logger.info(
-          `Successfully set CustomerIO push handler as low priority (${DEFAULT_LOW_PRIORITY}) in AndroidManifest.xml`
-        );
-      }
-
-      application[0].service.push({
-        '$': {
-          'android:name': customerIOMessagingpush,
-          'android:exported': 'false',
-        },
-        'intent-filter': [intentFilter],
-      });
-    } else if (options.setHighPriorityPushHandler === true) {
-      // Service exists, need to ensure it becomes high priority (remove priority attribute)
-      const existingService = application[0].service[existingServiceIndex];
-
-      if (existingService['intent-filter'] && existingService['intent-filter'].length > 0) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const intentFilter = existingService['intent-filter'][0] as any;
-        if (intentFilter.$ && intentFilter.$['android:priority']) {
-          delete intentFilter.$['android:priority'];
-          logger.info(
-            'Successfully updated existing CustomerIO push handler to high priority in AndroidManifest.xml'
-          );
-        }
-      }
-    } else if (options.setHighPriorityPushHandler === false) {
-      // Service exists, update to low priority
-      const existingService = application[0].service[existingServiceIndex];
-
-      // Update existing service intent-filter with fixed priority
-      if (existingService['intent-filter'] && existingService['intent-filter'].length > 0) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const intentFilter = existingService['intent-filter'][0] as any;
-        if (!intentFilter.$) {
-          intentFilter.$ = {};
-        }
-        intentFilter.$['android:priority'] = DEFAULT_LOW_PRIORITY.toString();
-        logger.info(
-          `Successfully updated existing CustomerIO push handler to low priority (${DEFAULT_LOW_PRIORITY}) in AndroidManifest.xml`
-        );
-      }
-    }
-
-    props.modResults.manifest.application = application;
     return props;
   });
 };

--- a/plugin/src/android/withAppGoogleServices.ts
+++ b/plugin/src/android/withAppGoogleServices.ts
@@ -8,21 +8,23 @@ import {
 import type { CustomerIOPluginOptionsAndroid } from '../types/cio-types';
 import { logger } from '../utils/logger';
 
+export function modifyAppBuildGradle(contents: string): string {
+  const regex = new RegExp(CIO_APP_GOOGLE_SNIPPET);
+  if (regex.test(contents)) {
+    logger.info('app/build.gradle snippet already exists. Skipping...');
+    return contents;
+  }
+  return contents.replace(
+    CIO_APP_APPLY_REGEX,
+    `$1\n${CIO_APP_GOOGLE_SNIPPET}`
+  );
+}
+
 export const withAppGoogleServices: ConfigPlugin<
   CustomerIOPluginOptionsAndroid
 > = (configOuter) => {
   return withAppBuildGradle(configOuter, (props) => {
-    const regex = new RegExp(CIO_APP_GOOGLE_SNIPPET);
-    const match = props.modResults.contents.match(regex);
-    if (!match) {
-      props.modResults.contents = props.modResults.contents.replace(
-        CIO_APP_APPLY_REGEX,
-        `$1\n${CIO_APP_GOOGLE_SNIPPET}`
-      );
-    } else {
-      logger.info('app/build.gradle snippet already exists. Skipping...');
-    }
-
+    props.modResults.contents = modifyAppBuildGradle(props.modResults.contents);
     return props;
   });
 };

--- a/plugin/src/android/withGoogleServicesJSON.ts
+++ b/plugin/src/android/withGoogleServicesJSON.ts
@@ -5,38 +5,40 @@ import { logger } from '../utils/logger';
 import { FileManagement } from './../helpers/utils/fileManagement';
 import type { CustomerIOPluginOptionsAndroid } from './../types/cio-types';
 
+export function copyGoogleServicesFile(
+  androidPath: string,
+  googleServicesFile: string | undefined
+): void {
+  const destination = `${androidPath}/app/google-services.json`;
+
+  if (FileManagement.exists(destination)) {
+    logger.info(`File already exists: ${destination}. Skipping...`);
+    return;
+  }
+
+  if (googleServicesFile && FileManagement.exists(googleServicesFile)) {
+    try {
+      FileManagement.copyFile(googleServicesFile, destination);
+    } catch {
+      logger.info(
+        `There was an error copying your google-services.json file. You can copy it manually into ${destination}`
+      );
+    }
+  } else {
+    logger.info(
+      `The Google Services file provided in ${googleServicesFile} doesn't seem to exist. You can copy it manually into ${destination}`
+    );
+  }
+}
+
 export const withGoogleServicesJSON: ConfigPlugin<
   CustomerIOPluginOptionsAndroid
 > = (configOuter, cioProps) => {
   return withProjectBuildGradle(configOuter, (props) => {
-    const options: CustomerIOPluginOptionsAndroid = {
-      androidPath: props.modRequest.platformProjectRoot,
-      googleServicesFile: cioProps?.googleServicesFile,
-    };
-    const { androidPath, googleServicesFile } = options;
-    if (!FileManagement.exists(`${androidPath}/app/google-services.json`)) {
-      if (googleServicesFile && FileManagement.exists(googleServicesFile)) {
-        try {
-          FileManagement.copyFile(
-            googleServicesFile,
-            `${androidPath}/app/google-services.json`
-          );
-        } catch {
-          logger.info(
-            `There was an error copying your google-services.json file. You can copy it manually into ${androidPath}/app/google-services.json`
-          );
-        }
-      } else {
-        logger.info(
-          `The Google Services file provided in ${googleServicesFile} doesn't seem to exist. You can copy it manually into ${androidPath}/app/google-services.json`
-        );
-      }
-    } else {
-      logger.info(
-        `File already exists: ${androidPath}/app/google-services.json. Skipping...`
-      );
-    }
-
+    copyGoogleServicesFile(
+      props.modRequest.platformProjectRoot,
+      cioProps?.googleServicesFile
+    );
     return props;
   });
 };

--- a/plugin/src/android/withLocationGradleProperties.ts
+++ b/plugin/src/android/withLocationGradleProperties.ts
@@ -6,6 +6,28 @@ import type { CustomerIOPluginLocationOptions } from '../types/cio-types';
 
 const CUSTOMERIO_LOCATION_ENABLED_KEY = 'customerio_location_enabled';
 
+export function modifyGradleProperties(
+  items: PropertiesItem[]
+): PropertiesItem[] {
+  const existingIndex = items.findIndex(
+    (item) => item.type === 'property' && item.key === CUSTOMERIO_LOCATION_ENABLED_KEY
+  );
+
+  const newItem: PropertiesItem = {
+    type: 'property',
+    key: CUSTOMERIO_LOCATION_ENABLED_KEY,
+    value: 'true',
+  };
+
+  if (existingIndex >= 0) {
+    items[existingIndex] = newItem;
+  } else {
+    items.push(newItem);
+  }
+
+  return items;
+}
+
 /**
  * Adds or updates customerio_location_enabled in android/gradle.properties when location.enabled is true.
  * The Customer.io React Native SDK reads this to enable the location native module.
@@ -19,23 +41,7 @@ export const withLocationGradleProperties: ConfigPlugin<{
 
   return withGradleProperties(config, (config) => {
     const items = config.modResults as PropertiesItem[];
-    const existingIndex = items.findIndex(
-      (item) => item.type === 'property' && item.key === CUSTOMERIO_LOCATION_ENABLED_KEY
-    );
-
-    const newItem: PropertiesItem = {
-      type: 'property',
-      key: CUSTOMERIO_LOCATION_ENABLED_KEY,
-      value: 'true',
-    };
-
-    if (existingIndex >= 0) {
-      items[existingIndex] = newItem;
-    } else {
-      items.push(newItem);
-    }
-
-    config.modResults = items;
+    config.modResults = modifyGradleProperties(items);
     return config;
   });
 };

--- a/plugin/src/android/withMainApplicationModifications.ts
+++ b/plugin/src/android/withMainApplicationModifications.ts
@@ -36,6 +36,30 @@ const getLocationInitOptions = (
   trackingMode: sdkConfig?.location?.trackingMode,
 });
 
+const SDK_INITIALIZER_CLASS = 'CustomerIOSDKInitializer';
+const SDK_INITIALIZER_PACKAGE = 'io.customer.sdk.expo';
+const SDK_INITIALIZER_FILE = `${SDK_INITIALIZER_CLASS}.kt`;
+const SDK_INITIALIZER_IMPORT = `import ${SDK_INITIALIZER_PACKAGE}.${SDK_INITIALIZER_CLASS}`;
+
+/**
+ * Pure string transform: given the existing MainApplication contents, returns the contents
+ * with the CustomerIOSDKInitializer import and onCreate call injected (idempotent — if the
+ * initialize call is already present, the call-injection step is skipped).
+ */
+export function injectCustomerIOInitializerIntoMainApplication(
+  contents: string
+): string {
+  let next = addImportToFile(contents, SDK_INITIALIZER_IMPORT);
+  if (!next.includes(CIO_NATIVE_SDK_INITIALIZE_CALL)) {
+    next = addCodeToMethod(
+      next,
+      CIO_MAINAPPLICATION_ONCREATE_REGEX,
+      CIO_NATIVE_SDK_INITIALIZE_SNIPPET
+    );
+  }
+  return next;
+}
+
 /**
  * Setup CustomerIOSDKInitializer for Android auto initialization
  */
@@ -44,30 +68,16 @@ const setupCustomerIOSDKInitializer = (
   sdkConfig: NativeSDKConfig,
   location?: CustomerIOPluginLocationOptions,
 ): string => {
-  const SDK_INITIALIZER_CLASS = 'CustomerIOSDKInitializer';
-  const SDK_INITIALIZER_PACKAGE = 'io.customer.sdk.expo';
-
-  const SDK_INITIALIZER_FILE = `${SDK_INITIALIZER_CLASS}.kt`;
-  const SDK_INITIALIZER_IMPORT = `import ${SDK_INITIALIZER_PACKAGE}.${SDK_INITIALIZER_CLASS}`;
-
   const locationOptions = getLocationInitOptions(location, sdkConfig);
-  let content = config.modResults.contents;
 
   try {
     // Always regenerate the CustomerIOSDKInitializer file to reflect config changes
     copyTemplateFile(config, SDK_INITIALIZER_FILE, SDK_INITIALIZER_PACKAGE, (content) =>
       patchNativeSDKInitializer(content, PLATFORM.ANDROID, sdkConfig, locationOptions)
     );
-    // Add import if not already present
-    content = addImportToFile(content, SDK_INITIALIZER_IMPORT);
-    // Add initialization code to onCreate if not already present
-    if (!content.includes(CIO_NATIVE_SDK_INITIALIZE_CALL)) {
-      content = addCodeToMethod(content, CIO_MAINAPPLICATION_ONCREATE_REGEX, CIO_NATIVE_SDK_INITIALIZE_SNIPPET);
-    }
+    return injectCustomerIOInitializerIntoMainApplication(config.modResults.contents);
   } catch (error) {
     logger.warn(`Could not setup ${SDK_INITIALIZER_CLASS}:`, error);
     return config.modResults.contents;
   }
-
-  return content;
 };

--- a/plugin/src/android/withNotificationChannelMetadata.ts
+++ b/plugin/src/android/withNotificationChannelMetadata.ts
@@ -7,7 +7,7 @@ import type { CustomerIOPluginOptionsAndroid } from '../types/cio-types';
 /**
  * Adds a metadata entry to the Android manifest if it doesn't already exist
  */
-const addMetadataIfNotExists = (
+export const addMetadataIfNotExists = (
   application: ManifestApplication,
   name: string,
   value: string

--- a/plugin/src/android/withProjectBuildGradle.ts
+++ b/plugin/src/android/withProjectBuildGradle.ts
@@ -24,6 +24,40 @@ function shouldDisableAndroid16Support(
 }
 
 /**
+ * Pure string transform: injects an androidx resolution-strategy block into the
+ * project-level build.gradle's `allprojects { ... }` section when
+ * `disableAndroid16Support` is true. Idempotent — returns input unchanged if the
+ * snippet is already present, or if the flag is false.
+ */
+export function modifyProjectBuildGradleAndroid16Support(
+  contents: string,
+  options: { disableAndroid16Support: boolean }
+): string {
+  if (!options.disableAndroid16Support) {
+    return contents;
+  }
+
+  if (contents.includes('androidx.core:core-ktx:1.13.1')) {
+    return contents;
+  }
+
+  const resolutionStrategy = `
+    configurations.all {
+        resolutionStrategy {
+            // Disable Android 16 support by forcing older androidx versions
+            // Compatible with API 35 and AGP 8.8.2 (prevents API 36/AGP 8.9.1+ requirement)
+            force 'androidx.core:core-ktx:1.13.1'
+            force 'androidx.lifecycle:lifecycle-process:2.8.7'
+        }
+    }`;
+
+  return contents.replace(
+    /allprojects\s*\{/,
+    `allprojects {${resolutionStrategy}`
+  );
+}
+
+/**
  * Adds dependency resolution strategy to force specific androidx versions.
  * This disables Android 16 support for apps using Expo SDK 53 or older gradle versions.
  *
@@ -38,34 +72,10 @@ export function withProjectBuildGradle(
   androidOptions?: CustomerIOPluginOptionsAndroid
 ): ExpoConfig {
   return withExpoProjectBuildGradle(config, (config) => {
-    const { modResults } = config;
-
-    // Check if Android 16 support should be disabled
-    if (!shouldDisableAndroid16Support(config, androidOptions)) {
-      return config;
-    }
-
-    // Skip if already applied
-    if (modResults.contents.includes('androidx.core:core-ktx:1.13.1')) {
-      return config;
-    }
-
-    const resolutionStrategy = `
-    configurations.all {
-        resolutionStrategy {
-            // Disable Android 16 support by forcing older androidx versions
-            // Compatible with API 35 and AGP 8.8.2 (prevents API 36/AGP 8.9.1+ requirement)
-            force 'androidx.core:core-ktx:1.13.1'
-            force 'androidx.lifecycle:lifecycle-process:2.8.7'
-        }
-    }`;
-
-    // Add resolution strategy inside allprojects block
-    modResults.contents = modResults.contents.replace(
-      /allprojects\s*\{/,
-      `allprojects {${resolutionStrategy}`
+    config.modResults.contents = modifyProjectBuildGradleAndroid16Support(
+      config.modResults.contents,
+      { disableAndroid16Support: shouldDisableAndroid16Support(config, androidOptions) }
     );
-
     return config;
   });
 }

--- a/plugin/src/android/withProjectGoogleServices.ts
+++ b/plugin/src/android/withProjectGoogleServices.ts
@@ -7,19 +7,24 @@ import {
 } from './../helpers/constants/android';
 import type { CustomerIOPluginOptionsAndroid } from './../types/cio-types';
 
+export function modifyProjectBuildGradleForGoogleServices(contents: string): string {
+  const regex = new RegExp(CIO_PROJECT_GOOGLE_SNIPPET);
+  if (regex.test(contents)) {
+    return contents;
+  }
+  return contents.replace(
+    CIO_PROJECT_BUILDSCRIPTS_REGEX,
+    `$1\n${CIO_PROJECT_GOOGLE_SNIPPET}`
+  );
+}
+
 export const withProjectGoogleServices: ConfigPlugin<
   CustomerIOPluginOptionsAndroid
 > = (configOuter) => {
   return withProjectBuildGradle(configOuter, (props) => {
-    const regex = new RegExp(CIO_PROJECT_GOOGLE_SNIPPET);
-    const match = props.modResults.contents.match(regex);
-    if (!match) {
-      props.modResults.contents = props.modResults.contents.replace(
-        CIO_PROJECT_BUILDSCRIPTS_REGEX,
-        `$1\n${CIO_PROJECT_GOOGLE_SNIPPET}`
-      );
-    }
-
+    props.modResults.contents = modifyProjectBuildGradleForGoogleServices(
+      props.modResults.contents
+    );
     return props;
   });
 };

--- a/plugin/src/helpers/utils/injectCIOPodfileCode.ts
+++ b/plugin/src/helpers/utils/injectCIOPodfileCode.ts
@@ -34,43 +34,90 @@ export function buildHostAppPodSnippet(
   return `pod 'customerio-reactnative', :subspecs => ['${pushSubspec}', 'location'], :path => '${path}'`;
 }
 
+const HOST_APP_BLOCK_START = '# --- CustomerIO Host App START ---';
+const HOST_APP_BLOCK_END = '# --- CustomerIO Host App END ---';
+const NOTIFICATION_BLOCK_START = '# --- CustomerIO Notification START ---';
+const NOTIFICATION_BLOCK_END = '# --- CustomerIO Notification END ---';
+
+/**
+ * Pure string transform: given the existing Podfile contents, returns the
+ * Podfile with the CustomerIO host-app block injected before the Expo
+ * `post_install do |installer|` anchor. Idempotent — returns input unchanged
+ * if the block is already present.
+ */
+export function injectHostAppPodfileCode(
+  podfileContent: string,
+  iosPath: string,
+  isFcmPushProvider: boolean,
+  options?: InjectCIOPodfileOptions
+): string {
+  if (podfileContent.match(new RegExp(HOST_APP_BLOCK_START))) {
+    return podfileContent;
+  }
+
+  // We need to decide what line of code in the Podfile to insert our native code.
+  // The "post_install" line is always present in an Expo project Podfile so it's reliable.
+  // Find that line in the Podfile and then we will insert our code above that line.
+  const lineInPodfileToInjectSnippetBefore = /post_install do \|installer\|/;
+  const podLine = buildHostAppPodSnippet(iosPath, isFcmPushProvider, options);
+
+  const snippetToInjectInPodfile = `
+${HOST_APP_BLOCK_START}
+  ${podLine}
+${HOST_APP_BLOCK_END}
+`.trim();
+
+  return injectCodeByRegex(
+    podfileContent,
+    lineInPodfileToInjectSnippetBefore,
+    snippetToInjectInPodfile,
+  ).join('\n');
+}
+
 export async function injectCIOPodfileCode(
   iosPath: string,
   isFcmPushProvider: boolean,
   options?: InjectCIOPodfileOptions
 ) {
-  const blockStart = '# --- CustomerIO Host App START ---';
-  const blockEnd = '# --- CustomerIO Host App END ---';
-
   const filename = `${iosPath}/Podfile`;
   const podfile = await FileManagement.read(filename);
-  const matches = podfile.match(new RegExp(blockStart));
-
-  if (!matches) {
-    // We need to decide what line of code in the Podfile to insert our native code.
-    // The "post_install" line is always present in an Expo project Podfile so it's reliable.
-    // Find that line in the Podfile and then we will insert our code above that line.
-    const lineInPodfileToInjectSnippetBefore = /post_install do \|installer\|/;
-
-    const podLine = buildHostAppPodSnippet(iosPath, isFcmPushProvider, options);
-
-    const snippetToInjectInPodfile = `
-${blockStart}
-  ${podLine}
-${blockEnd}
-`.trim();
-
-    FileManagement.write(
-      filename,
-      injectCodeByRegex(
-        podfile,
-        lineInPodfileToInjectSnippetBefore,
-        snippetToInjectInPodfile
-      ).join('\n')
-    );
+  const next = injectHostAppPodfileCode(podfile, iosPath, isFcmPushProvider, options);
+  if (next !== podfile) {
+    FileManagement.write(filename, next);
   } else {
     logger.info('CustomerIO Podfile snippets already exists. Skipping...');
   }
+}
+
+/**
+ * Pure string transform: given the existing Podfile contents, returns the
+ * Podfile with the rich-push NotificationService target block appended at
+ * the end. Idempotent — returns input unchanged if the block is already
+ * present.
+ */
+export function appendNotificationTargetToPodfile(
+  podfileContent: string,
+  iosPath: string,
+  isFcmPushProvider: boolean,
+  useFrameworks: CustomerIOPluginOptionsIOS['useFrameworks'],
+): string {
+  if (podfileContent.match(new RegExp(NOTIFICATION_BLOCK_START))) {
+    return podfileContent;
+  }
+
+  const snippetToAppend = `
+${NOTIFICATION_BLOCK_START}
+target 'NotificationService' do
+  ${useFrameworks === 'static' ? 'use_frameworks! :linkage => :static' : ''}
+  pod 'customerio-reactnative-richpush/${isFcmPushProvider ? 'fcm' : 'apn'}', :path => '${getRelativePathToRNSDK(iosPath)}'
+end
+${NOTIFICATION_BLOCK_END}
+`.trim();
+
+  // Mirror FileManagement.append: append directly with no separator (real
+  // Podfiles end with a trailing newline, so the appended block starts on a
+  // fresh line in practice).
+  return `${podfileContent}${snippetToAppend}`;
 }
 
 export async function injectCIONotificationPodfileCode(
@@ -80,23 +127,15 @@ export async function injectCIONotificationPodfileCode(
 ) {
   const filename = `${iosPath}/Podfile`;
   const podfile = await FileManagement.read(filename);
-
-  const blockStart = '# --- CustomerIO Notification START ---';
-  const blockEnd = '# --- CustomerIO Notification END ---';
-
-  const matches = podfile.match(new RegExp(blockStart));
-
-  if (!matches) {
-    const snippetToInjectInPodfile = `
-${blockStart}
-target 'NotificationService' do
-  ${useFrameworks === 'static' ? 'use_frameworks! :linkage => :static' : ''}
-  pod 'customerio-reactnative-richpush/${isFcmPushProvider ? 'fcm' : 'apn'
-      }', :path => '${getRelativePathToRNSDK(iosPath)}'
-end
-${blockEnd}
-`.trim();
-
-    FileManagement.append(filename, snippetToInjectInPodfile);
+  const next = appendNotificationTargetToPodfile(
+    podfile,
+    iosPath,
+    isFcmPushProvider,
+    useFrameworks,
+  );
+  if (next !== podfile) {
+    // FileManagement.append matches what the previous direct-append did.
+    // Slice off the leading content (already on disk) and append only the new tail.
+    FileManagement.append(filename, next.slice(podfile.length));
   }
 }

--- a/plugin/src/ios/withAppDelegateModifications.ts
+++ b/plugin/src/ios/withAppDelegateModifications.ts
@@ -153,9 +153,12 @@ const addFirebaseDelegateForwardDeclarationIfNeeded = (
   return stringContents;
 };
 
-const addAppdelegateHeaderModification = (stringContents: string) => {
-  // Add UNUserNotificationCenterDelegate if needed
-  stringContents = stringContents.replace(
+/**
+ * Pure string transform: ensures the AppDelegate header (Objective-C path) declares
+ * `UNUserNotificationCenterDelegate` and imports `UserNotifications`. Idempotent.
+ */
+export function modifyAppDelegateHeader(headerContent: string): string {
+  return headerContent.replace(
     CIO_APPDELEGATEHEADER_REGEX,
     (match, interfaceDeclaration, _groupedDelegates, existingDelegates) => {
       if (
@@ -179,9 +182,7 @@ ${interfaceDeclaration.trim()} <${CIO_APPDELEGATEHEADER_USER_NOTIFICATION_CENTER
       }
     }
   );
-
-  return stringContents;
-};
+}
 
 const addHandleDeeplinkInKilledState = (stringContents: string) => {
   // Find if the deep link code snippet is already present
@@ -219,58 +220,70 @@ const addHandleDeeplinkInKilledState = (stringContents: string) => {
   return stringContents;
 };
 
+/**
+ * Pure string transform: produces the modified Objective-C AppDelegate.m / AppDelegate.mm
+ * contents wired with the Customer.io push pipeline (imports, declarations, notification
+ * configuration, registration callbacks, optional killed-state deep-link, FCM forward decl,
+ * Expo notifications header). The caller is responsible for the AppDelegate header file
+ * (.h) — see `modifyAppDelegateHeader`.
+ */
+export function modifyAppDelegateContents(
+  contents: string,
+  projectName: string,
+  props: CustomerIOPluginOptionsIOS
+): string {
+  let next = addImport(contents, projectName);
+  next = addNotificationHandlerDeclaration(next);
+
+  // unless this property is explicity set to true, push notification
+  // registration will be added to the AppDelegate
+  if (props.pushNotification?.disableNotificationRegistration !== true) {
+    next = addNotificationConfiguration(next);
+  }
+
+  next = addInitializeNativeCioSdk(next);
+
+  if (props.pushNotification?.handleDeeplinkInKilledState === true) {
+    next = addHandleDeeplinkInKilledState(next);
+  }
+
+  next = addDidFailToRegisterForRemoteNotificationsWithError(next);
+  next = addDidRegisterForRemoteNotificationsWithDeviceToken(next);
+
+  if (isFcmPushProvider(props)) {
+    next = addFirebaseDelegateForwardDeclarationIfNeeded(next);
+  }
+
+  next = addExpoNotificationsHeaderModification(next);
+
+  return next;
+}
+
 export const withAppDelegateModifications: ConfigPlugin<
   CustomerIOPluginOptionsIOS
 > = (configOuter, props) => {
   return withAppDelegate(configOuter, async (config) => {
-    let stringContents = config.modResults.contents;
+    const stringContents = config.modResults.contents;
     const regex = new RegExp(
       `#import <${config.modRequest.projectName}-Swift.h>`
     );
-    const match = stringContents.match(regex);
 
-    if (!match) {
-      const headerPath = getAppDelegateHeaderFilePath(
-        config.modRequest.projectRoot
-      );
-      let headerContent = await FileManagement.read(headerPath);
-      headerContent = addAppdelegateHeaderModification(headerContent);
-      FileManagement.write(headerPath, headerContent);
-
-      stringContents = addImport(
-        stringContents,
-        config.modRequest.projectName as string
-      );
-      stringContents = addNotificationHandlerDeclaration(stringContents);
-
-      // unless this property is explicity set to true, push notification
-      // registration will be added to the AppDelegate
-      if (props.pushNotification?.disableNotificationRegistration !== true) {
-        stringContents = addNotificationConfiguration(stringContents);
-      }
-
-      stringContents = addInitializeNativeCioSdk(stringContents);
-
-      if (props.pushNotification?.handleDeeplinkInKilledState === true) {
-        stringContents = addHandleDeeplinkInKilledState(stringContents);
-      }
-
-      stringContents =
-        addDidFailToRegisterForRemoteNotificationsWithError(stringContents);
-      stringContents =
-        addDidRegisterForRemoteNotificationsWithDeviceToken(stringContents);
-
-      if (isFcmPushProvider(props)) {
-        stringContents =
-          addFirebaseDelegateForwardDeclarationIfNeeded(stringContents);
-      }
-
-      stringContents = addExpoNotificationsHeaderModification(stringContents);
-
-      config.modResults.contents = stringContents;
-    } else {
+    if (stringContents.match(regex)) {
       logger.info('Customerio AppDelegate changes already exist. Skipping...');
+      return config;
     }
+
+    const headerPath = getAppDelegateHeaderFilePath(
+      config.modRequest.projectRoot
+    );
+    const headerContent = await FileManagement.read(headerPath);
+    FileManagement.write(headerPath, modifyAppDelegateHeader(headerContent));
+
+    config.modResults.contents = modifyAppDelegateContents(
+      stringContents,
+      config.modRequest.projectName as string,
+      props
+    );
 
     return config;
   });

--- a/plugin/src/ios/withCIOIosSwift.ts
+++ b/plugin/src/ios/withCIOIosSwift.ts
@@ -232,12 +232,19 @@ export const withCIOIosSwift = (
   if (props?.pushNotification) {
     // With push notifications: delegate to CioSdkAppDelegateHandler for both push and auto-init
     return withAppDelegate(configOuter, async (config) => {
-      return modifyAppDelegateWithPushAppDelegateHandler(config, props);
+      config.modResults.contents = modifyAppDelegateForPushHandler(
+        config.modResults.contents,
+        props
+      );
+      return config;
     });
   } else if (sdkConfig) {
     // Without push notifications: directly inject auto initialization into AppDelegate
     return withAppDelegate(configOuter, async (config) => {
-      return modifyAppDelegateWithNativeSDKInitializer(config);
+      config.modResults.contents = modifyAppDelegateForNativeSDKInitializer(
+        config.modResults.contents
+      );
+      return config;
     });
   } else {
     return configOuter;
@@ -245,77 +252,53 @@ export const withCIOIosSwift = (
 };
 
 /**
- * Modify the AppDelegate to integrate with Customer.io SDK
+ * Pure string transform: produces the Swift AppDelegate contents wired to delegate to
+ * `CioSdkAppDelegateHandler` for both push notifications and (when configured) auto-init.
+ * Idempotent — returns `contents` unchanged when the handler is already present.
  */
-const modifyAppDelegateWithPushAppDelegateHandler = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  config: any,
+export function modifyAppDelegateForPushHandler(
+  contents: string,
   props: CustomerIOPluginOptionsIOS
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): any => {
-  const appDelegateContent = config.modResults.contents;
-
-  // Check if modifications have already been applied
-  if (appDelegateContent.includes(CIO_SDK_APP_DELEGATE_HANDLER_CLASS)) {
+): string {
+  if (contents.includes(CIO_SDK_APP_DELEGATE_HANDLER_CLASS)) {
     logger.info(
       'CustomerIO Swift AppDelegate changes already exist. Skipping...'
     );
-    return config;
+    return contents;
   }
 
-  // Add the handler property declaration
-  let modifiedContent = addHandlerPropertyDeclaration(appDelegateContent);
-
-  // Modify didFinishLaunchingWithOptions to initialize and call the handler
-  modifiedContent = modifyDidFinishLaunchingWithOptions(
-    modifiedContent,
+  let next = addHandlerPropertyDeclaration(contents);
+  next = modifyDidFinishLaunchingWithOptions(
+    next,
     `  cioSdkHandler.application(application, didFinishLaunchingWithOptions: launchOptions)\n\n    `
   );
+  next = addDidRegisterForRemoteNotificationsWithDeviceToken(next);
+  next = addDidFailToRegisterForRemoteNotificationsWithError(next);
 
-  // Add didRegisterForRemoteNotificationsWithDeviceToken implementation
-  modifiedContent =
-    addDidRegisterForRemoteNotificationsWithDeviceToken(modifiedContent);
-
-  // Add didFailToRegisterForRemoteNotificationsWithError implementation
-  modifiedContent =
-    addDidFailToRegisterForRemoteNotificationsWithError(modifiedContent);
-
-  // Add deep link handling for killed state if enabled
   if (props.pushNotification?.handleDeeplinkInKilledState === true) {
-    modifiedContent = addHandleDeeplinkInKilledState(modifiedContent);
+    next = addHandleDeeplinkInKilledState(next);
   }
 
-  config.modResults.contents = modifiedContent;
-  return config;
-};
+  return next;
+}
 
 /**
- * Modify the AppDelegate to integrate with Customer.io SDK
+ * Pure string transform: injects the auto-init snippet into the Swift AppDelegate's
+ * didFinishLaunchingWithOptions for the no-push path. Idempotent.
  */
-const modifyAppDelegateWithNativeSDKInitializer = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  config: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): any => {
-  const appDelegateContent = config.modResults.contents;
-
-  // Check if modifications have already been applied
-  if (appDelegateContent.includes(CIO_NATIVE_SDK_INITIALIZE_CALL)) {
+export function modifyAppDelegateForNativeSDKInitializer(contents: string): string {
+  if (contents.includes(CIO_NATIVE_SDK_INITIALIZE_CALL)) {
     logger.info(
       'CustomerIO Swift AppDelegate changes already exist. Skipping...'
     );
-    return config;
+    return contents;
   }
 
-  // Modify didFinishLaunchingWithOptions to initialize and call the handler
-  const modifiedContent = modifyDidFinishLaunchingWithOptions(
-    appDelegateContent,
+  return modifyDidFinishLaunchingWithOptions(
+    contents,
     CIO_NATIVE_SDK_INITIALIZE_SNIPPET,
   );
-
-  config.modResults.contents = modifiedContent;
-  return config;
-};
+}
 
 /**
  * Check if a method exists in the AppDelegate content

--- a/plugin/src/ios/withGoogleServicesJsonFile.ts
+++ b/plugin/src/ios/withGoogleServicesJsonFile.ts
@@ -6,6 +6,65 @@ import { logger } from '../utils/logger';
 import { FileManagement } from './../helpers/utils/fileManagement';
 import { isFcmPushProvider } from './utils';
 
+export type CopyGoogleServicePlistOptions = {
+  iosPath: string;
+  appName: string | undefined;
+  googleServicesFile: string | undefined;
+  expoIosGoogleServicesFileSet: boolean;
+  xcodeProject: XcodeProject;
+};
+
+/**
+ * Copies the FCM GoogleService-Info.plist into the iOS project (when needed) and registers it
+ * in the Xcode project's Resources group. Idempotent — no-ops if a plist is already present
+ * at either of the two well-known locations Expo / RN Firebase use.
+ */
+export function copyGoogleServicePlistFile({
+  iosPath,
+  appName,
+  googleServicesFile,
+  expoIosGoogleServicesFileSet,
+  xcodeProject,
+}: CopyGoogleServicePlistOptions): void {
+  const destination = `${iosPath}/GoogleService-Info.plist`;
+
+  if (FileManagement.exists(destination)) {
+    logger.info(`File already exists: ${destination}. Skipping...`);
+    return;
+  }
+
+  if (appName && FileManagement.exists(`${iosPath}/${appName}/GoogleService-Info.plist`)) {
+    // This is where RN Firebase potentially copies GoogleService-Info.plist
+    // Do not copy if it's already done by Firebase to avoid conflict in Resources
+    logger.info(
+      `File already exists: ${iosPath}/${appName}/GoogleService-Info.plist. Skipping...`
+    );
+    return;
+  }
+
+  if (googleServicesFile && FileManagement.exists(googleServicesFile)) {
+    if (expoIosGoogleServicesFileSet) {
+      logger.warn(
+        'Specifying both Expo ios.googleServicesFile and Customer.io ios.pushNotification.googleServicesFile can cause a conflict' +
+        ' duplicating GoogleService-Info.plist in the iOS project resources. Please remove Customer.io ios.pushNotification.googleServicesFile'
+      );
+    }
+
+    try {
+      FileManagement.copyFile(googleServicesFile, destination);
+      addFileToXcodeProject(xcodeProject, 'GoogleService-Info.plist');
+    } catch {
+      logger.error(
+        `There was an error copying your GoogleService-Info.plist file. You can copy it manually into ${destination}`
+      );
+    }
+  } else {
+    logger.error(
+      `The Google Services file provided in ${googleServicesFile} doesn't seem to exist. You can copy it manually into ${destination}`
+    );
+  }
+}
+
 export const withGoogleServicesJsonFile: ConfigPlugin<
   CustomerIOPluginOptionsIOS
 > = (config, cioProps) => {
@@ -21,54 +80,13 @@ export const withGoogleServicesJsonFile: ConfigPlugin<
       ' GoogleService-Info.plist as part of Firebase integration'
     );
 
-    // googleServicesFile
-    const iosPath = props.modRequest.platformProjectRoot;
-    const googleServicesFile = cioProps.pushNotification?.googleServicesFile;
-    const appName = props.modRequest.projectName;
-
-    if (FileManagement.exists(`${iosPath}/GoogleService-Info.plist`)) {
-      logger.info(
-        `File already exists: ${iosPath}/GoogleService-Info.plist. Skipping...`
-      );
-      return props;
-    }
-
-    if (
-      FileManagement.exists(`${iosPath}/${appName}/GoogleService-Info.plist`)
-    ) {
-      // This is where RN Firebase potentially copies GoogleService-Info.plist
-      // Do not copy if it's already done by Firebase to avoid conflict in Resources
-      logger.info(
-        `File already exists: ${iosPath}/${appName}/GoogleService-Info.plist. Skipping...`
-      );
-      return props;
-    }
-
-    if (googleServicesFile && FileManagement.exists(googleServicesFile)) {
-      if (config.ios?.googleServicesFile) {
-        logger.warn(
-          'Specifying both Expo ios.googleServicesFile and Customer.io ios.pushNotification.googleServicesFile can cause a conflict' +
-          ' duplicating GoogleService-Info.plist in the iOS project resources. Please remove Customer.io ios.pushNotification.googleServicesFile'
-        );
-      }
-
-      try {
-        FileManagement.copyFile(
-          googleServicesFile,
-          `${iosPath}/GoogleService-Info.plist`
-        );
-
-        addFileToXcodeProject(props.modResults, 'GoogleService-Info.plist');
-      } catch {
-        logger.error(
-          `There was an error copying your GoogleService-Info.plist file. You can copy it manually into ${iosPath}/GoogleService-Info.plist`
-        );
-      }
-    } else {
-      logger.error(
-        `The Google Services file provided in ${googleServicesFile} doesn't seem to exist. You can copy it manually into ${iosPath}/GoogleService-Info.plist`
-      );
-    }
+    copyGoogleServicePlistFile({
+      iosPath: props.modRequest.platformProjectRoot,
+      appName: props.modRequest.projectName,
+      googleServicesFile: cioProps.pushNotification?.googleServicesFile,
+      expoIosGoogleServicesFileSet: Boolean(config.ios?.googleServicesFile),
+      xcodeProject: props.modResults,
+    });
 
     return props;
   });

--- a/plugin/src/ios/withNotificationsXcodeProject.ts
+++ b/plugin/src/ios/withNotificationsXcodeProject.ts
@@ -101,109 +101,61 @@ export const withCioNotificationsXcodeProject: ConfigPlugin<
   });
 };
 
-const addRichPushXcodeProj = async (
-  options: CustomerIOPluginOptionsIOS,
+const NSE_ENTITLEMENTS_FILENAME = 'NotificationService.entitlements';
+
+export type AddNseTargetToXcodeProjectOptions = {
+  appleTeamId?: string;
+  bundleIdentifier?: string;
+  iosDeploymentTarget?: string;
+  appGroupId?: string;
+};
+
+/**
+ * Mutates the parsed XcodeProject to register the rich-push NotificationService
+ * extension target: creates a PBXGroup for its files, registers the group under
+ * the project's top-level group, adds the app_extension target, wires three
+ * build phases (Sources, Resources, Frameworks), configures the target's build
+ * settings (DEVELOPMENT_TEAM, IPHONEOS_DEPLOYMENT_TARGET, code-sign style,
+ * Swift version, and CODE_SIGN_ENTITLEMENTS when `appGroupId` is set), and
+ * stamps the development team attribute on both the new target and the
+ * project's main target attributes.
+ *
+ * Idempotent — returns the project unchanged if a target named
+ * `CIO_NOTIFICATION_TARGET_NAME` is already present.
+ */
+export function addNotificationServiceExtensionToXcodeProject(
   xcodeProject: XcodeProject,
-) => {
-  const {
-    appleTeamId,
-    bundleIdentifier,
-    bundleShortVersion,
-    bundleVersion,
-    iosPath,
-    iosDeploymentTarget,
-    useFrameworks,
-  } = options;
-
-  const isFcmProvider = isFcmPushProvider(options);
-
-  await injectCIONotificationPodfileCode(iosPath, useFrameworks, isFcmProvider);
-
-  // Check if `CIO_NOTIFICATION_TARGET_NAME` group already exist in the project
-  // If true then skip creating a new group to avoid duplicate folders
+  options: AddNseTargetToXcodeProjectOptions,
+): XcodeProject {
   if (xcodeProject.pbxTargetByName(CIO_NOTIFICATION_TARGET_NAME)) {
     logger.warn(
-      `${CIO_NOTIFICATION_TARGET_NAME} already exists in project. Skipping...`
+      `${CIO_NOTIFICATION_TARGET_NAME} already exists in project. Skipping...`,
     );
-    return;
+    return xcodeProject;
   }
 
-  const nsePath = `${iosPath}/${CIO_NOTIFICATION_TARGET_NAME}`;
-  FileManagement.mkdir(nsePath, {
-    recursive: true,
-  });
+  const { appleTeamId, bundleIdentifier, iosDeploymentTarget, appGroupId } = options;
 
   const platformSpecificFiles = ['NotificationService.swift'];
-
-  const nseEntitlementsFilename = 'NotificationService.entitlements';
-  const appGroupId = options.pushNotification?.appGroupId;
-
-  // Write NSE entitlements file only when appGroupId is explicitly configured
-  if (appGroupId) {
-    const nseEntitlementsContent = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>com.apple.security.application-groups</key>
-  <array>
-    <string>${appGroupId}</string>
-  </array>
-</dict>
-</plist>
-`;
-    FileManagement.writeFile(`${nsePath}/${nseEntitlementsFilename}`, nseEntitlementsContent);
-  }
-
   const commonFiles = [
     PLIST_FILENAME,
     'NotificationService.h',
     'NotificationService.m',
     ENV_FILENAME,
   ];
-
-  const getTargetFile = (filename: string) => `${nsePath}/${filename}`;
-  // Copy platform-specific files
-  platformSpecificFiles.forEach((filename) => {
-    const targetFile = getTargetFile(filename);
-    FileManagement.copyFile(
-      `${getIosNativeFilesPath()}/${isFcmProvider ? 'fcm' : 'apn'
-      }/${filename}`,
-      targetFile
-    );
-  });
-
-  // Copy common files
-  commonFiles.forEach((filename) => {
-    const targetFile = getTargetFile(filename);
-    FileManagement.copyFile(
-      `${getIosNativeFilesPath()}/common/${filename}`,
-      targetFile
-    );
-  });
-
-  /* MODIFY COPIED EXTENSION FILES */
-  const infoPlistTargetFile = getTargetFile(PLIST_FILENAME);
-  updateNseInfoPlist({
-    bundleVersion,
-    bundleShortVersion,
-    infoPlistTargetFile,
-  });
-  updateNseEnv(getTargetFile(ENV_FILENAME), options.pushNotification?.env);
-  updateNseNotificationService(getTargetFile('NotificationService.swift'), options.pushNotification?.appGroupId);
-
   // The entitlements file is generated (not copied from source), so it's listed separately
-  // for the Xcode group so it appears in the file navigator
+  // for the Xcode group so it appears in the file navigator.
   const allGroupFiles = [
     ...platformSpecificFiles,
     ...commonFiles,
-    ...(appGroupId ? [nseEntitlementsFilename] : []),
+    ...(appGroupId ? [NSE_ENTITLEMENTS_FILENAME] : []),
   ];
 
   // Create new PBXGroup for the extension
   const extGroup = xcodeProject.addPbxGroup(
     allGroupFiles,
     CIO_NOTIFICATION_TARGET_NAME,
-    CIO_NOTIFICATION_TARGET_NAME
+    CIO_NOTIFICATION_TARGET_NAME,
   );
 
   // Add the new PBXGroup to the top level group. This makes the
@@ -223,20 +175,12 @@ const addRichPushXcodeProj = async (
   projObjects.PBXTargetDependency = projObjects.PBXTargetDependency || {};
   projObjects.PBXContainerItemProxy = projObjects.PBXTargetDependency || {};
 
-  if (xcodeProject.pbxTargetByName(CIO_NOTIFICATION_TARGET_NAME)) {
-    logger.warn(
-      `${CIO_NOTIFICATION_TARGET_NAME} already exists in project. Skipping...`
-    );
-    return;
-  }
-
-  // Add the NSE target
-  // This also adds PBXTargetDependency and PBXContainerItemProxy
+  // Add the NSE target. This also adds PBXTargetDependency and PBXContainerItemProxy.
   const nseTarget = xcodeProject.addTarget(
     CIO_NOTIFICATION_TARGET_NAME,
     'app_extension',
     CIO_NOTIFICATION_TARGET_NAME,
-    `${bundleIdentifier}.richpush`
+    `${bundleIdentifier}.richpush`,
   );
 
   // Add build phases to the new target
@@ -244,21 +188,10 @@ const addRichPushXcodeProj = async (
     ['NotificationService.m', 'NotificationService.swift', 'Env.swift'],
     'PBXSourcesBuildPhase',
     'Sources',
-    nseTarget.uuid
+    nseTarget.uuid,
   );
-  xcodeProject.addBuildPhase(
-    [],
-    'PBXResourcesBuildPhase',
-    'Resources',
-    nseTarget.uuid
-  );
-
-  xcodeProject.addBuildPhase(
-    [],
-    'PBXFrameworksBuildPhase',
-    'Frameworks',
-    nseTarget.uuid
-  );
+  xcodeProject.addBuildPhase([], 'PBXResourcesBuildPhase', 'Resources', nseTarget.uuid);
+  xcodeProject.addBuildPhase([], 'PBXFrameworksBuildPhase', 'Frameworks', nseTarget.uuid);
 
   // Edit the Deployment info of the target
   const configurations = xcodeProject.pbxXCBuildConfigurationSection();
@@ -266,17 +199,16 @@ const addRichPushXcodeProj = async (
     if (
       typeof configurations[key].buildSettings !== 'undefined' &&
       configurations[key].buildSettings.PRODUCT_NAME ===
-      `"${CIO_NOTIFICATION_TARGET_NAME}"`
+        `"${CIO_NOTIFICATION_TARGET_NAME}"`
     ) {
       const buildSettingsObj = configurations[key].buildSettings;
       buildSettingsObj.DEVELOPMENT_TEAM = appleTeamId;
-      buildSettingsObj.IPHONEOS_DEPLOYMENT_TARGET =
-        iosDeploymentTarget || '15.1';
+      buildSettingsObj.IPHONEOS_DEPLOYMENT_TARGET = iosDeploymentTarget || '15.1';
       buildSettingsObj.TARGETED_DEVICE_FAMILY = TARGETED_DEVICE_FAMILY;
       buildSettingsObj.CODE_SIGN_STYLE = 'Automatic';
       buildSettingsObj.SWIFT_VERSION = 4.2;
       if (appGroupId) {
-        buildSettingsObj.CODE_SIGN_ENTITLEMENTS = `${CIO_NOTIFICATION_TARGET_NAME}/${nseEntitlementsFilename}`;
+        buildSettingsObj.CODE_SIGN_ENTITLEMENTS = `${CIO_NOTIFICATION_TARGET_NAME}/${NSE_ENTITLEMENTS_FILENAME}`;
       }
     }
   }
@@ -284,6 +216,99 @@ const addRichPushXcodeProj = async (
   // Add development team to the target & the main
   xcodeProject.addTargetAttribute('DevelopmentTeam', appleTeamId, nseTarget);
   xcodeProject.addTargetAttribute('DevelopmentTeam', appleTeamId);
+
+  return xcodeProject;
+}
+
+const addRichPushXcodeProj = async (
+  options: CustomerIOPluginOptionsIOS,
+  xcodeProject: XcodeProject,
+) => {
+  const {
+    appleTeamId,
+    bundleIdentifier,
+    bundleShortVersion,
+    bundleVersion,
+    iosPath,
+    iosDeploymentTarget,
+    useFrameworks,
+  } = options;
+
+  const isFcmProvider = isFcmPushProvider(options);
+  const appGroupId = options.pushNotification?.appGroupId;
+
+  await injectCIONotificationPodfileCode(iosPath, useFrameworks, isFcmProvider);
+
+  // Skip the rest of the work if the NSE target is already in place. The pbxproj-mutating
+  // helper has its own idempotency check, but bailing out here also avoids redundant file
+  // copies and entitlements writes when prebuild re-runs against an already-prepared project.
+  if (xcodeProject.pbxTargetByName(CIO_NOTIFICATION_TARGET_NAME)) {
+    logger.warn(
+      `${CIO_NOTIFICATION_TARGET_NAME} already exists in project. Skipping...`,
+    );
+    return;
+  }
+
+  const nsePath = `${iosPath}/${CIO_NOTIFICATION_TARGET_NAME}`;
+  FileManagement.mkdir(nsePath, { recursive: true });
+
+  // Write NSE entitlements file only when appGroupId is explicitly configured
+  if (appGroupId) {
+    const nseEntitlementsContent = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.application-groups</key>
+  <array>
+    <string>${appGroupId}</string>
+  </array>
+</dict>
+</plist>
+`;
+    FileManagement.writeFile(`${nsePath}/${NSE_ENTITLEMENTS_FILENAME}`, nseEntitlementsContent);
+  }
+
+  const platformSpecificFiles = ['NotificationService.swift'];
+  const commonFiles = [
+    PLIST_FILENAME,
+    'NotificationService.h',
+    'NotificationService.m',
+    ENV_FILENAME,
+  ];
+  const getTargetFile = (filename: string) => `${nsePath}/${filename}`;
+
+  // Copy platform-specific files
+  platformSpecificFiles.forEach((filename) => {
+    FileManagement.copyFile(
+      `${getIosNativeFilesPath()}/${isFcmProvider ? 'fcm' : 'apn'}/${filename}`,
+      getTargetFile(filename),
+    );
+  });
+
+  // Copy common files
+  commonFiles.forEach((filename) => {
+    FileManagement.copyFile(
+      `${getIosNativeFilesPath()}/common/${filename}`,
+      getTargetFile(filename),
+    );
+  });
+
+  /* MODIFY COPIED EXTENSION FILES */
+  updateNseInfoPlist({
+    bundleVersion,
+    bundleShortVersion,
+    infoPlistTargetFile: getTargetFile(PLIST_FILENAME),
+  });
+  updateNseEnv(getTargetFile(ENV_FILENAME), options.pushNotification?.env);
+  updateNseNotificationService(getTargetFile('NotificationService.swift'), appGroupId);
+
+  // Register the NSE target in the parsed Xcode project
+  addNotificationServiceExtensionToXcodeProject(xcodeProject, {
+    appleTeamId,
+    bundleIdentifier,
+    iosDeploymentTarget,
+    appGroupId,
+  });
 };
 
 /**

--- a/plugin/src/ios/withNotificationsXcodeProject.ts
+++ b/plugin/src/ios/withNotificationsXcodeProject.ts
@@ -18,6 +18,21 @@ import { isExpoVersion53OrHigher, isFcmPushProvider } from './utils';
 const PLIST_FILENAME = `${CIO_NOTIFICATION_TARGET_NAME}-Info.plist`;
 const ENV_FILENAME = 'Env.swift';
 
+// NSE source files registered in the Xcode group AND copied to the target
+// directory. Single source of truth — both `addNotificationServiceExtensionToXcodeProject`
+// (registers them in the PBXGroup) and `addRichPushXcodeProj` (copies them
+// from the plugin's native-files dir) read the same arrays. Keeping these
+// in sync is load-bearing: the Xcode group must reference the same files
+// that exist on disk, or the build fails with "no such file" / unresolved
+// references.
+const NSE_PLATFORM_SPECIFIC_FILES = ['NotificationService.swift'];
+const NSE_COMMON_FILES = [
+  PLIST_FILENAME,
+  'NotificationService.h',
+  'NotificationService.m',
+  ENV_FILENAME,
+];
+
 const TARGETED_DEVICE_FAMILY = `"1,2"`;
 
 const addNotificationServiceExtension = async (
@@ -136,18 +151,11 @@ export function addNotificationServiceExtensionToXcodeProject(
 
   const { appleTeamId, bundleIdentifier, iosDeploymentTarget, appGroupId } = options;
 
-  const platformSpecificFiles = ['NotificationService.swift'];
-  const commonFiles = [
-    PLIST_FILENAME,
-    'NotificationService.h',
-    'NotificationService.m',
-    ENV_FILENAME,
-  ];
   // The entitlements file is generated (not copied from source), so it's listed separately
   // for the Xcode group so it appears in the file navigator.
   const allGroupFiles = [
-    ...platformSpecificFiles,
-    ...commonFiles,
+    ...NSE_PLATFORM_SPECIFIC_FILES,
+    ...NSE_COMMON_FILES,
     ...(appGroupId ? [NSE_ENTITLEMENTS_FILENAME] : []),
   ];
 
@@ -268,17 +276,10 @@ const addRichPushXcodeProj = async (
     FileManagement.writeFile(`${nsePath}/${NSE_ENTITLEMENTS_FILENAME}`, nseEntitlementsContent);
   }
 
-  const platformSpecificFiles = ['NotificationService.swift'];
-  const commonFiles = [
-    PLIST_FILENAME,
-    'NotificationService.h',
-    'NotificationService.m',
-    ENV_FILENAME,
-  ];
   const getTargetFile = (filename: string) => `${nsePath}/${filename}`;
 
   // Copy platform-specific files
-  platformSpecificFiles.forEach((filename) => {
+  NSE_PLATFORM_SPECIFIC_FILES.forEach((filename) => {
     FileManagement.copyFile(
       `${getIosNativeFilesPath()}/${isFcmProvider ? 'fcm' : 'apn'}/${filename}`,
       getTargetFile(filename),
@@ -286,7 +287,7 @@ const addRichPushXcodeProj = async (
   });
 
   // Copy common files
-  commonFiles.forEach((filename) => {
+  NSE_COMMON_FILES.forEach((filename) => {
     FileManagement.copyFile(
       `${getIosNativeFilesPath()}/common/${filename}`,
       getTargetFile(filename),

--- a/plugin/src/ios/withNotificationsXcodeProject.ts
+++ b/plugin/src/ios/withNotificationsXcodeProject.ts
@@ -286,89 +286,108 @@ const addRichPushXcodeProj = async (
   xcodeProject.addTargetAttribute('DevelopmentTeam', appleTeamId);
 };
 
+/**
+ * Pure string transform: substitutes the `{{BUNDLE_VERSION}}` and
+ * `{{BUNDLE_SHORT_VERSION}}` placeholders in the NSE Info.plist template.
+ * Either or both may be provided; missing values leave the corresponding
+ * placeholder untouched.
+ */
+export function applyBundleVersionToNsePlist(
+  content: string,
+  payload: { bundleVersion?: string; bundleShortVersion?: string }
+): string {
+  let next = content;
+  if (payload.bundleVersion) {
+    next = replaceCodeByRegex(next, /\{\{BUNDLE_VERSION\}\}/, payload.bundleVersion);
+  }
+  if (payload.bundleShortVersion) {
+    next = replaceCodeByRegex(next, /\{\{BUNDLE_SHORT_VERSION\}\}/, payload.bundleShortVersion);
+  }
+  return next;
+}
+
 const updateNseInfoPlist = (payload: {
   bundleVersion?: string;
   bundleShortVersion?: string;
   infoPlistTargetFile: string;
 }) => {
-  const BUNDLE_SHORT_VERSION_RE = /\{\{BUNDLE_SHORT_VERSION\}\}/;
-  const BUNDLE_VERSION_RE = /\{\{BUNDLE_VERSION\}\}/;
-
-  let plistFileString = FileManagement.readFile(payload.infoPlistTargetFile);
-
-  if (payload.bundleVersion) {
-    plistFileString = replaceCodeByRegex(
-      plistFileString,
-      BUNDLE_VERSION_RE,
-      payload.bundleVersion
-    );
-  }
-
-  if (payload.bundleShortVersion) {
-    plistFileString = replaceCodeByRegex(
-      plistFileString,
-      BUNDLE_SHORT_VERSION_RE,
-      payload.bundleShortVersion
-    );
-  }
-
-  FileManagement.writeFile(payload.infoPlistTargetFile, plistFileString);
+  const next = applyBundleVersionToNsePlist(
+    FileManagement.readFile(payload.infoPlistTargetFile),
+    payload,
+  );
+  FileManagement.writeFile(payload.infoPlistTargetFile, next);
 };
+
+/**
+ * Pure string transform: substitutes the `{{APP_GROUP_ID_BUILDER_LINE}}`
+ * placeholder in NotificationService.swift with either the configured
+ * appGroupId builder line or an empty string.
+ */
+export function applyAppGroupIdToNotificationService(
+  content: string,
+  appGroupId?: string
+): string {
+  const builderLine = appGroupId
+    ? `        .appGroupId(${JSON.stringify(appGroupId)})\n`
+    : '';
+  return replaceCodeByRegex(content, /\{\{APP_GROUP_ID_BUILDER_LINE\}\}/, builderLine);
+}
 
 const updateNseNotificationService = (
   notificationServiceFile: string,
   appGroupId?: string,
 ) => {
-  const APP_GROUP_ID_BUILDER_LINE_RE = /\{\{APP_GROUP_ID_BUILDER_LINE\}\}/;
-
-  let content = FileManagement.readFile(notificationServiceFile);
-  const builderLine = appGroupId
-    ? `        .appGroupId(${JSON.stringify(appGroupId)})\n`
-    : '';
-  content = replaceCodeByRegex(content, APP_GROUP_ID_BUILDER_LINE_RE, builderLine);
-  FileManagement.writeFile(notificationServiceFile, content);
+  const next = applyAppGroupIdToNotificationService(
+    FileManagement.readFile(notificationServiceFile),
+    appGroupId,
+  );
+  FileManagement.writeFile(notificationServiceFile, next);
 };
 
-const updateNseEnv = (
-  envFileName: string,
-  richPushConfig?: RichPushConfig
-) => {
-  const CDP_API_KEY_RE = /\{\{CDP_API_KEY\}\}/;
-  const REGION_RE = /\{\{REGION\}\}/;
-
-  let envFileContent = FileManagement.readFile(envFileName);
-
-  // Use merged config values (config takes precedence over env)
+/**
+ * Pure string transform: substitutes the `{{CDP_API_KEY}}` and `{{REGION}}`
+ * placeholders in the NSE Env.swift template. Missing or invalid region
+ * falls back to `Region.US` and logs a warning.
+ */
+export function applyRichPushConfigToEnv(
+  content: string,
+  richPushConfig?: RichPushConfig,
+): string {
   const cdpApiKey = richPushConfig?.cdpApiKey;
   const region = richPushConfig?.region;
 
-  if (!validateRichPushConfig(richPushConfig)) {
-    return;
-  }
-  envFileContent = replaceCodeByRegex(
-    envFileContent,
-    CDP_API_KEY_RE,
+  let next = replaceCodeByRegex(
+    content,
+    /\{\{CDP_API_KEY\}\}/,
     cdpApiKey || 'MISSING_API_KEY',
   );
 
-  // Simplify region mapping with case insensitive keys and fallback for invalid regions
   const regionKey = region?.toLowerCase() ?? '';
-  const regionMap = {
-    us: 'Region.US',
-    eu: 'Region.EU',
-  } as const;
+  const regionMap = { us: 'Region.US', eu: 'Region.EU' } as const;
   const mappedRegion = regionMap[regionKey as keyof typeof regionMap];
   if (!mappedRegion) {
     logger.warn(
       `${regionKey} is an invalid region. Please use the values from the docs: https://docs.customer.io/integrations/sdk/expo/getting-started/packages-options/#configuring-the-expo-plugin`
     );
-    // Fallback to US if invalid region provided
-    envFileContent = replaceCodeByRegex(envFileContent, REGION_RE, regionMap.us);
+    next = replaceCodeByRegex(next, /\{\{REGION\}\}/, regionMap.us);
   } else {
-    envFileContent = replaceCodeByRegex(envFileContent, REGION_RE, mappedRegion);
+    next = replaceCodeByRegex(next, /\{\{REGION\}\}/, mappedRegion);
   }
+  return next;
+}
 
-  FileManagement.writeFile(envFileName, envFileContent);
+const updateNseEnv = (
+  envFileName: string,
+  richPushConfig?: RichPushConfig
+) => {
+  if (!validateRichPushConfig(richPushConfig)) {
+    return;
+  }
+  const next = applyRichPushConfigToEnv(
+    FileManagement.readFile(envFileName),
+    richPushConfig,
+  );
+  FileManagement.writeFile(envFileName, next);
 };
 
 async function addPushNotificationFile(
@@ -410,79 +429,84 @@ async function addPushNotificationFile(
   xcodeProject.addSourceFile(`${appName}/${targetFileName}`, null, group);
 }
 
-const updatePushFile = (
+/**
+ * Pure string transform: substitutes every PushService.swift placeholder
+ * (`{{REGISTER_SNIPPET}}`, `{{CDP_API_KEY}}`, `{{REGION}}`,
+ * `{{AUTO_TRACK_PUSH_EVENTS}}`, `{{AUTO_FETCH_DEVICE_TOKEN}}`,
+ * `{{SHOW_PUSH_APP_IN_FOREGROUND}}`, `{{APP_GROUP_ID_BUILDER_LINE}}`) using
+ * the configured push-notification options. Validation of the rich-push
+ * config (cdpApiKey/region required) is the wrapper's responsibility.
+ */
+export function applyConfigToPushFile(
+  content: string,
   options: CustomerIOPluginOptionsIOS,
-  envFileName: string
-) => {
-  const REGISTER_RE = /\{\{REGISTER_SNIPPET\}\}/;
-
-  let envFileContent = FileManagement.readFile(envFileName);
-  const disableNotificationRegistration =
-    options.pushNotification?.disableNotificationRegistration;
+): string {
   const richPushConfig = options.pushNotification?.env;
   const { cdpApiKey, region } = richPushConfig || {
     cdpApiKey: 'MISSING_API_KEY',
     region: undefined,
   };
-  if (!validateRichPushConfig(richPushConfig)) {
-    return;
-  }
+  const disableNotificationRegistration =
+    options.pushNotification?.disableNotificationRegistration;
 
-  let snippet = '';
   // unless this property is explicitly set to true, push notification
   // registration will be added to the AppDelegate
-  if (disableNotificationRegistration !== true) {
-    snippet = CIO_REGISTER_PUSHNOTIFICATION_SNIPPET;
-  }
-  envFileContent = replaceCodeByRegex(envFileContent, REGISTER_RE, snippet);
+  const registerSnippet = disableNotificationRegistration !== true
+    ? CIO_REGISTER_PUSHNOTIFICATION_SNIPPET
+    : '';
 
-  envFileContent = replaceCodeByRegex(
-    envFileContent,
-    /\{\{CDP_API_KEY\}\}/,
-    cdpApiKey,
-  );
+  let next = replaceCodeByRegex(content, /\{\{REGISTER_SNIPPET\}\}/, registerSnippet);
+  next = replaceCodeByRegex(next, /\{\{CDP_API_KEY\}\}/, cdpApiKey);
 
   if (region) {
-    envFileContent = replaceCodeByRegex(
-      envFileContent,
-      /\{\{REGION\}\}/,
-      region.toUpperCase()
-    );
+    next = replaceCodeByRegex(next, /\{\{REGION\}\}/, region.toUpperCase());
   }
 
   const autoTrackPushEvents =
     options.pushNotification?.autoTrackPushEvents !== false;
-  envFileContent = replaceCodeByRegex(
-    envFileContent,
+  next = replaceCodeByRegex(
+    next,
     /\{\{AUTO_TRACK_PUSH_EVENTS\}\}/,
-    autoTrackPushEvents.toString()
+    autoTrackPushEvents.toString(),
   );
 
   const autoFetchDeviceToken =
     options.pushNotification?.autoFetchDeviceToken !== false;
-  envFileContent = replaceCodeByRegex(
-    envFileContent,
+  next = replaceCodeByRegex(
+    next,
     /\{\{AUTO_FETCH_DEVICE_TOKEN\}\}/,
-    autoFetchDeviceToken.toString()
+    autoFetchDeviceToken.toString(),
   );
 
   const showPushAppInForeground =
     options.pushNotification?.showPushAppInForeground !== false;
-  envFileContent = replaceCodeByRegex(
-    envFileContent,
+  next = replaceCodeByRegex(
+    next,
     /\{\{SHOW_PUSH_APP_IN_FOREGROUND\}\}/,
-    showPushAppInForeground.toString()
+    showPushAppInForeground.toString(),
   );
 
   const appGroupId = options.pushNotification?.appGroupId;
   const appGroupIdBuilderLine = appGroupId
     ? `        .appGroupId(${JSON.stringify(appGroupId)})\n`
     : '';
-  envFileContent = replaceCodeByRegex(
-    envFileContent,
+  next = replaceCodeByRegex(
+    next,
     /\{\{APP_GROUP_ID_BUILDER_LINE\}\}/,
-    appGroupIdBuilderLine
+    appGroupIdBuilderLine,
   );
 
-  FileManagement.writeFile(envFileName, envFileContent);
+  return next;
+}
+
+const updatePushFile = (
+  options: CustomerIOPluginOptionsIOS,
+  envFileName: string
+) => {
+  const richPushConfig = options.pushNotification?.env;
+  if (!validateRichPushConfig(richPushConfig)) {
+    return;
+  }
+  const next = applyConfigToPushFile(FileManagement.readFile(envFileName), options);
+  FileManagement.writeFile(envFileName, next);
 };


### PR DESCRIPTION
[MBL-1671: \[Mobile-Expo\] Speed up Expo plugin compatibility testing with fixture-based tests](https://linear.app/customerio/issue/MBL-1671/mobile-expo-speed-up-expo-plugin-compatibility-testing-with-fixture)

## Overview

This is the second of six stacked PRs introducing a tiered testing approach for the plugin. Today every PR runs a full `expo prebuild → real native build` matrix on macOS — slow, expensive, and narrow in coverage. The new tiers:

1. **Fast Jest scenario suite (PR-time)** — pure-helper unit tests against hand-curated, version-pinned fixtures, parameterized over config variants, idempotency checks, and negative-template inputs. Runs on `ubuntu-latest` in seconds.
2. **Slim 3-cell smoke matrix (PR-time)** — Android + iOS APN + iOS FCM at the latest SDK, real `expo prebuild` + native build. Catches Gradle / CocoaPods / xcodebuild regressions a fast suite can't see.
3. **Release-gated full matrix** — today's full matrix moves behind merges to `main` via `workflow_run` chaining, so it remains the deep backstop without blocking every PR.

Together with PR 1, this PR finishes the prep step for tier 1: each plugin mod's transformation logic is now addressable as a pure function that the scenario suite can drive without going through `expo prebuild`.

## Stack

- PR 1: Android pure-helper extractions — refactor only.
- **➡️ PR 2 (this PR): iOS pure-helper extractions** — refactor only. Stacked on PR 1.
- PR 3: Test infrastructure + Android scenario coverage — additive tests, no `plugin/src/` changes.
- PR 4: iOS scenario coverage + pbxproj fixture set — additive tests.
- PR 5: CI restructure — slim PR-time matrix, release-gating workflow chained off `main`.
- PR 6: Delete legacy snapshot tier — runs after one stable release cycle on the new setup.

## What this PR ships

The transformation logic inside each iOS `withXxx` mod that still inlined string manipulation in its callback is factored out into a named, exported, pure helper, mirroring PR 1's Android pattern and the `modifyObjcAppDelegate` / `modifyAppDelegate` convention used by Firebase and Sentry config plugins.

This is intentionally a **refactor-only** PR: no wrapper signatures change, no behavior changes, no test edits. The existing iOS mock tests pass unchanged — that's the load-bearing evidence that this is behavior-preserving. If any wrapper signature or output had shifted, those tests would have failed.

Of the seven iOS modules, three needed extraction (the AppDelegate Objective-C orchestrator, the Swift AppDelegate orchestrators for the push and no-push paths, and the FCM `GoogleService-Info.plist` copy step). The other four are deliberately untouched: one is a pure orchestrator, one is a thin wrapper around an already-factored helper, the utility module exports were already pure, and the notifications Xcode mod's pure-string portions already live in a dedicated helper file.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typescript` — clean
- [x] iOS mock tests (`withCIOIos`, `withCIOIosSwift`, `injectCIOPodfileCode`, `appGroupId`) — all green
- [x] Android + utils sanity tests — all green
- [ ] `Validate Plugin Compatibility` full matrix runs green via the existing PR triggers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a refactor, but it touches iOS build-time code generation (Podfile/AppDelegate/Xcode project mutations), where small string/ordering differences could break prebuilds or cause duplicate/incorrect project entries.
> 
> **Overview**
> Refactors the iOS plugin mods to **extract exported, pure transformation helpers** for Podfile injection, AppDelegate (Obj-C and Swift) edits, GoogleService-Info.plist copying, and Notification Service Extension project setup.
> 
> Wrapper mods now mostly read existing files, call the new helpers (e.g., `injectHostAppPodfileCode`, `appendNotificationTargetToPodfile`, `modifyAppDelegateContents`/`modifyAppDelegateHeader`, `copyGoogleServicePlistFile`, `addNotificationServiceExtensionToXcodeProject`, and template-appliers like `applyConfigToPushFile`), then write/apply changes only when the output differs to preserve idempotency and reduce redundant work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f73fb2ef8458ced5cdeea444a658fd9f7587cf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->