### PR TITLE
fix: pass App token to actions/checkout in deploy-sdk

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -26,7 +26,9 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.CIO_APP_ID }}
+          # Client ID of the cio-mobile-release GitHub App. Public value
+          # (visible in the App's settings URL); no need to store as a secret.
+          client-id: Iv23lioetkOFxtjR0Ezu
           private-key: ${{ secrets.CIO_APP_SECRET }}
 
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -30,6 +30,8 @@ jobs:
           private_key: ${{ secrets.CIO_APP_SECRET }}
 
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Deploy git tag via semantic release
         uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4.2.0

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -26,9 +26,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          # Client ID of the cio-mobile-release GitHub App. Public value
-          # (visible in the App's settings URL); no need to store as a secret.
-          client-id: Iv23lioetkOFxtjR0Ezu
+          client-id: ${{ secrets.CIO_APP_CLIENT_ID }}
           private-key: ${{ secrets.CIO_APP_SECRET }}
 
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -24,10 +24,10 @@ jobs:
 
       - name: 'Generate token'
         id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app_id: ${{ secrets.CIO_APP_ID }}
-          private_key: ${{ secrets.CIO_APP_SECRET }}
+          app-id: ${{ secrets.CIO_APP_ID }}
+          private-key: ${{ secrets.CIO_APP_SECRET }}
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Overview

`Deploy SDK` was failing on the `main` ruleset with `GH013: Repository rule violations found … Changes must be made through a pull request`, despite the workflow correctly minting a GitHub App installation token from `CIO_APP_ID` / `CIO_APP_SECRET` and exposing it to `semantic-release` as `GITHUB_TOKEN`.

Root cause: `actions/checkout@v4` with no `token:` input persists the default `GITHUB_TOKEN` (= `github-actions[bot]`) into local git config under `http.https://github.com/.extraheader`. When `@semantic-release/git` later runs `git push https://github.com/customerio/customerio-expo-plugin HEAD:main` with no embedded credentials, git resolves auth from that persisted header — not from the step-level `GITHUB_TOKEN` env var. The push goes out as `github-actions[bot]`, which is not on the ruleset bypass list, hence the rejection.

## This PR

Adds `with: { token: \${{ steps.generate_token.outputs.token }} }` to the `actions/checkout@v4` step in `deploy-sdk.yml` so the persisted git credentials are the App installation token, matching the identity on the ruleset bypass list. No other change.

## Verification

The diagnostic probe in #351 ran four sha256 comparisons on a recent run:

```
App installation token         : 5499ac77446448f09cecb8cee6e5c5f7585fd9af570f8a21b11c46db58fa5909
Default GITHUB_TOKEN           : 5004ab8aa2a2f834619cf294e17de7ba8c8eed6507b80ff9f75576744c856f16
Persisted by default checkout  : 5004ab8aa2a2f834619cf294e17de7ba8c8eed6507b80ff9f75576744c856f16
Persisted by app-token checkout: 5499ac77446448f09cecb8cee6e5c5f7585fd9af570f8a21b11c46db58fa5909
```

The default checkout persists `GITHUB_TOKEN`; the `token:`-input checkout persists the App token. After this PR merges, the `git push` inside `semantic-release` will authenticate as the App.

## Test plan

- [ ] Merge this PR. `Deploy SDK` runs on the resulting push to `main`; confirm it completes without GH013 and creates the next git tag.
- [ ] Confirm the new release commit on `main` is authored by the deploy App (not `github-actions[bot]`).
- [ ] Once green, close #351 and delete the `chore/debug-app-token-bypass` branch — the probe workflow can be removed in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow/auth change that only affects how the `Deploy SDK` job authenticates during `checkout` and subsequent pushes; main risk is misconfigured secrets/input names causing the deploy workflow to fail.
> 
> **Overview**
> Fixes `Deploy SDK` deployments by ensuring git operations authenticate as the GitHub App instead of the default `GITHUB_TOKEN`.
> 
> Updates `.github/workflows/deploy-sdk.yml` to mint the token via `actions/create-github-app-token` and passes the resulting token into `actions/checkout@v4`, so `semantic-release`/`@semantic-release/git` pushes use the App identity and can bypass repo rulesets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 935f1b4e4e27beb82600a2a631af1ef0e724b162. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->