### PR TITLE
chore: debug workflow to verify app-token bypass identity (stacked on #352)

### DIFF
--- a/.github/workflows/debug-app-token.yml
+++ b/.github/workflows/debug-app-token.yml
@@ -1,19 +1,24 @@
 name: Debug App Token Bypass
 
-# Manually-triggered probe to verify which identity actually pushes to main
-# during the deploy-sdk workflow. Two questions this answers:
-#   1. What is the slug of the App minted from CIO_APP_ID / CIO_APP_SECRET?
-#      (This is the identity that must appear on the ruleset bypass list.)
-#   2. After `actions/checkout@v4` with no `token:` set, whose credentials
-#      get persisted into local git config and used by later `git push`?
+# Probe to verify which token actually authenticates `git push` from the
+# deploy-sdk workflow. Hypothesis: `actions/checkout@v4` with no `token:`
+# input persists the default GITHUB_TOKEN (= github-actions[bot]) into
+# local git config (`http.https://github.com/.extraheader`), so a later
+# `git push` — including the one inside @semantic-release/git — uses
+# THAT token rather than the App token exposed only as a step-level env
+# var. github-actions[bot] is not on the ruleset bypass list, hence the
+# GH013 rejection.
 #
-# The hypothesis: a default checkout persists GITHUB_TOKEN
-# (= github-actions[bot]), which overrides the App token even when the App
-# token is exported as the GITHUB_TOKEN env var to a later step. That bot is
-# not on the ruleset bypass list, hence "Changes must be made through a pull
-# request."
+# Method: mint the App installation token, then run actions/checkout twice
+# (default vs `token: <app-token>`) and after each, decode the persisted
+# auth header and compare its SHA-256 to the App token's SHA-256.
 #
-# This workflow does NOT push anything. It only inspects token identities.
+#   default checkout    -> expected: persisted token != App token
+#   `token:` checkout   -> expected: persisted token == App token
+#
+# Hashes are safe to print; the raw tokens are not.
+#
+# This workflow does not push anything.
 
 on:
   workflow_dispatch:
@@ -35,44 +40,41 @@ jobs:
           app_id: ${{ secrets.CIO_APP_ID }}
           private_key: ${{ secrets.CIO_APP_SECRET }}
 
-      - name: Identify App-token identity (must match ruleset bypass entry)
+      - name: Hash the App installation token
+        id: app_hash
         env:
           TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
-          echo "::group::App identity from CIO_APP_ID"
-          curl -sS \
-            -H "Authorization: Bearer $TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/app \
-            | jq '{slug, id, name, owner: .owner.login}'
-          echo "::endgroup::"
+          HASH=$(printf '%s' "$TOKEN" | sha256sum | cut -d' ' -f1)
+          echo "App-token sha256: $HASH"
+          echo "app_token_sha=$HASH" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout WITHOUT app token (default — current deploy-sdk.yml behavior)
+      - name: Hash the default GITHUB_TOKEN
+        id: default_hash
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          HASH=$(printf '%s' "$TOKEN" | sha256sum | cut -d' ' -f1)
+          echo "Default GITHUB_TOKEN sha256: $HASH"
+          echo "default_token_sha=$HASH" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout WITHOUT app token (default - current deploy-sdk.yml behavior)
         uses: actions/checkout@v4
 
-      - name: Decode credentials persisted by default checkout
+      - name: Hash credentials persisted by default checkout
+        id: default_persisted
         run: |
-          echo "::group::Local git http config after default checkout"
-          git config --local --list | grep -iE 'http|extraheader' || echo "(none)"
-          echo "::endgroup::"
-
           HEADER=$(git config --local http.https://github.com/.extraheader || true)
           BASIC=$(printf '%s' "$HEADER" | sed -n 's/^AUTHORIZATION: basic //ip')
           if [ -z "$BASIC" ]; then
-            echo "No persisted auth header found — nothing to decode."
-            exit 0
+            echo "No persisted auth header found."
+            exit 1
           fi
-
           DECODED=$(printf '%s' "$BASIC" | base64 -d 2>/dev/null || true)
           PERSISTED=$(printf '%s' "$DECODED" | sed 's/^x-access-token://')
-
-          echo "::group::Identity of the persisted token (this is what 'git push' would use)"
-          curl -sS \
-            -H "Authorization: Bearer $PERSISTED" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/app \
-            | jq '{slug, id, name}' || true
-          echo "::endgroup::"
+          HASH=$(printf '%s' "$PERSISTED" | sha256sum | cut -d' ' -f1)
+          echo "Persisted-after-default-checkout sha256: $HASH"
+          echo "persisted_sha=$HASH" >> "$GITHUB_OUTPUT"
 
       - name: Re-checkout WITH app token (proposed fix)
         uses: actions/checkout@v4
@@ -80,29 +82,46 @@ jobs:
           token: ${{ steps.app_token.outputs.token }}
           clean: true
 
-      - name: Decode credentials persisted by app-token checkout
+      - name: Hash credentials persisted by app-token checkout
+        id: appcheckout_persisted
         run: |
           HEADER=$(git config --local http.https://github.com/.extraheader || true)
           BASIC=$(printf '%s' "$HEADER" | sed -n 's/^AUTHORIZATION: basic //ip')
           DECODED=$(printf '%s' "$BASIC" | base64 -d 2>/dev/null || true)
           PERSISTED=$(printf '%s' "$DECODED" | sed 's/^x-access-token://')
+          HASH=$(printf '%s' "$PERSISTED" | sha256sum | cut -d' ' -f1)
+          echo "Persisted-after-app-token-checkout sha256: $HASH"
+          echo "persisted_sha=$HASH" >> "$GITHUB_OUTPUT"
 
-          echo "::group::Identity of the persisted token after passing token: to checkout"
-          curl -sS \
-            -H "Authorization: Bearer $PERSISTED" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/app \
-            | jq '{slug, id, name}'
-          echo "::endgroup::"
-
-      - name: Summary
+      - name: Compare hashes and report
+        env:
+          APP_SHA:                   ${{ steps.app_hash.outputs.app_token_sha }}
+          DEFAULT_SHA:               ${{ steps.default_hash.outputs.default_token_sha }}
+          DEFAULT_PERSISTED_SHA:     ${{ steps.default_persisted.outputs.persisted_sha }}
+          APPCHECKOUT_PERSISTED_SHA: ${{ steps.appcheckout_persisted.outputs.persisted_sha }}
         run: |
-          echo "Compare the two persisted-token identities above."
-          echo "  - Default checkout should resolve to the 'github-actions' app"
-          echo "    (the identity 'github-actions[bot]', which is NOT on the bypass list)."
-          echo "  - App-token checkout should resolve to the same slug printed in"
-          echo "    the first step (the App you added to the bypass list)."
+          echo "App installation token         : $APP_SHA"
+          echo "Default GITHUB_TOKEN           : $DEFAULT_SHA"
+          echo "Persisted by default checkout  : $DEFAULT_PERSISTED_SHA"
+          echo "Persisted by app-token checkout: $APPCHECKOUT_PERSISTED_SHA"
           echo
-          echo "If those two identities differ, the hypothesis is confirmed:"
-          echo "the default checkout persists creds that override the App token"
-          echo "during 'git push' in semantic-release."
+
+          if [ "$DEFAULT_PERSISTED_SHA" = "$DEFAULT_SHA" ]; then
+            echo "PASS: Default checkout persisted the default GITHUB_TOKEN."
+          elif [ "$DEFAULT_PERSISTED_SHA" = "$APP_SHA" ]; then
+            echo "FAIL: Default checkout persisted the App token - hypothesis WRONG."
+          else
+            echo "WARN: Default checkout persisted a token matching neither - unexpected."
+          fi
+
+          if [ "$APPCHECKOUT_PERSISTED_SHA" = "$APP_SHA" ]; then
+            echo "PASS: App-token checkout persisted the App installation token."
+          else
+            echo "FAIL: App-token checkout did NOT persist the App token - unexpected."
+          fi
+
+          echo
+          if [ "$DEFAULT_PERSISTED_SHA" = "$DEFAULT_SHA" ] \
+             && [ "$APPCHECKOUT_PERSISTED_SHA" = "$APP_SHA" ]; then
+            echo "HYPOTHESIS CONFIRMED: deploy-sdk.yml needs 'token: \${{ steps.generate_token.outputs.token }}' on actions/checkout."
+          fi

--- a/.github/workflows/debug-app-token.yml
+++ b/.github/workflows/debug-app-token.yml
@@ -17,6 +17,9 @@ name: Debug App Token Bypass
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/debug-app-token.yml
 
 permissions:
   contents: read

--- a/.github/workflows/debug-app-token.yml
+++ b/.github/workflows/debug-app-token.yml
@@ -35,10 +35,10 @@ jobs:
     steps:
       - name: Generate App installation token
         id: app_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app_id: ${{ secrets.CIO_APP_ID }}
-          private_key: ${{ secrets.CIO_APP_SECRET }}
+          app-id: ${{ secrets.CIO_APP_ID }}
+          private-key: ${{ secrets.CIO_APP_SECRET }}
 
       - name: Hash the App installation token
         id: app_hash

--- a/.github/workflows/debug-app-token.yml
+++ b/.github/workflows/debug-app-token.yml
@@ -1,0 +1,105 @@
+name: Debug App Token Bypass
+
+# Manually-triggered probe to verify which identity actually pushes to main
+# during the deploy-sdk workflow. Two questions this answers:
+#   1. What is the slug of the App minted from CIO_APP_ID / CIO_APP_SECRET?
+#      (This is the identity that must appear on the ruleset bypass list.)
+#   2. After `actions/checkout@v4` with no `token:` set, whose credentials
+#      get persisted into local git config and used by later `git push`?
+#
+# The hypothesis: a default checkout persists GITHUB_TOKEN
+# (= github-actions[bot]), which overrides the App token even when the App
+# token is exported as the GITHUB_TOKEN env var to a later step. That bot is
+# not on the ruleset bypass list, hence "Changes must be made through a pull
+# request."
+#
+# This workflow does NOT push anything. It only inspects token identities.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate App installation token
+        id: app_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.CIO_APP_ID }}
+          private_key: ${{ secrets.CIO_APP_SECRET }}
+
+      - name: Identify App-token identity (must match ruleset bypass entry)
+        env:
+          TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          echo "::group::App identity from CIO_APP_ID"
+          curl -sS \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/app \
+            | jq '{slug, id, name, owner: .owner.login}'
+          echo "::endgroup::"
+
+      - name: Checkout WITHOUT app token (default — current deploy-sdk.yml behavior)
+        uses: actions/checkout@v4
+
+      - name: Decode credentials persisted by default checkout
+        run: |
+          echo "::group::Local git http config after default checkout"
+          git config --local --list | grep -iE 'http|extraheader' || echo "(none)"
+          echo "::endgroup::"
+
+          HEADER=$(git config --local http.https://github.com/.extraheader || true)
+          BASIC=$(printf '%s' "$HEADER" | sed -n 's/^AUTHORIZATION: basic //ip')
+          if [ -z "$BASIC" ]; then
+            echo "No persisted auth header found — nothing to decode."
+            exit 0
+          fi
+
+          DECODED=$(printf '%s' "$BASIC" | base64 -d 2>/dev/null || true)
+          PERSISTED=$(printf '%s' "$DECODED" | sed 's/^x-access-token://')
+
+          echo "::group::Identity of the persisted token (this is what 'git push' would use)"
+          curl -sS \
+            -H "Authorization: Bearer $PERSISTED" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/app \
+            | jq '{slug, id, name}' || true
+          echo "::endgroup::"
+
+      - name: Re-checkout WITH app token (proposed fix)
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app_token.outputs.token }}
+          clean: true
+
+      - name: Decode credentials persisted by app-token checkout
+        run: |
+          HEADER=$(git config --local http.https://github.com/.extraheader || true)
+          BASIC=$(printf '%s' "$HEADER" | sed -n 's/^AUTHORIZATION: basic //ip')
+          DECODED=$(printf '%s' "$BASIC" | base64 -d 2>/dev/null || true)
+          PERSISTED=$(printf '%s' "$DECODED" | sed 's/^x-access-token://')
+
+          echo "::group::Identity of the persisted token after passing token: to checkout"
+          curl -sS \
+            -H "Authorization: Bearer $PERSISTED" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/app \
+            | jq '{slug, id, name}'
+          echo "::endgroup::"
+
+      - name: Summary
+        run: |
+          echo "Compare the two persisted-token identities above."
+          echo "  - Default checkout should resolve to the 'github-actions' app"
+          echo "    (the identity 'github-actions[bot]', which is NOT on the bypass list)."
+          echo "  - App-token checkout should resolve to the same slug printed in"
+          echo "    the first step (the App you added to the bypass list)."
+          echo
+          echo "If those two identities differ, the hypothesis is confirmed:"
+          echo "the default checkout persists creds that override the App token"
+          echo "during 'git push' in semantic-release."

--- a/.github/workflows/debug-app-token.yml
+++ b/.github/workflows/debug-app-token.yml
@@ -37,7 +37,7 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.CIO_APP_ID }}
+          client-id: ${{ secrets.CIO_APP_CLIENT_ID }}
           private-key: ${{ secrets.CIO_APP_SECRET }}
 
       - name: App identity (must match the ruleset bypass entry)

--- a/.github/workflows/debug-app-token.yml
+++ b/.github/workflows/debug-app-token.yml
@@ -40,6 +40,16 @@ jobs:
           app-id: ${{ secrets.CIO_APP_ID }}
           private-key: ${{ secrets.CIO_APP_SECRET }}
 
+      - name: App identity (must match the ruleset bypass entry)
+        env:
+          APP_SLUG: ${{ steps.app_token.outputs.app-slug }}
+          INSTALLATION_ID: ${{ steps.app_token.outputs.installation-id }}
+        run: |
+          echo "App slug       : $APP_SLUG"
+          echo "Installation ID: $INSTALLATION_ID"
+          echo "Pushes use the identity '${APP_SLUG}[bot]'."
+          echo "Verify Settings > Rules > Rulesets > main > Bypass list contains an entry for this App."
+
       - name: Hash the App installation token
         id: app_hash
         env:

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -26,7 +26,9 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.CIO_APP_ID }}
+          # Client ID of the cio-mobile-release GitHub App. Public value
+          # (visible in the App's settings URL); no need to store as a secret.
+          client-id: Iv23lioetkOFxtjR0Ezu
           private-key: ${{ secrets.CIO_APP_SECRET }}
 
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -30,6 +30,8 @@ jobs:
           private_key: ${{ secrets.CIO_APP_SECRET }}
 
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Deploy git tag via semantic release
         uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4.2.0

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -26,9 +26,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          # Client ID of the cio-mobile-release GitHub App. Public value
-          # (visible in the App's settings URL); no need to store as a secret.
-          client-id: Iv23lioetkOFxtjR0Ezu
+          client-id: ${{ secrets.CIO_APP_CLIENT_ID }}
           private-key: ${{ secrets.CIO_APP_SECRET }}
 
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -24,10 +24,10 @@ jobs:
 
       - name: 'Generate token'
         id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app_id: ${{ secrets.CIO_APP_ID }}
-          private_key: ${{ secrets.CIO_APP_SECRET }}
+          app-id: ${{ secrets.CIO_APP_ID }}
+          private-key: ${{ secrets.CIO_APP_SECRET }}
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Overview

Diagnostic probe for the deploy-sdk failure where pushes to `main` were rejected with `GH013 / Changes must be made through a pull request`. Stacked on top of #352 so the workflow exercises the same App-token-minting path as the production deploy.

Two facts the probe verifies:

1. **App slug** — the App minted from `CIO_APP_ID` / `CIO_APP_SECRET` reports its `app-slug` directly from `actions/create-github-app-token`'s outputs. That slug must appear on the `main` ruleset bypass list with mode **Always**. Pushes from this App go out under the identity `<slug>[bot]`.
2. **Persisted-credentials hypothesis** — `actions/checkout@v4` with no `token:` input persists the default `GITHUB_TOKEN` into `http.https://github.com/.extraheader`, so a later `git push` uses *that* token instead of any App token exposed only as a step-level env var. The probe SHA-256-compares (a) the App token, (b) the default `GITHUB_TOKEN`, (c) what default checkout persisted, and (d) what `with: token: <app-token>` checkout persisted, and asserts (a)≠(c) and (a)=(d).

## This PR

Adds `.github/workflows/debug-app-token.yml`, a `workflow_dispatch` + `pull_request` (path-scoped) probe that prints:
- `App slug` and `Installation ID` from the create-github-app-token outputs.
- Four sha256 hashes for the comparison described above.
- A summary line confirming the hypothesis.

The workflow does not push anything, runs with `permissions: contents: read`, and has no side effects.

## Expected output

```
App slug       : <your-app-slug>
Installation ID: <numeric-id>

App installation token         : <hash-A>
Default GITHUB_TOKEN           : <hash-B>
Persisted by default checkout  : <hash-B>   <- matches default
Persisted by app-token checkout: <hash-A>   <- matches app token

PASS: Default checkout persisted the default GITHUB_TOKEN.
PASS: App-token checkout persisted the App installation token.

HYPOTHESIS CONFIRMED: ...
```

## Test plan

- [ ] Auto-runs on this PR via `pull_request` trigger.
- [ ] Confirm the printed `App slug` matches the App entry on Settings > Rules > Rulesets > `main` > Bypass list.
- [ ] Confirm both PASS lines and `HYPOTHESIS CONFIRMED` appear.
- [ ] Once #352 merges and the next `Deploy SDK` run succeeds against `main`, this PR can be closed and the branch + workflow file removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)