### PR TITLE
chore(ci): skip CI on the semantic-release commit

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -23,7 +23,7 @@
           "CHANGELOG.md",
           "package.json"
         ],
-        "message": "chore: prepare for ${nextRelease.version}\n\n${nextRelease.notes}"
+        "message": "chore: prepare for ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
     ["@semantic-release/github", {


### PR DESCRIPTION
## Overview

After #352, the semantic-release "prepare for X.Y.Z" commit is pushed by `cio-mobile-release[bot]` (a GitHub App installation token), not the workflow's auto-`GITHUB_TOKEN`. GitHub's recursion guard (which suppresses workflow runs triggered by `GITHUB_TOKEN`) does not apply to App pushes, so:

- `Deploy SDK` now self-triggers on its own release-prep commit. semantic-release no-ops because there are no new commits to release, but a runner still spins.
- `Lint`, `Test`, `Check API Changes`, `Validate Plugin Compat`, and `Publish test apps` always ran on release-prep commits — pre-#352 with `actor` inherited from the human PR merger, post-#352 with `actor=cio-mobile-release[bot]`. Either way, validating a CHANGELOG-only commit is wasted runner time.

Verified empirically against `d540269` (3.4.0, post-#352) vs `f563703` (3.3.0, pre-#352):

| Commit | actor | Deploy SDK ran? |
|---|---|---|
| `f563703` (pre-#352) | `mahmoud-elmorabea` | No (recursion guard) |
| `d540269` (post-#352) | `cio-mobile-release[bot]` | **Yes** (recursive) |

## This PR

Append `[skip ci]` to the `@semantic-release/git` commit-message template in `.releaserc.json`:

```diff
-"message": "chore: prepare for ${nextRelease.version}\n\n${nextRelease.notes}"
+"message": "chore: prepare for ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
```

GitHub evaluates `[skip ci]` against the head commit message of the push, regardless of pusher identity, and applies the skip to both `push` and `pull_request` events. This silences the recursive `Deploy SDK` run *and* every other push-listening workflow for the release-prep commit. One line, no per-job actor guards, no boilerplate tax on future workflows.

Reference: [Skipping workflow runs - GitHub Docs](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs).

### Limitations to be aware of

- Skip directives only apply to `push` and `pull_request`. `pull_request_target`, `schedule`, and merge queue events are explicitly **not** suppressed by the docs. Tag-only triggers (`on: push: tags:`) aren't documented either way; today no workflow uses them, but if one is added later, an actor guard would be the right complement.
- A workflow skipped via `[skip ci]` leaves any required-checks in `Pending` state. Doesn't bite us — the release-prep commit lands directly on `main` without a PR — but worth knowing.

## Test plan

- [ ] Merge #352 first, then this PR.
- [ ] Wait for the next release-prep commit to land on `main`. The commit message should end with ` [skip ci]`.
- [ ] Verify `gh run list --commit <sha>` returns no runs (or only ignored/skipped runs) for that commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the semantic-release git commit message template to include `[skip ci]`, affecting when GitHub Actions runs but not application logic.
> 
> **Overview**
> Updates semantic-release’s `@semantic-release/git` commit message template in `.releaserc.json` to append `[skip ci]` to the release “prepare for X.Y.Z” commit, preventing GitHub Actions workflows from running on that autogenerated commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82df1b2a153a89db4f4567d202c657add5552948. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->