### PR TITLE
ci: prune push triggers — main only

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -3,7 +3,7 @@ name: Publish test apps
 on:
   pull_request:
   push:
-    branches: [ main, beta, feature/* ]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/check-api-changes.yml
+++ b/.github/workflows/check-api-changes.yml
@@ -3,7 +3,7 @@ name: Check API Changes
 on:
   pull_request:
   push:
-    branches: [main, beta, feature/*]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: Lint and TypeScript
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   pull_request:
   push:
-    branches: [ main, beta, feature/* ]
+    branches: [main]
 
 jobs:
   test-deploy:


### PR DESCRIPTION
## Overview

The fast PR-time workflows currently fire **twice** on every push to a `feature/*` branch — once as the PR event, once as the push event — and `lint.yml`'s blanket `push:` fires on *every* push to *every* branch. With \`beta\` no longer used as an integration branch, the simple fix is to drop everything except \`main\` from push triggers and let \`pull_request:\` cover the rest.

## What's in this PR

| File | Before (push branches) | After |
| --- | --- | --- |
| \`lint.yml\` | \`push:\` (no filter — every branch) | \`[main]\` |
| \`check-api-changes.yml\` | \`[main, beta, feature/*]\` | \`[main]\` |
| \`test.yml\` | \`[main, beta, feature/*]\` | \`[main]\` |
| \`build-sample-apps.yml\` | \`[main, beta, feature/*]\` | \`[main]\` |

\`pull_request:\` is preserved on every workflow that had it, so:
- Every PR still runs lint / typecheck / api-extractor / Jest projects / scenario suite / smoke matrix.
- Feature-branch sample-app builds still publish to Firebase via the PR event in \`build-sample-apps.yml\`.
- Post-merge signal on \`main\` (the release branch) is preserved.

## What this fixes

- Closes the documented \`feature/*\` CI double-trigger on the umbrella branch.
- Stops \`lint.yml\` firing on unrelated pushes (e.g. experiment branches with no PR).
- Removes \`beta\` from triggers since the team has moved off it.

## Out of scope (flagged for follow-up)

\`reusable_build_sample_apps.yml\` lines 60 and 184 still reference \`refs/heads/beta\` for Firebase distribution-group assignment. That's runtime branch-routing logic, not a trigger — now dead code, but left here so this PR stays focused. Easy follow-up to delete the \`beta\` arm from those checks.

## Risk

If any of these workflow names are wired into branch protection / a GitHub Ruleset as **required status checks** on \`beta\`, those checks will stop reporting on \`beta\` pushes. Worth a quick \`gh api repos/customerio/customerio-expo-plugin/rulesets\` before merging if anything's wired up to \`beta\` specifically.

## Test plan

- [ ] PR-trigger runs of all four workflows fire on this PR (lint, check-api-changes, test, smoke matrix, build-sample-apps)
- [ ] After merging into \`feature/fixture-based-tests\`, a follow-up push to that umbrella branch should fire each workflow **once**, not twice (PR event only)
- [ ] After merging the umbrella to \`main\`, \`main\` still receives full post-merge signal
- [ ] Confirm no required status check on \`beta\` is silently dropped