### PR TITLE
fix: cover AppDelegate.swift per pinned SDK with fixtures

### DIFF
--- a/.github/workflows/validate-plugin-compatibility-matrix.yml
+++ b/.github/workflows/validate-plugin-compatibility-matrix.yml
@@ -134,6 +134,7 @@ jobs:
         run: |
           npm run compatibility:validate-plugin -- \
             --app-path=${{ env.APP_PATH }} \
+            --expo-version=${{ matrix.expo-version }} \
             --platforms=${{ matrix.platform }}\
             --ios-use-frameworks="static" \
             ${{ matrix.ios-push-provider && format(' --ios-push-providers={0}', matrix.ios-push-provider) }}

--- a/.github/workflows/validate-plugin-compatibility.yml
+++ b/.github/workflows/validate-plugin-compatibility.yml
@@ -116,6 +116,7 @@ jobs:
         run: |
           npm run compatibility:validate-plugin -- \
             --app-path=${{ env.APP_PATH }} \
+            --expo-version=latest \
             --platforms=${{ matrix.platform }}\
             --ios-use-frameworks="static" \
             ${{ matrix.ios-push-provider && format(' --ios-push-providers={0}', matrix.ios-push-provider) }}

--- a/__tests__/android/__snapshots__/main-application-modifications.test.js.snap
+++ b/__tests__/android/__snapshots__/main-application-modifications.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Expo 54+ MainApplication tests Plugin injects CIO initializer into MainApplication.kt 1`] = `
+exports[`Expo 54 MainApplication tests Plugin injects CIO initializer into MainApplication.kt 1`] = `
 "package io.customer.testbed.expo
 
 import android.app.Application

--- a/__tests__/android/main-application-modifications.test.js
+++ b/__tests__/android/main-application-modifications.test.js
@@ -1,7 +1,6 @@
 const {
   testAppPath,
   getTestAppAndroidJavaSourcePath,
-  isExpoVersionAtLeast,
   isExpoVersionLatest,
 } = require('../utils');
 const fs = require('fs-extra');
@@ -10,33 +9,18 @@ const path = require('path');
 const testProjectPath = testAppPath();
 const androidPath = path.join(testProjectPath, 'android');
 
-// The snapshot is pinned to Expo SDK 54's MainApplication.kt template
-// (`ReactNativeHostWrapper` + `DefaultReactNativeHost`). SDK 55 rewrote the
-// host bootstrap to use `ExpoReactHostFactory.getDefaultReactHost`, so the
-// snapshot will not match newer SDKs. Until per-SDK fixtures are added for
-// Android (mirroring `__tests__/scenarios/ios/appDelegateSwiftSdkVersions`),
-// scope this test to the pinned SDK 54 row only.
-const runsExpo54Snapshot =
-  !isExpoVersionLatest() &&
-  isExpoVersionAtLeast('54.0.0') &&
-  !isExpoVersionAtLeast('55.0.0');
-
-describe('Expo 54 MainApplication tests', () => {
+// Full-file prebuild snapshot — only runs on the `latest` row of the
+// compatibility matrix. Pinned SDK rows (currently 54) get scenario tests
+// in __tests__/scenarios/android/mainApplicationVersions.test.ts which run
+// the pure transform against vanilla CLI-generated fixtures.
+(isExpoVersionLatest() ? describe : describe.skip)('Expo latest MainApplication tests', () => {
   const mainApplicationPath = path.join(
     androidPath,
     getTestAppAndroidJavaSourcePath(),
     'MainApplication.kt'
   );
-  if (runsExpo54Snapshot) {
-    test('Plugin injects CIO initializer into MainApplication.kt', async () => {
-      const content = await fs.readFile(mainApplicationPath, 'utf8');
-      expect(content).toMatchSnapshot();
-    });
-  } else {
-    // Skip name must match the active test name so jest doesn't flag the
-    // SDK-54 snapshot as obsolete on rows where the test is skipped.
-    test.skip('Plugin injects CIO initializer into MainApplication.kt', () => {
-      // Snapshot pinned to Expo SDK 54 template — see comment above.
-    });
-  }
+  test('Plugin injects CIO initializer into MainApplication.kt', async () => {
+    const content = await fs.readFile(mainApplicationPath, 'utf8');
+    expect(content).toMatchSnapshot();
+  });
 });

--- a/__tests__/android/main-application-modifications.test.js
+++ b/__tests__/android/main-application-modifications.test.js
@@ -1,5 +1,4 @@
-const { testAppPath, getTestAppAndroidJavaSourcePath, getExpoVersion } = require('../utils');
-const semver = require('semver');
+const { testAppPath, getTestAppAndroidJavaSourcePath, isExpoVersionAtLeast } = require('../utils');
 const fs = require('fs-extra');
 const path = require('path');
 
@@ -12,7 +11,7 @@ describe('Expo 54+ MainApplication tests', () => {
     getTestAppAndroidJavaSourcePath(),
     'MainApplication.kt'
   );
-  if (semver.gte(semver.coerce(getExpoVersion()), '54.0.0')) {
+  if (isExpoVersionAtLeast('54.0.0')) {
     test('Plugin injects CIO initializer into MainApplication.kt', async () => {
       const content = await fs.readFile(mainApplicationPath, 'utf8');
       expect(content).toMatchSnapshot();

--- a/__tests__/android/main-application-modifications.test.js
+++ b/__tests__/android/main-application-modifications.test.js
@@ -1,24 +1,41 @@
-const { testAppPath, getTestAppAndroidJavaSourcePath, isExpoVersionAtLeast } = require('../utils');
+const {
+  testAppPath,
+  getTestAppAndroidJavaSourcePath,
+  getExpoVersion,
+  isExpoVersionAtLeast,
+  isExpoVersionLatest,
+} = require('../utils');
 const fs = require('fs-extra');
 const path = require('path');
 
 const testProjectPath = testAppPath();
 const androidPath = path.join(testProjectPath, 'android');
 
-describe('Expo 54+ MainApplication tests', () => {
+// The snapshot is pinned to Expo SDK 54's MainApplication.kt template
+// (`ReactNativeHostWrapper` + `DefaultReactNativeHost`). SDK 55 rewrote the
+// host bootstrap to use `ExpoReactHostFactory.getDefaultReactHost`, so the
+// snapshot will not match newer SDKs. Until per-SDK fixtures are added for
+// Android (mirroring `__tests__/scenarios/ios/appDelegateSwiftSdkVersions`),
+// scope this test to the pinned SDK 54 row only.
+const runsExpo54Snapshot =
+  !isExpoVersionLatest() &&
+  isExpoVersionAtLeast('54.0.0') &&
+  !isExpoVersionAtLeast('55.0.0');
+
+describe('Expo 54 MainApplication tests', () => {
   const mainApplicationPath = path.join(
     androidPath,
     getTestAppAndroidJavaSourcePath(),
     'MainApplication.kt'
   );
-  if (isExpoVersionAtLeast('54.0.0')) {
+  if (runsExpo54Snapshot) {
     test('Plugin injects CIO initializer into MainApplication.kt', async () => {
       const content = await fs.readFile(mainApplicationPath, 'utf8');
       expect(content).toMatchSnapshot();
     });
   } else {
-    test.skip('Plugin injects CIO initializer into MainApplication.kt', () => {
-      // Skipped: Only relevant for Expo 54+ (snapshot matches Expo 54 template)
+    test.skip(`Plugin injects CIO initializer into MainApplication.kt (Expo ${getExpoVersion()})`, () => {
+      // Snapshot pinned to Expo SDK 54 template — see comment above.
     });
   }
 });

--- a/__tests__/android/main-application-modifications.test.js
+++ b/__tests__/android/main-application-modifications.test.js
@@ -1,7 +1,6 @@
 const {
   testAppPath,
   getTestAppAndroidJavaSourcePath,
-  getExpoVersion,
   isExpoVersionAtLeast,
   isExpoVersionLatest,
 } = require('../utils');
@@ -34,7 +33,9 @@ describe('Expo 54 MainApplication tests', () => {
       expect(content).toMatchSnapshot();
     });
   } else {
-    test.skip(`Plugin injects CIO initializer into MainApplication.kt (Expo ${getExpoVersion()})`, () => {
+    // Skip name must match the active test name so jest doesn't flag the
+    // SDK-54 snapshot as obsolete on rows where the test is skipped.
+    test.skip('Plugin injects CIO initializer into MainApplication.kt', () => {
       // Snapshot pinned to Expo SDK 54 template — see comment above.
     });
   }

--- a/__tests__/fixtures/android/MainApplication.sdk54.kt
+++ b/__tests__/fixtures/android/MainApplication.sdk54.kt
@@ -1,7 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Expo latest MainApplication tests Plugin injects CIO initializer into MainApplication.kt 1`] = `
-"package io.customer.testbed.expo
+package io.customer.expo.fixture
 
 import android.app.Application
 import android.content.res.Configuration
@@ -9,28 +6,37 @@ import android.content.res.Configuration
 import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
+import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.ReactHost
 import com.facebook.react.common.ReleaseLevel
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
+import com.facebook.react.defaults.DefaultReactNativeHost
 
 import expo.modules.ApplicationLifecycleDispatcher
-import expo.modules.ExpoReactHostFactory
-
-import io.customer.sdk.expo.CustomerIOSDKInitializer
+import expo.modules.ReactNativeHostWrapper
 
 class MainApplication : Application(), ReactApplication {
 
-  override val reactHost: ReactHost by lazy {
-    ExpoReactHostFactory.getDefaultReactHost(
-      context = applicationContext,
-      packageList =
-        PackageList(this).packages.apply {
-          // Packages that cannot be autolinked yet can be added manually here, for example:
-          // add(MyReactNativePackage())
-        }
-    )
-  }
+  override val reactNativeHost: ReactNativeHost = ReactNativeHostWrapper(
+      this,
+      object : DefaultReactNativeHost(this) {
+        override fun getPackages(): List<ReactPackage> =
+            PackageList(this).packages.apply {
+              // Packages that cannot be autolinked yet can be added manually here, for example:
+              // add(MyReactNativePackage())
+            }
+
+          override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"
+
+          override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
+
+          override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+      }
+  )
+
+  override val reactHost: ReactHost
+    get() = ReactNativeHostWrapper.createReactHost(applicationContext, reactNativeHost)
 
   override fun onCreate() {
     super.onCreate()
@@ -41,9 +47,6 @@ class MainApplication : Application(), ReactApplication {
     }
     loadReactNative(this)
     ApplicationLifecycleDispatcher.onApplicationCreate(this)
-  
-    // Auto Initialize Native Customer.io SDK
-    CustomerIOSDKInitializer.initialize(this)
   }
 
   override fun onConfigurationChanged(newConfig: Configuration) {
@@ -51,5 +54,3 @@ class MainApplication : Application(), ReactApplication {
     ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
   }
 }
-"
-`;

--- a/__tests__/fixtures/android/MainApplication.sdk55.kt
+++ b/__tests__/fixtures/android/MainApplication.sdk55.kt
@@ -1,7 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Expo latest MainApplication tests Plugin injects CIO initializer into MainApplication.kt 1`] = `
-"package io.customer.testbed.expo
+package io.customer.expo.fixture
 
 import android.app.Application
 import android.content.res.Configuration
@@ -16,8 +13,6 @@ import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
 
 import expo.modules.ApplicationLifecycleDispatcher
 import expo.modules.ExpoReactHostFactory
-
-import io.customer.sdk.expo.CustomerIOSDKInitializer
 
 class MainApplication : Application(), ReactApplication {
 
@@ -41,9 +36,6 @@ class MainApplication : Application(), ReactApplication {
     }
     loadReactNative(this)
     ApplicationLifecycleDispatcher.onApplicationCreate(this)
-  
-    // Auto Initialize Native Customer.io SDK
-    CustomerIOSDKInitializer.initialize(this)
   }
 
   override fun onConfigurationChanged(newConfig: Configuration) {
@@ -51,5 +43,3 @@ class MainApplication : Application(), ReactApplication {
     ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
   }
 }
-"
-`;

--- a/__tests__/fixtures/ios/AppDelegate.sdk54.swift
+++ b/__tests__/fixtures/ios/AppDelegate.sdk54.swift
@@ -1,0 +1,70 @@
+import Expo
+import React
+import ReactAppDependencyProvider
+
+@UIApplicationMain
+public class AppDelegate: ExpoAppDelegate {
+  var window: UIWindow?
+
+  var reactNativeDelegate: ExpoReactNativeFactoryDelegate?
+  var reactNativeFactory: RCTReactNativeFactory?
+
+  public override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    let delegate = ReactNativeDelegate()
+    let factory = ExpoReactNativeFactory(delegate: delegate)
+    delegate.dependencyProvider = RCTAppDependencyProvider()
+
+    reactNativeDelegate = delegate
+    reactNativeFactory = factory
+    bindReactNativeFactory(factory)
+
+#if os(iOS) || os(tvOS)
+    window = UIWindow(frame: UIScreen.main.bounds)
+    factory.startReactNative(
+      withModuleName: "main",
+      in: window,
+      launchOptions: launchOptions)
+#endif
+
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  // Linking API
+  public override func application(
+    _ app: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  ) -> Bool {
+    return super.application(app, open: url, options: options) || RCTLinkingManager.application(app, open: url, options: options)
+  }
+
+  // Universal Links
+  public override func application(
+    _ application: UIApplication,
+    continue userActivity: NSUserActivity,
+    restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+  ) -> Bool {
+    let result = RCTLinkingManager.application(application, continue: userActivity, restorationHandler: restorationHandler)
+    return super.application(application, continue: userActivity, restorationHandler: restorationHandler) || result
+  }
+}
+
+class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
+  // Extension point for config-plugins
+
+  override func sourceURL(for bridge: RCTBridge) -> URL? {
+    // needed to return the correct URL for expo-dev-client.
+    bridge.bundleURL ?? bundleURL()
+  }
+
+  override func bundleURL() -> URL? {
+#if DEBUG
+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
+#else
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
+}

--- a/__tests__/fixtures/ios/AppDelegate.sdk55.swift
+++ b/__tests__/fixtures/ios/AppDelegate.sdk55.swift
@@ -1,14 +1,9 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Expo latest AppDelegate tests Plugin injects CIO handler into AppDelegate.swift 1`] = `
-"internal import Expo
+internal import Expo
 import React
 import ReactAppDependencyProvider
 
 @main
 class AppDelegate: ExpoAppDelegate {
-  let cioSdkHandler = CioSdkAppDelegateHandler()
-
   var window: UIWindow?
 
   var reactNativeDelegate: ExpoReactNativeFactoryDelegate?
@@ -25,32 +20,15 @@ class AppDelegate: ExpoAppDelegate {
     reactNativeDelegate = delegate
     reactNativeFactory = factory
 
-    // Deep link workaround for app killed state start
-    var modifiedLaunchOptions = launchOptions
-    if let launchOptions = launchOptions,
-       let pushContent = launchOptions[UIApplication.LaunchOptionsKey.remoteNotification] as? [AnyHashable: Any],
-       let cio = pushContent["CIO"] as? [String: Any],
-       let push = cio["push"] as? [String: Any],
-       let link = push["link"] as? String,
-       !launchOptions.keys.contains(UIApplication.LaunchOptionsKey.url) {
-        
-        var mutableLaunchOptions = launchOptions
-        mutableLaunchOptions[UIApplication.LaunchOptionsKey.url] = URL(string: link)
-        modifiedLaunchOptions = mutableLaunchOptions
-    }
-    // Deep link workaround for app killed state ends
-
 #if os(iOS) || os(tvOS)
     window = UIWindow(frame: UIScreen.main.bounds)
     factory.startReactNative(
       withModuleName: "main",
       in: window,
-      launchOptions: modifiedLaunchOptions)
+      launchOptions: launchOptions)
 #endif
 
-      cioSdkHandler.application(application, didFinishLaunchingWithOptions: launchOptions)
-
-    return super.application(application, didFinishLaunchingWithOptions: modifiedLaunchOptions)
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 
   // Linking API
@@ -71,20 +49,6 @@ class AppDelegate: ExpoAppDelegate {
     let result = RCTLinkingManager.application(application, continue: userActivity, restorationHandler: restorationHandler)
     return super.application(application, continue: userActivity, restorationHandler: restorationHandler) || result
   }
-
-  // Handle device token registration
-  public override func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-    // Call CustomerIO SDK handler
-    cioSdkHandler.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
-    super.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
-  }
-
-  // Handle remote notification registration errors
-  public override func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-    // Call CustomerIO SDK handler
-    cioSdkHandler.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
-    super.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
-  }
 }
 
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
@@ -103,5 +67,3 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
 #endif
   }
 }
-"
-`;

--- a/__tests__/ios/apn/AppDelegate-swift.test.js
+++ b/__tests__/ios/apn/AppDelegate-swift.test.js
@@ -1,12 +1,15 @@
-const { testAppPath, testAppName, isExpoVersion53OrHigher } = require('../../utils');
+const { testAppPath, testAppName, isExpoVersionLatest } = require('../../utils');
 const fs = require('fs-extra');
 const path = require('path');
 
 const testProjectPath = testAppPath();
 const iosPath = path.join(testProjectPath, 'ios');
 
-// Tests for Expo 53+ (Swift)
-(isExpoVersion53OrHigher() ? describe : describe.skip)('Expo 53+ AppDelegate tests', () => {
+// Full-file prebuild snapshot — only runs on the `latest` row of the
+// compatibility matrix. Pinned SDK rows (currently 54) get scenario tests
+// in __tests__/scenarios/ios/appDelegateSwiftSdkVersions.test.ts which use
+// vanilla CLI-generated fixtures instead.
+(isExpoVersionLatest() ? describe : describe.skip)('Expo latest AppDelegate tests', () => {
   const appDelegateSwiftPath = path.join(
     iosPath,
     `${testAppName()}/AppDelegate.swift`

--- a/__tests__/ios/fcm/AppDelegate-swift.test.js
+++ b/__tests__/ios/fcm/AppDelegate-swift.test.js
@@ -1,12 +1,15 @@
-const { testAppPath, testAppName, isExpoVersion53OrHigher } = require('../../utils');
+const { testAppPath, testAppName, isExpoVersionLatest } = require('../../utils');
 const fs = require('fs-extra');
 const path = require('path');
 
 const testProjectPath = testAppPath();
 const iosPath = path.join(testProjectPath, 'ios');
 
-// Tests for Expo 53+ (Swift)
-(isExpoVersion53OrHigher() ? describe : describe.skip)('Expo 53+ FCM AppDelegate tests', () => {
+// Full-file prebuild snapshot — only runs on the `latest` row of the
+// compatibility matrix. Pinned SDK rows (currently 54) get scenario tests
+// in __tests__/scenarios/ios/appDelegateSwiftSdkVersions.test.ts which use
+// vanilla CLI-generated fixtures instead.
+(isExpoVersionLatest() ? describe : describe.skip)('Expo latest FCM AppDelegate tests', () => {
   const appDelegateSwiftPath = path.join(
     iosPath,
     `${testAppName()}/AppDelegate.swift`

--- a/__tests__/ios/fcm/__snapshots__/AppDelegate-swift.test.js.snap
+++ b/__tests__/ios/fcm/__snapshots__/AppDelegate-swift.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Expo 53+ FCM AppDelegate tests Plugin injects CIO handler into AppDelegate.swift for FCM 1`] = `
+exports[`Expo latest FCM AppDelegate tests Plugin injects CIO handler into AppDelegate.swift for FCM 1`] = `
 "internal import Expo
 import React
 import ReactAppDependencyProvider

--- a/__tests__/scenarios/android/mainApplicationVersions.test.ts
+++ b/__tests__/scenarios/android/mainApplicationVersions.test.ts
@@ -1,0 +1,142 @@
+import * as fs from 'fs';
+import { injectCustomerIOInitializerIntoMainApplication } from '../../../plugin/src/android/withMainApplicationModifications';
+import { getFixturePath } from '../../utils';
+
+describe('MainApplication.kt — Expo SDK 54 vanilla baseline', () => {
+  const baseline = fs.readFileSync(
+    getFixturePath('android', 'MainApplication.sdk54.kt'),
+    'utf8'
+  );
+
+  it('injects CustomerIOSDKInitializer import + onCreate call', () => {
+    expect(injectCustomerIOInitializerIntoMainApplication(baseline))
+      .toMatchInlineSnapshot(`
+      "package io.customer.expo.fixture
+
+      import android.app.Application
+      import android.content.res.Configuration
+
+      import com.facebook.react.PackageList
+      import com.facebook.react.ReactApplication
+      import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
+      import com.facebook.react.ReactNativeHost
+      import com.facebook.react.ReactPackage
+      import com.facebook.react.ReactHost
+      import com.facebook.react.common.ReleaseLevel
+      import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
+      import com.facebook.react.defaults.DefaultReactNativeHost
+
+      import expo.modules.ApplicationLifecycleDispatcher
+      import expo.modules.ReactNativeHostWrapper
+
+      import io.customer.sdk.expo.CustomerIOSDKInitializer
+
+      class MainApplication : Application(), ReactApplication {
+
+        override val reactNativeHost: ReactNativeHost = ReactNativeHostWrapper(
+            this,
+            object : DefaultReactNativeHost(this) {
+              override fun getPackages(): List<ReactPackage> =
+                  PackageList(this).packages.apply {
+                    // Packages that cannot be autolinked yet can be added manually here, for example:
+                    // add(MyReactNativePackage())
+                  }
+
+                override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"
+
+                override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
+
+                override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+            }
+        )
+
+        override val reactHost: ReactHost
+          get() = ReactNativeHostWrapper.createReactHost(applicationContext, reactNativeHost)
+
+        override fun onCreate() {
+          super.onCreate()
+          DefaultNewArchitectureEntryPoint.releaseLevel = try {
+            ReleaseLevel.valueOf(BuildConfig.REACT_NATIVE_RELEASE_LEVEL.uppercase())
+          } catch (e: IllegalArgumentException) {
+            ReleaseLevel.STABLE
+          }
+          loadReactNative(this)
+          ApplicationLifecycleDispatcher.onApplicationCreate(this)
+        
+          // Auto Initialize Native Customer.io SDK
+          CustomerIOSDKInitializer.initialize(this)
+        }
+
+        override fun onConfigurationChanged(newConfig: Configuration) {
+          super.onConfigurationChanged(newConfig)
+          ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
+        }
+      }
+      "
+    `);
+  });
+});
+
+describe('MainApplication.kt — Expo SDK 55 vanilla baseline', () => {
+  const baseline = fs.readFileSync(
+    getFixturePath('android', 'MainApplication.sdk55.kt'),
+    'utf8'
+  );
+
+  it('injects CustomerIOSDKInitializer import + onCreate call', () => {
+    expect(injectCustomerIOInitializerIntoMainApplication(baseline))
+      .toMatchInlineSnapshot(`
+      "package io.customer.expo.fixture
+
+      import android.app.Application
+      import android.content.res.Configuration
+
+      import com.facebook.react.PackageList
+      import com.facebook.react.ReactApplication
+      import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
+      import com.facebook.react.ReactPackage
+      import com.facebook.react.ReactHost
+      import com.facebook.react.common.ReleaseLevel
+      import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
+
+      import expo.modules.ApplicationLifecycleDispatcher
+      import expo.modules.ExpoReactHostFactory
+
+      import io.customer.sdk.expo.CustomerIOSDKInitializer
+
+      class MainApplication : Application(), ReactApplication {
+
+        override val reactHost: ReactHost by lazy {
+          ExpoReactHostFactory.getDefaultReactHost(
+            context = applicationContext,
+            packageList =
+              PackageList(this).packages.apply {
+                // Packages that cannot be autolinked yet can be added manually here, for example:
+                // add(MyReactNativePackage())
+              }
+          )
+        }
+
+        override fun onCreate() {
+          super.onCreate()
+          DefaultNewArchitectureEntryPoint.releaseLevel = try {
+            ReleaseLevel.valueOf(BuildConfig.REACT_NATIVE_RELEASE_LEVEL.uppercase())
+          } catch (e: IllegalArgumentException) {
+            ReleaseLevel.STABLE
+          }
+          loadReactNative(this)
+          ApplicationLifecycleDispatcher.onApplicationCreate(this)
+        
+          // Auto Initialize Native Customer.io SDK
+          CustomerIOSDKInitializer.initialize(this)
+        }
+
+        override fun onConfigurationChanged(newConfig: Configuration) {
+          super.onConfigurationChanged(newConfig)
+          ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
+        }
+      }
+      "
+    `);
+  });
+});

--- a/__tests__/scenarios/ios/appDelegateSwiftSdkVersions.test.ts
+++ b/__tests__/scenarios/ios/appDelegateSwiftSdkVersions.test.ts
@@ -1,0 +1,247 @@
+import * as fs from 'fs';
+import { modifyAppDelegateForPushHandler } from '../../../plugin/src/ios/withCIOIosSwift';
+import type { CustomerIOPluginOptionsIOS } from '../../../plugin/src/types/cio-types';
+import { getFixturePath } from '../../utils';
+
+// Mirrors the default config that `scripts/compatibility/configure-plugin.js`
+// writes when `--add-default-config` is passed: APN provider with deep-link
+// killed-state handling enabled.
+const defaultPushOptions = {
+  pushNotification: {
+    provider: 'apn',
+    handleDeeplinkInKilledState: true,
+  },
+} as CustomerIOPluginOptionsIOS;
+
+describe('AppDelegate.swift — Expo SDK 54 vanilla baseline', () => {
+  const baseline = fs.readFileSync(
+    getFixturePath('ios', 'AppDelegate.sdk54.swift'),
+    'utf8'
+  );
+
+  it('injects CIO handler + deep-link killed-state block (default config)', () => {
+    expect(modifyAppDelegateForPushHandler(baseline, defaultPushOptions))
+      .toMatchInlineSnapshot(`
+      "import Expo
+      import React
+      import ReactAppDependencyProvider
+
+      @UIApplicationMain
+      public class AppDelegate: ExpoAppDelegate {
+        let cioSdkHandler = CioSdkAppDelegateHandler()
+
+        var window: UIWindow?
+
+        var reactNativeDelegate: ExpoReactNativeFactoryDelegate?
+        var reactNativeFactory: RCTReactNativeFactory?
+
+        public override func application(
+          _ application: UIApplication,
+          didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+        ) -> Bool {
+          let delegate = ReactNativeDelegate()
+          let factory = ExpoReactNativeFactory(delegate: delegate)
+          delegate.dependencyProvider = RCTAppDependencyProvider()
+
+          reactNativeDelegate = delegate
+          reactNativeFactory = factory
+          bindReactNativeFactory(factory)
+
+          // Deep link workaround for app killed state start
+          var modifiedLaunchOptions = launchOptions
+          if let launchOptions = launchOptions,
+             let pushContent = launchOptions[UIApplication.LaunchOptionsKey.remoteNotification] as? [AnyHashable: Any],
+             let cio = pushContent["CIO"] as? [String: Any],
+             let push = cio["push"] as? [String: Any],
+             let link = push["link"] as? String,
+             !launchOptions.keys.contains(UIApplication.LaunchOptionsKey.url) {
+              
+              var mutableLaunchOptions = launchOptions
+              mutableLaunchOptions[UIApplication.LaunchOptionsKey.url] = URL(string: link)
+              modifiedLaunchOptions = mutableLaunchOptions
+          }
+          // Deep link workaround for app killed state ends
+
+      #if os(iOS) || os(tvOS)
+          window = UIWindow(frame: UIScreen.main.bounds)
+          factory.startReactNative(
+            withModuleName: "main",
+            in: window,
+            launchOptions: modifiedLaunchOptions)
+      #endif
+
+            cioSdkHandler.application(application, didFinishLaunchingWithOptions: launchOptions)
+
+          return super.application(application, didFinishLaunchingWithOptions: modifiedLaunchOptions)
+        }
+
+        // Linking API
+        public override func application(
+          _ app: UIApplication,
+          open url: URL,
+          options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+        ) -> Bool {
+          return super.application(app, open: url, options: options) || RCTLinkingManager.application(app, open: url, options: options)
+        }
+
+        // Universal Links
+        public override func application(
+          _ application: UIApplication,
+          continue userActivity: NSUserActivity,
+          restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+        ) -> Bool {
+          let result = RCTLinkingManager.application(application, continue: userActivity, restorationHandler: restorationHandler)
+          return super.application(application, continue: userActivity, restorationHandler: restorationHandler) || result
+        }
+
+        // Handle device token registration
+        public override func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+          // Call CustomerIO SDK handler
+          cioSdkHandler.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+          super.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+        }
+
+        // Handle remote notification registration errors
+        public override func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+          // Call CustomerIO SDK handler
+          cioSdkHandler.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+          super.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+        }
+      }
+
+      class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
+        // Extension point for config-plugins
+
+        override func sourceURL(for bridge: RCTBridge) -> URL? {
+          // needed to return the correct URL for expo-dev-client.
+          bridge.bundleURL ?? bundleURL()
+        }
+
+        override func bundleURL() -> URL? {
+      #if DEBUG
+          return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
+      #else
+          return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+      #endif
+        }
+      }
+      "
+    `);
+  });
+});
+
+describe('AppDelegate.swift — Expo SDK 55 vanilla baseline', () => {
+  const baseline = fs.readFileSync(
+    getFixturePath('ios', 'AppDelegate.sdk55.swift'),
+    'utf8'
+  );
+
+  it('injects CIO handler + deep-link killed-state block (default config)', () => {
+    expect(modifyAppDelegateForPushHandler(baseline, defaultPushOptions))
+      .toMatchInlineSnapshot(`
+      "internal import Expo
+      import React
+      import ReactAppDependencyProvider
+
+      @main
+      class AppDelegate: ExpoAppDelegate {
+        let cioSdkHandler = CioSdkAppDelegateHandler()
+
+        var window: UIWindow?
+
+        var reactNativeDelegate: ExpoReactNativeFactoryDelegate?
+        var reactNativeFactory: RCTReactNativeFactory?
+
+        public override func application(
+          _ application: UIApplication,
+          didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+        ) -> Bool {
+          let delegate = ReactNativeDelegate()
+          let factory = ExpoReactNativeFactory(delegate: delegate)
+          delegate.dependencyProvider = RCTAppDependencyProvider()
+
+          reactNativeDelegate = delegate
+          reactNativeFactory = factory
+
+          // Deep link workaround for app killed state start
+          var modifiedLaunchOptions = launchOptions
+          if let launchOptions = launchOptions,
+             let pushContent = launchOptions[UIApplication.LaunchOptionsKey.remoteNotification] as? [AnyHashable: Any],
+             let cio = pushContent["CIO"] as? [String: Any],
+             let push = cio["push"] as? [String: Any],
+             let link = push["link"] as? String,
+             !launchOptions.keys.contains(UIApplication.LaunchOptionsKey.url) {
+              
+              var mutableLaunchOptions = launchOptions
+              mutableLaunchOptions[UIApplication.LaunchOptionsKey.url] = URL(string: link)
+              modifiedLaunchOptions = mutableLaunchOptions
+          }
+          // Deep link workaround for app killed state ends
+
+      #if os(iOS) || os(tvOS)
+          window = UIWindow(frame: UIScreen.main.bounds)
+          factory.startReactNative(
+            withModuleName: "main",
+            in: window,
+            launchOptions: modifiedLaunchOptions)
+      #endif
+
+            cioSdkHandler.application(application, didFinishLaunchingWithOptions: launchOptions)
+
+          return super.application(application, didFinishLaunchingWithOptions: modifiedLaunchOptions)
+        }
+
+        // Linking API
+        public override func application(
+          _ app: UIApplication,
+          open url: URL,
+          options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+        ) -> Bool {
+          return super.application(app, open: url, options: options) || RCTLinkingManager.application(app, open: url, options: options)
+        }
+
+        // Universal Links
+        public override func application(
+          _ application: UIApplication,
+          continue userActivity: NSUserActivity,
+          restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+        ) -> Bool {
+          let result = RCTLinkingManager.application(application, continue: userActivity, restorationHandler: restorationHandler)
+          return super.application(application, continue: userActivity, restorationHandler: restorationHandler) || result
+        }
+
+        // Handle device token registration
+        public override func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+          // Call CustomerIO SDK handler
+          cioSdkHandler.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+          super.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+        }
+
+        // Handle remote notification registration errors
+        public override func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+          // Call CustomerIO SDK handler
+          cioSdkHandler.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+          super.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+        }
+      }
+
+      class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
+        // Extension point for config-plugins
+
+        override func sourceURL(for bridge: RCTBridge) -> URL? {
+          // needed to return the correct URL for expo-dev-client.
+          bridge.bundleURL ?? bundleURL()
+        }
+
+        override func bundleURL() -> URL? {
+      #if DEBUG
+          return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
+      #else
+          return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+      #endif
+        }
+      }
+      "
+    `);
+  });
+});

--- a/__tests__/utils.d.ts
+++ b/__tests__/utils.d.ts
@@ -5,4 +5,6 @@ export function getTestAppAndroidPackagePath(): string;
 export function getTestAppAndroidJavaSourcePath(): string;
 export function getExpoVersion(): string;
 export function isExpoVersion53OrHigher(): boolean;
+export function isExpoVersionAtLeast(targetVersion: string): boolean;
+export function isExpoVersionLatest(): boolean;
 export function getFixturePath(area: string, name: string): string;

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -59,6 +59,16 @@ function isExpoVersion53OrHigher() {
   return semver.gte(validVersion, '53.0.0');
 }
 
+/**
+ * True when the compatibility matrix invoked the tests with `--expo-version=latest`.
+ * Used to gate the prebuild-output snapshot test so the snapshot only needs to
+ * track upstream template churn for one row of the matrix; pinned SDK rows get
+ * their own scenario tests with per-version fixtures.
+ */
+function isExpoVersionLatest() {
+  return process.env.EXPO_VERSION === 'latest';
+}
+
 module.exports = {
   testAppPath,
   testAppName,
@@ -67,5 +77,6 @@ module.exports = {
   getTestAppAndroidJavaSourcePath,
   getExpoVersion,
   isExpoVersion53OrHigher,
+  isExpoVersionLatest,
   getFixturePath,
 };

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -43,20 +43,27 @@ function getExpoVersion() {
 }
 
 /**
+ * Returns true when EXPO_VERSION is `latest` or its semver is >= targetVersion.
+ * `latest` is treated as the newest supported SDK so version-gated tests still
+ * run on the matrix's `latest` row, where the resolved SDK can't be known
+ * statically without resolving the npm dist-tag.
+ */
+function isExpoVersionAtLeast(targetVersion) {
+  const sdkVersion = getExpoVersion();
+  if (sdkVersion === 'latest') return true;
+
+  const validVersion = semver.valid(sdkVersion) || semver.coerce(sdkVersion);
+  if (!validVersion) return false;
+
+  return semver.gte(validVersion, targetVersion);
+}
+
+/**
  * Check if the Expo version is 53 or higher
  * @returns {boolean} True if Expo version is 53 or higher
  */
 function isExpoVersion53OrHigher() {
-  const sdkVersion = getExpoVersion();
-
-  // If sdkVersion is not a valid semver, coerce it to a valid one if possible
-  const validVersion = semver.valid(sdkVersion) || semver.coerce(sdkVersion);
-
-  // If we couldn't get a valid version, return false
-  if (!validVersion) return false;
-
-  // Check if the version is greater than or equal to 53.0.0
-  return semver.gte(validVersion, '53.0.0');
+  return isExpoVersionAtLeast('53.0.0');
 }
 
 /**
@@ -77,6 +84,7 @@ module.exports = {
   getTestAppAndroidJavaSourcePath,
   getExpoVersion,
   isExpoVersion53OrHigher,
+  isExpoVersionAtLeast,
   isExpoVersionLatest,
   getFixturePath,
 };


### PR DESCRIPTION
## Summary
- `__tests__/ios/apn/AppDelegate-swift.test.js` matched the prebuilt `AppDelegate.swift` against a single snapshot that tracked the **Expo SDK 55** template. PR #360 bumped the test-app fixture to SDK 55, which broke the SDK 54 rows of the matrix on the first push to `main` ([run 26157165670](https://github.com/customerio/customerio-expo-plugin/actions/runs/26157165670)).
- Per-SDK coverage now lives in `__tests__/scenarios/ios/appDelegateSwiftSdkVersions.test.ts`: each row runs the pure `modifyAppDelegateForPushHandler` transform against a CLI-generated vanilla baseline (`AppDelegate.sdk54.swift`, `AppDelegate.sdk55.swift`) and asserts the result with `toMatchInlineSnapshot()`. Fixtures were produced by `npx create-expo-app@latest --template default@sdk-<n>` followed by `expo prebuild --platform=ios --no-install --clean` — same code path Expo uses for any fresh app of that SDK.
- The prebuild-output snapshot is now gated to the `EXPO_VERSION=latest` matrix row only. That row remains the canary that flags upstream template churn — when SDK 56 ships and Expo's `latest` resolves to it, the snapshot will need regenerating and an SDK 56 fixture added to the scenario test.
- Both compatibility workflows (`validate-plugin-compatibility.yml`, `validate-plugin-compatibility-matrix.yml`) now pass `--expo-version` through to `compatibility:validate-plugin`. Previously the flag was omitted, so `EXPO_VERSION` silently defaulted to `53` in the jest env regardless of which matrix row was running.

## Test plan
- [ ] Matrix CI (`Validate Plugin Compatibility Release`) — all 6 jobs green, including `Expo 54 - ios (apn)` and `Expo 54 - ios (fcm)` which previously failed.
- [ ] `Expo latest - ios (apn|fcm)` still runs the full prebuild snapshot test.
- [ ] `Expo 54 - ios (apn|fcm)` now skips `Expo latest AppDelegate tests` (`isExpoVersionLatest()` false) and exercises the new scenario inline snapshots instead.
- [ ] Other suites (lint, typecheck, unit, pnpm compat) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to CI workflows and Jest test coverage, improving matrix correctness without affecting plugin runtime behavior. Main risk is potential CI flakiness or needing snapshot/fixture updates when Expo templates change.
> 
> **Overview**
> Fixes Expo compatibility CI to actually run tests with the matrix’s Expo version by passing `--expo-version` through to `compatibility:validate-plugin` (both smoke and full matrix workflows).
> 
> Refactors Android and iOS prebuild snapshot tests to run **only** on the `EXPO_VERSION=latest` row, and adds per-SDK scenario tests that validate the pure transforms against new vanilla fixtures (`MainApplication` for SDK 54/55 and `AppDelegate.swift` for SDK 54/55) using inline snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bfbee95a16ca4c72fc1c5593f90da4b15396caa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->