### PR TITLE
fix: bump customerio-reactnative to 6.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "xcode": "^3.0.1"
       },
       "peerDependencies": {
-        "customerio-reactnative": "6.4.0"
+        "customerio-reactnative": "6.4.3"
       }
     },
     "node_modules/@babel/cli": {
@@ -7892,9 +7892,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-6.4.0.tgz",
-      "integrity": "sha512-akDlFyN/wdOcffrEhH95J2FtFurGsJxowr4WodeqnY9C0+WFZRHMGqSN/PgcbwyH4wL9/8U88jDBgUOaGmbCLw==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-6.4.3.tgz",
+      "integrity": "sha512-Mukk7Gryfu/1EC5OTp935+JY4Cs55E+lFMCdAI8f+AaLlvwBTJZWBYy3lP+vwNL4h+2tJKb2RQsR/rgBBQS/0A==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "customerio-reactnative": "6.4.0"
+    "customerio-reactnative": "6.4.3"
   },
   "devDependencies": {
     "dotenv": "^16.4.5",

--- a/test-app-pnpm-monorepo/apps/mobile/package.json
+++ b/test-app-pnpm-monorepo/apps/mobile/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@cio-test/shared-cio-utils": "workspace:*",
     "customerio-expo-plugin": "file:../../../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.4.0",
+    "customerio-reactnative": "^6.4.3",
     "expo": "~54.0.2",
     "expo-build-properties": "^1.0.8",
     "expo-status-bar": "~3.0.8",

--- a/test-app-pnpm-monorepo/packages/shared-cio-utils/package.json
+++ b/test-app-pnpm-monorepo/packages/shared-cio-utils/package.json
@@ -5,6 +5,6 @@
   "main": "index.ts",
   "types": "index.ts",
   "dependencies": {
-    "customerio-reactnative": "^6.4.0"
+    "customerio-reactnative": "^6.4.3"
   }
 }

--- a/test-app-pnpm/package.json
+++ b/test-app-pnpm/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.4.0",
+    "customerio-reactnative": "^6.4.3",
     "expo": "~54.0.2",
     "expo-build-properties": "^1.0.8",
     "expo-status-bar": "~3.0.8",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -15,7 +15,7 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.4.0",
+    "customerio-reactnative": "^6.4.3",
     "dotenv": "^17.2.2",
     "expo": "~55.0.23",
     "expo-build-properties": "~55.0.13",


### PR DESCRIPTION
## Summary
- Bumps the `customerio-reactnative` peer dependency from `6.4.0` to `6.4.3` (latest on npm) and aligns the test-app, test-app-pnpm, and test-app-pnpm-monorepo manifests to `^6.4.3`.
- `package-lock.json` is refreshed for the bumped peer requirement.

## What's in 6.4.1 → 6.4.3
- **6.4.1** – Fix `EXC_BAD_ACCESS` in `RCTInlineMessageNative.updateProps` on iOS Fabric (customerio-reactnative#581).
- **6.4.2** – Honor top-level `apiHost` / `cdnHost` in `CioConfig` (customerio-reactnative#584).
- **6.4.3** – Bumps native SDKs (iOS 4.4.3, Android 4.17.1) and resolves third-party vulnerabilities (customerio-reactnative#594, #585).

## Test plan
- [ ] `npm test` locally (pre-existing failures on `main` are unchanged; no new failures introduced by the bump)
- [ ] CI green on Android + iOS compatibility matrix
- [ ] Smoke test on `test-app` (Expo SDK 55) and `test-app-pnpm` (Expo SDK 54) with the new peer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk manifest-only change, but it does tighten/shift the required peer version and updates the resolved `customerio-reactnative` package in `package-lock.json`, which could affect consumer installs.
> 
> **Overview**
> Updates the plugin’s `peerDependencies` to require `customerio-reactnative@6.4.3` (from `6.4.0`) and aligns all bundled test apps/monorepo packages to depend on `^6.4.3`.
> 
> Refreshes `package-lock.json` so the resolved `customerio-reactnative` entry matches `6.4.3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68f55f6d870245d52409ce87ff0e42fb439070f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->