### PR TITLE
feat: bump customerio-reactnative to 6.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "xcode": "^3.0.1"
       },
       "peerDependencies": {
-        "customerio-reactnative": "6.4.3"
+        "customerio-reactnative": "6.5.0"
       }
     },
     "node_modules/@babel/cli": {
@@ -7892,9 +7892,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-6.4.3.tgz",
-      "integrity": "sha512-Mukk7Gryfu/1EC5OTp935+JY4Cs55E+lFMCdAI8f+AaLlvwBTJZWBYy3lP+vwNL4h+2tJKb2RQsR/rgBBQS/0A==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-6.5.0.tgz",
+      "integrity": "sha512-S7c8cpD7kgWztsvsazetqiC1T+fssABRuc+lA5uQJNiSneGeD90ZC9o4iQT7rNmkO6ck1iLPW6RXUhi+NvZFbA==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "customerio-reactnative": "6.4.3"
+    "customerio-reactnative": "6.5.0"
   },
   "devDependencies": {
     "dotenv": "^16.4.5",

--- a/test-app-pnpm-monorepo/apps/mobile/package.json
+++ b/test-app-pnpm-monorepo/apps/mobile/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@cio-test/shared-cio-utils": "workspace:*",
     "customerio-expo-plugin": "file:../../../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.4.3",
+    "customerio-reactnative": "^6.5.0",
     "expo": "~54.0.2",
     "expo-build-properties": "^1.0.8",
     "expo-status-bar": "~3.0.8",

--- a/test-app-pnpm-monorepo/packages/shared-cio-utils/package.json
+++ b/test-app-pnpm-monorepo/packages/shared-cio-utils/package.json
@@ -5,6 +5,6 @@
   "main": "index.ts",
   "types": "index.ts",
   "dependencies": {
-    "customerio-reactnative": "^6.4.3"
+    "customerio-reactnative": "^6.5.0"
   }
 }

--- a/test-app-pnpm/package.json
+++ b/test-app-pnpm/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.4.3",
+    "customerio-reactnative": "^6.5.0",
     "expo": "~54.0.2",
     "expo-build-properties": "^1.0.8",
     "expo-status-bar": "~3.0.8",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -15,7 +15,7 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.4.3",
+    "customerio-reactnative": "^6.5.0",
     "dotenv": "^17.2.2",
     "expo": "~55.0.23",
     "expo-build-properties": "~55.0.13",


### PR DESCRIPTION
## Summary
Bumps the `customerio-reactnative` peer dependency from `6.4.3` → `6.5.0` (latest published release) and updates the test apps to match.

## Changes
- `package.json` — `peerDependencies.customerio-reactnative` → `6.5.0`
- `package-lock.json` — regenerated entry (version/resolved/integrity) + root peer dep
- `test-app/package.json` — `^6.5.0`
- `test-app-pnpm/package.json` — `^6.5.0`
- `test-app-pnpm-monorepo/apps/mobile/package.json` — `^6.5.0`
- `test-app-pnpm-monorepo/packages/shared-cio-utils/package.json` — `^6.5.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 23d2d6d8faf25a105f166c63fa1f46249628476d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->