### PR TITLE
fix: update customerio-reactnative to 6.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-expo-plugin",
-  "version": "3.3.0",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-expo-plugin",
-      "version": "3.3.0",
+      "version": "3.6.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -35,7 +35,7 @@
         "xcode": "^3.0.1"
       },
       "peerDependencies": {
-        "customerio-reactnative": "6.5.0"
+        "customerio-reactnative": "6.5.1"
       }
     },
     "node_modules/@babel/cli": {
@@ -7892,9 +7892,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-6.5.0.tgz",
-      "integrity": "sha512-S7c8cpD7kgWztsvsazetqiC1T+fssABRuc+lA5uQJNiSneGeD90ZC9o4iQT7rNmkO6ck1iLPW6RXUhi+NvZFbA==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-6.5.1.tgz",
+      "integrity": "sha512-bQpHuQF7wpqytj077cp+vlaxIIgbZZBdSRj2aNBzbII4pcTzIR1fp5F7jdd8Xs00drjxgHwAyyN3oa/mg4S0rQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "customerio-reactnative": "6.5.0"
+    "customerio-reactnative": "6.5.1"
   },
   "devDependencies": {
     "dotenv": "^16.4.5",

--- a/test-app-pnpm-monorepo/apps/mobile/package.json
+++ b/test-app-pnpm-monorepo/apps/mobile/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@cio-test/shared-cio-utils": "workspace:*",
     "customerio-expo-plugin": "file:../../../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.5.0",
+    "customerio-reactnative": "^6.5.1",
     "expo": "~54.0.2",
     "expo-build-properties": "^1.0.8",
     "expo-status-bar": "~3.0.8",

--- a/test-app-pnpm-monorepo/packages/shared-cio-utils/package.json
+++ b/test-app-pnpm-monorepo/packages/shared-cio-utils/package.json
@@ -5,6 +5,6 @@
   "main": "index.ts",
   "types": "index.ts",
   "dependencies": {
-    "customerio-reactnative": "^6.5.0"
+    "customerio-reactnative": "^6.5.1"
   }
 }

--- a/test-app-pnpm/package.json
+++ b/test-app-pnpm/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.5.0",
+    "customerio-reactnative": "^6.5.1",
     "expo": "~54.0.2",
     "expo-build-properties": "^1.0.8",
     "expo-status-bar": "~3.0.8",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -15,7 +15,7 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.5.0",
+    "customerio-reactnative": "^6.5.1",
     "dotenv": "^17.2.2",
     "expo": "~55.0.23",
     "expo-build-properties": "~55.0.13",


### PR DESCRIPTION
Bumps the `customerio-reactnative` peer dependency `6.5.0 → 6.5.1`, which carries the latest native SDKs (iOS 4.5.1, Android 4.18.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version alignment only; no plugin or runtime logic changes in the diff.
> 
> **Overview**
> Aligns the Expo plugin with **customerio-reactnative 6.5.1** by raising the **peer dependency** from `6.5.0` to `6.5.1` in the root `package.json` and refreshing **package-lock.json** so installs resolve to the new SDK.
> 
> Sample and compatibility apps (`test-app`, `test-app-pnpm`, and the pnpm monorepo mobile app plus `shared-cio-utils`) now depend on `^6.5.1` so local prebuild tests match what consumers are expected to install alongside the plugin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfa01ab7e191f20c57951453bbc835100500ea63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->