### PR TITLE
fix: update customerio-reactnative to 6.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "xcode": "^3.0.1"
       },
       "peerDependencies": {
-        "customerio-reactnative": "6.5.1"
+        "customerio-reactnative": "6.5.2"
       }
     },
     "node_modules/@babel/cli": {
@@ -7892,9 +7892,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-6.5.1.tgz",
-      "integrity": "sha512-bQpHuQF7wpqytj077cp+vlaxIIgbZZBdSRj2aNBzbII4pcTzIR1fp5F7jdd8Xs00drjxgHwAyyN3oa/mg4S0rQ==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-6.5.2.tgz",
+      "integrity": "sha512-y4/peiR5rkAHY9AD7RinW08aEDNmmfOD4p0TTvhyr1qcHMqeWYPtUVTCqrgaddzvdGijz2e9rnQhYO8sTSSXBw==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "customerio-reactnative": "6.5.1"
+    "customerio-reactnative": "6.5.2"
   },
   "devDependencies": {
     "dotenv": "^16.4.5",

--- a/test-app-pnpm-monorepo/apps/mobile/package.json
+++ b/test-app-pnpm-monorepo/apps/mobile/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@cio-test/shared-cio-utils": "workspace:*",
     "customerio-expo-plugin": "file:../../../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.5.1",
+    "customerio-reactnative": "^6.5.2",
     "expo": "~54.0.2",
     "expo-build-properties": "^1.0.8",
     "expo-status-bar": "~3.0.8",

--- a/test-app-pnpm-monorepo/packages/shared-cio-utils/package.json
+++ b/test-app-pnpm-monorepo/packages/shared-cio-utils/package.json
@@ -5,6 +5,6 @@
   "main": "index.ts",
   "types": "index.ts",
   "dependencies": {
-    "customerio-reactnative": "^6.5.1"
+    "customerio-reactnative": "^6.5.2"
   }
 }

--- a/test-app-pnpm/package.json
+++ b/test-app-pnpm/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.5.1",
+    "customerio-reactnative": "^6.5.2",
     "expo": "~54.0.2",
     "expo-build-properties": "^1.0.8",
     "expo-status-bar": "~3.0.8",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -15,7 +15,7 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.5.1",
+    "customerio-reactnative": "^6.5.2",
     "dotenv": "^17.2.2",
     "expo": "~55.0.23",
     "expo-build-properties": "~55.0.13",


### PR DESCRIPTION
Bumps the bundled React Native SDK (`customerio-reactnative`) to **6.5.2**, which ships native iOS 4.5.3 and Android 4.18.2.

Updates the peer dependency pin and the test apps; `package-lock.json` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version bump only with no changes to plugin implementation or runtime behavior in this repo.
> 
> **Overview**
> Bumps the **customerio-expo-plugin** peer dependency on `customerio-reactnative` from **6.5.1** to **6.5.2**, aligning the plugin with the latest React Native SDK (including updated native iOS/Android versions in that release).
> 
> The same version is applied across **npm** lockfile resolution and all **test apps** (`test-app`, `test-app-pnpm`, and the pnpm monorepo mobile app and shared package). No plugin source or config logic changes—dependency pins and lockfile only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8143821dee1412bcf2d6002cf20c8ddeac15b275. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->