### PR TITLE
chore: add geofence build-time enablement (manual init)

### DIFF
--- a/__tests__/android/withGeofenceGradleProperties.test.ts
+++ b/__tests__/android/withGeofenceGradleProperties.test.ts
@@ -1,0 +1,89 @@
+import { withGradleProperties } from '@expo/config-plugins';
+import type { ExpoConfig } from '@expo/config-types';
+import { withGeofenceGradleProperties } from '../../plugin/src/android/withGeofenceGradleProperties';
+
+jest.mock('@expo/config-plugins');
+
+const mockWithGradleProperties = withGradleProperties as jest.MockedFunction<
+  typeof withGradleProperties
+>;
+
+describe('withGeofenceGradleProperties', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('adds customerio_geofence_enabled=true when geofence.enabled is true', () => {
+    const mockConfig = {
+      modResults: [
+        { type: 'property' as const, key: 'someKey', value: 'someValue' },
+      ],
+    };
+
+    mockWithGradleProperties.mockImplementation((config, modifier) => {
+      modifier(mockConfig as any);
+      return config;
+    });
+
+    withGeofenceGradleProperties({} as ExpoConfig, {
+      geofence: { enabled: true },
+    });
+
+    expect(mockConfig.modResults).toContainEqual({
+      type: 'property',
+      key: 'customerio_geofence_enabled',
+      value: 'true',
+    });
+    expect(mockConfig.modResults).toHaveLength(2);
+  });
+
+  it('updates existing customerio_geofence_enabled when geofence.enabled is true', () => {
+    const mockConfig = {
+      modResults: [
+        {
+          type: 'property' as const,
+          key: 'customerio_geofence_enabled',
+          value: 'false',
+        },
+      ],
+    };
+
+    mockWithGradleProperties.mockImplementation((config, modifier) => {
+      modifier(mockConfig as any);
+      return config;
+    });
+
+    withGeofenceGradleProperties({} as ExpoConfig, {
+      geofence: { enabled: true },
+    });
+
+    expect(mockConfig.modResults).toHaveLength(1);
+    expect(mockConfig.modResults[0]).toEqual({
+      type: 'property',
+      key: 'customerio_geofence_enabled',
+      value: 'true',
+    });
+  });
+
+  it('does not modify config when geofence.enabled is false', () => {
+    mockWithGradleProperties.mockImplementation((config) => config);
+
+    const config = {} as ExpoConfig;
+    const result = withGeofenceGradleProperties(config, {
+      geofence: { enabled: false },
+    });
+
+    expect(result).toBe(config);
+    expect(mockWithGradleProperties).not.toHaveBeenCalled();
+  });
+
+  it('does not modify config when geofence is omitted', () => {
+    mockWithGradleProperties.mockImplementation((config) => config);
+
+    const config = {} as ExpoConfig;
+    const result = withGeofenceGradleProperties(config, {});
+
+    expect(result).toBe(config);
+    expect(mockWithGradleProperties).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,0 +1,72 @@
+import type { ExpoConfig } from '@expo/config-types';
+import withCustomerIOPlugin from '../plugin/src/index';
+import { isExpoVersion53OrHigher } from '../plugin/src/ios/utils';
+import { withCIOIos } from '../plugin/src/ios/withCIOIos';
+import { withCIOAndroid } from '../plugin/src/android/withCIOAndroid';
+import { withExpoVersion } from '../plugin/src/utils/writeExpoVersion';
+import type { CustomerIOPluginOptions } from '../plugin/src/types/cio-types';
+
+jest.mock('../plugin/src/ios/utils');
+jest.mock('../plugin/src/ios/withCIOIos');
+jest.mock('../plugin/src/android/withCIOAndroid');
+jest.mock('../plugin/src/utils/writeExpoVersion');
+
+const mockIsExpo53 = isExpoVersion53OrHigher as jest.MockedFunction<
+  typeof isExpoVersion53OrHigher
+>;
+const mockWithCIOIos = withCIOIos as jest.MockedFunction<typeof withCIOIos>;
+const mockWithCIOAndroid = withCIOAndroid as jest.MockedFunction<typeof withCIOAndroid>;
+const mockWithExpoVersion = withExpoVersion as jest.MockedFunction<typeof withExpoVersion>;
+
+const baseConfig = { name: 'Test', slug: 'test' } as ExpoConfig;
+const baseProps: CustomerIOPluginOptions = {
+  android: { androidPath: 'android' },
+  ios: { iosPath: 'ios' },
+};
+
+describe('withCustomerIOPlugin geofence gating', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockWithExpoVersion.mockImplementation((c) => c);
+    mockWithCIOIos.mockImplementation((c) => c);
+    mockWithCIOAndroid.mockImplementation((c) => c as ExpoConfig);
+  });
+
+  it('throws when geofence.enabled on Expo < 53', () => {
+    mockIsExpo53.mockReturnValue(false);
+
+    expect(() =>
+      withCustomerIOPlugin(baseConfig, { ...baseProps, geofence: { enabled: true } })
+    ).toThrow(/geofence requires Expo SDK 53/);
+  });
+
+  it('does not throw and forwards geofence to platform mods on Expo 53+', () => {
+    mockIsExpo53.mockReturnValue(true);
+
+    const geofence = { enabled: true };
+    withCustomerIOPlugin(baseConfig, { ...baseProps, geofence });
+
+    expect(mockWithCIOIos).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined,
+      baseProps.ios,
+      undefined,
+      geofence
+    );
+    expect(mockWithCIOAndroid).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined,
+      baseProps.android,
+      undefined,
+      geofence
+    );
+  });
+
+  it('does not throw when geofence is disabled on Expo < 53', () => {
+    mockIsExpo53.mockReturnValue(false);
+
+    expect(() =>
+      withCustomerIOPlugin(baseConfig, { ...baseProps, geofence: { enabled: false } })
+    ).not.toThrow();
+  });
+});

--- a/__tests__/ios/injectCIOPodfileCode.test.ts
+++ b/__tests__/ios/injectCIOPodfileCode.test.ts
@@ -92,6 +92,49 @@ describe('buildHostAppPodSnippet', () => {
     );
   });
 
+  it('uses :subspecs => with push + geofence when geofence enabled', () => {
+    const options: InjectCIOPodfileOptions = {
+      geofenceEnabled: true,
+      hasPush: true,
+    };
+    const fcmSnippet = buildHostAppPodSnippet(IOS_PATH, true, options);
+    expectsPodLine(
+      fcmSnippet,
+      `pod 'customerio-reactnative', :subspecs => ['fcm', 'geofence'], :path => '${RESOLVED_PATH}'`
+    );
+
+    const apnSnippet = buildHostAppPodSnippet(IOS_PATH, false, options);
+    expectsPodLine(
+      apnSnippet,
+      `pod 'customerio-reactnative', :subspecs => ['apn', 'geofence'], :path => '${RESOLVED_PATH}'`
+    );
+  });
+
+  it('emits only the geofence subspec line when geofenceEnabled and !hasPush', () => {
+    const options: InjectCIOPodfileOptions = {
+      geofenceEnabled: true,
+      hasPush: false,
+    };
+    const snippet = buildHostAppPodSnippet(IOS_PATH, true, options);
+    expectsPodLine(
+      snippet,
+      `pod 'customerio-reactnative', :subspecs => ['geofence'], :path => '${RESOLVED_PATH}'`
+    );
+  });
+
+  it('omits the redundant location subspec when geofence is enabled (geofence implies location)', () => {
+    const options: InjectCIOPodfileOptions = {
+      locationEnabled: true,
+      geofenceEnabled: true,
+      hasPush: true,
+    };
+    const snippet = buildHostAppPodSnippet(IOS_PATH, false, options);
+    expectsPodLine(
+      snippet,
+      `pod 'customerio-reactnative', :subspecs => ['apn', 'geofence'], :path => '${RESOLVED_PATH}'`
+    );
+  });
+
   it('does not emit any Ruby lambda or install-time resolver block', () => {
     const snippet = buildHostAppPodSnippet(IOS_PATH, false);
     // Lambda was the previous shape; we resolve at prebuild now and bake.

--- a/__tests__/ios/withCIOIos.test.ts
+++ b/__tests__/ios/withCIOIos.test.ts
@@ -1,12 +1,13 @@
 import type { ExpoConfig } from '@expo/config-types';
 import { withCIOIos } from '../../plugin/src/ios/withCIOIos';
-import type { CustomerIOPluginLocationOptions, CustomerIOPluginOptionsIOS } from '../../plugin/src/types/cio-types';
+import type { CustomerIOPluginGeofenceOptions, CustomerIOPluginLocationOptions, CustomerIOPluginOptionsIOS } from '../../plugin/src/types/cio-types';
 
 const mockWithCioXcodeProject = jest.fn((config: ExpoConfig, _props?: object) => config);
 const mockWithCIOIosSwift = jest.fn((config: ExpoConfig) => config);
 const mockWithAppDelegateModifications = jest.fn((config: ExpoConfig) => config);
 const mockWithCioNotificationsXcodeProject = jest.fn((config: ExpoConfig) => config);
 const mockWithGoogleServicesJsonFile = jest.fn((config: ExpoConfig) => config);
+const mockWithGeofenceAppDelegate = jest.fn((config: ExpoConfig) => config);
 const mockWithEntitlementsPlist = jest.fn((config: ExpoConfig, callback: (c: unknown) => unknown) => {
   callback({ ios: { bundleIdentifier: 'com.test.app' }, modResults: {} });
   return config;
@@ -35,6 +36,10 @@ jest.mock('../../plugin/src/ios/withNotificationsXcodeProject', () => ({
 jest.mock('../../plugin/src/ios/withGoogleServicesJsonFile', () => ({
   withGoogleServicesJsonFile: (config: ExpoConfig) =>
     mockWithGoogleServicesJsonFile(config),
+}));
+jest.mock('../../plugin/src/ios/withGeofenceAppDelegate', () => ({
+  withGeofenceAppDelegate: (config: ExpoConfig) =>
+    mockWithGeofenceAppDelegate(config),
 }));
 jest.mock('../../plugin/src/ios/utils', () => ({
   isExpoVersion53OrHigher: jest.fn(() => true),
@@ -65,8 +70,9 @@ describe('withCIOIos', () => {
       expect(mockWithCioNotificationsXcodeProject).not.toHaveBeenCalled();
       expect(mockWithCioXcodeProject).toHaveBeenCalledTimes(1);
       expect(mockWithCioXcodeProject).toHaveBeenCalledWith(mockConfig, {
-        podfileOptions: { locationEnabled: true, hasPush: false },
+        podfileOptions: { locationEnabled: true, geofenceEnabled: false, hasPush: false },
       });
+      expect(mockWithGeofenceAppDelegate).not.toHaveBeenCalled();
     });
 
     it('does not call withCioXcodeProject when location.enabled is false', () => {
@@ -159,6 +165,59 @@ describe('withCIOIos', () => {
       withCIOIos(mockConfig, undefined, { iosPath: '/test/ios' });
 
       expect(mockWithEntitlementsPlist).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('geofence-only (no push, no config)', () => {
+    const geofence: CustomerIOPluginGeofenceOptions = { enabled: true };
+
+    it('adds the geofence subspec and injects the AppDelegate bootstrap when geofence.enabled', () => {
+      withCIOIos(mockConfig, undefined, undefined, undefined, geofence);
+
+      expect(mockWithCIOIosSwift).not.toHaveBeenCalled();
+      expect(mockWithCioXcodeProject).toHaveBeenCalledTimes(1);
+      expect(mockWithCioXcodeProject).toHaveBeenCalledWith(mockConfig, {
+        podfileOptions: { locationEnabled: false, geofenceEnabled: true, hasPush: false },
+      });
+      expect(mockWithGeofenceAppDelegate).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing when geofence.enabled is false', () => {
+      withCIOIos(mockConfig, undefined, undefined, undefined, { enabled: false });
+
+      expect(mockWithCioXcodeProject).not.toHaveBeenCalled();
+      expect(mockWithGeofenceAppDelegate).not.toHaveBeenCalled();
+    });
+
+    it('combines location and geofence subspec flags when both enabled', () => {
+      withCIOIos(mockConfig, undefined, undefined, { enabled: true }, geofence);
+
+      expect(mockWithCioXcodeProject).toHaveBeenCalledWith(mockConfig, {
+        podfileOptions: { locationEnabled: true, geofenceEnabled: true, hasPush: false },
+      });
+      expect(mockWithGeofenceAppDelegate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('geofence with push', () => {
+    it('passes geofenceEnabled to the Podfile and injects the AppDelegate bootstrap', () => {
+      const props: CustomerIOPluginOptionsIOS = {
+        iosPath: '/test/ios',
+        pushNotification: { provider: 'apn' },
+      };
+
+      withCIOIos(mockConfig, undefined, props, undefined, { enabled: true });
+
+      expect(mockWithCioXcodeProject).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          podfileOptions: expect.objectContaining({
+            geofenceEnabled: true,
+            hasPush: true,
+          }),
+        })
+      );
+      expect(mockWithGeofenceAppDelegate).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/__tests__/ios/withGeofenceAppDelegate.test.ts
+++ b/__tests__/ios/withGeofenceAppDelegate.test.ts
@@ -1,0 +1,101 @@
+import { modifyAppDelegateForGeofenceBootstrap } from '../../plugin/src/ios/withGeofenceAppDelegate';
+
+jest.mock('../../plugin/src/utils/logger', () => ({
+  logger: { warn: jest.fn(), info: jest.fn() },
+}));
+
+// Mirrors the real Expo SDK 53+ Swift AppDelegate: React Native is started via
+// factory.startReactNative(...) partway through didFinishLaunchingWithOptions, before the return.
+const PRISTINE_APP_DELEGATE = `import Expo
+import React
+import ReactAppDependencyProvider
+
+@main
+class AppDelegate: ExpoAppDelegate {
+  var window: UIWindow?
+
+  public override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    let delegate = ReactNativeDelegate()
+    let factory = ExpoReactNativeFactory(delegate: delegate)
+    delegate.dependencyProvider = RCTAppDependencyProvider()
+
+#if os(iOS) || os(tvOS)
+    window = UIWindow(frame: UIScreen.main.bounds)
+    factory.startReactNative(
+      withModuleName: "main",
+      in: window,
+      launchOptions: launchOptions)
+#endif
+
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+}
+`;
+
+// Expo SDK 54 uses `internal import Expo`.
+const APP_DELEGATE_INTERNAL_IMPORT = PRISTINE_APP_DELEGATE.replace(
+  'import Expo',
+  'internal import Expo'
+);
+
+describe('modifyAppDelegateForGeofenceBootstrap', () => {
+  it('adds the geofence import guarded by canImport', () => {
+    const result = modifyAppDelegateForGeofenceBootstrap(PRISTINE_APP_DELEGATE);
+    expect(result).toContain('#if canImport(CioLocationGeofence)');
+    expect(result).toContain('import CioLocationGeofence');
+    // Import lands after the existing imports, before the class declaration.
+    expect(result.indexOf('import CioLocationGeofence')).toBeLessThan(
+      result.indexOf('class AppDelegate')
+    );
+  });
+
+  it('injects the bootstrap at the top of didFinishLaunchingWithOptions, before React Native starts', () => {
+    const result = modifyAppDelegateForGeofenceBootstrap(PRISTINE_APP_DELEGATE);
+    expect(result).toContain(
+      'GeofenceModule.bootstrapForBackgroundDelivery(launchOptions: launchOptions)'
+    );
+    // Cold-wake delivery must not depend on the JS runtime, so the bootstrap has to run before
+    // factory.startReactNative(...) boots React Native (and before the delegate is created).
+    const bootstrapIdx = result.indexOf('bootstrapForBackgroundDelivery');
+    expect(bootstrapIdx).toBeGreaterThan(-1);
+    expect(bootstrapIdx).toBeLessThan(result.indexOf('let delegate = ReactNativeDelegate()'));
+    expect(bootstrapIdx).toBeLessThan(result.indexOf('factory.startReactNative'));
+  });
+
+  it('guards the bootstrap call with canImport', () => {
+    const result = modifyAppDelegateForGeofenceBootstrap(PRISTINE_APP_DELEGATE);
+    const guardCount = (result.match(/#if canImport\(CioLocationGeofence\)/g) || []).length;
+    // One guard for the import, one for the bootstrap call.
+    expect(guardCount).toBe(2);
+  });
+
+  it('handles the `internal import` variant', () => {
+    const result = modifyAppDelegateForGeofenceBootstrap(APP_DELEGATE_INTERNAL_IMPORT);
+    expect(result).toContain('import CioLocationGeofence');
+    expect(result).toContain('bootstrapForBackgroundDelivery');
+  });
+
+  it('is idempotent', () => {
+    const once = modifyAppDelegateForGeofenceBootstrap(PRISTINE_APP_DELEGATE);
+    const twice = modifyAppDelegateForGeofenceBootstrap(once);
+    expect(twice).toBe(once);
+    expect((twice.match(/bootstrapForBackgroundDelivery/g) || []).length).toBe(1);
+  });
+
+  it('injects the bootstrap on re-run when only the import was applied previously', () => {
+    // Simulates a prior prebuild that added the import but failed to inject the bootstrap:
+    // the re-run must add the missing bootstrap without duplicating the import.
+    const importOnly = PRISTINE_APP_DELEGATE.replace(
+      'import ReactAppDependencyProvider',
+      'import ReactAppDependencyProvider\n\n#if canImport(CioLocationGeofence)\nimport CioLocationGeofence\n#endif'
+    );
+    const result = modifyAppDelegateForGeofenceBootstrap(importOnly);
+    expect(result).toContain(
+      'GeofenceModule.bootstrapForBackgroundDelivery(launchOptions: launchOptions)'
+    );
+    expect((result.match(/import CioLocationGeofence/g) || []).length).toBe(1);
+  });
+});

--- a/api-extractor-output/customerio-expo-plugin.api.md
+++ b/api-extractor-output/customerio-expo-plugin.api.md
@@ -5,6 +5,11 @@
 ```ts
 
 // @public
+export type CustomerIOPluginGeofenceOptions = {
+    enabled?: boolean;
+};
+
+// @public
 export type CustomerIOPluginLocationOptions = {
     enabled?: boolean;
 };
@@ -15,6 +20,7 @@ export type CustomerIOPluginOptions = {
     android: CustomerIOPluginOptionsAndroid;
     ios: CustomerIOPluginOptionsIOS;
     location?: CustomerIOPluginLocationOptions;
+    geofence?: CustomerIOPluginGeofenceOptions;
 };
 
 // @public

--- a/plugin/src/android/withCIOAndroid.ts
+++ b/plugin/src/android/withCIOAndroid.ts
@@ -3,10 +3,12 @@ import type { ExpoConfig } from '@expo/config-types';
 import type {
   CustomerIOPluginOptionsAndroid,
   CustomerIOPluginLocationOptions,
+  CustomerIOPluginGeofenceOptions,
   NativeSDKConfig,
 } from '../types/cio-types';
 import { withAndroidManifestUpdates } from './withAndroidManifestUpdates';
 import { withAppGoogleServices } from './withAppGoogleServices';
+import { withGeofenceGradleProperties } from './withGeofenceGradleProperties';
 import { withGoogleServicesJSON } from './withGoogleServicesJSON';
 import { withLocationGradleProperties } from './withLocationGradleProperties';
 import { withMainApplicationModifications } from './withMainApplicationModifications';
@@ -20,6 +22,7 @@ export function withCIOAndroid(
   sdkConfig?: NativeSDKConfig,
   props?: CustomerIOPluginOptionsAndroid,
   location?: CustomerIOPluginLocationOptions,
+  geofence?: CustomerIOPluginGeofenceOptions,
 ): ExpoConfig {
   // Only run notification setup if props are provided
   if (props) {
@@ -49,6 +52,11 @@ export function withCIOAndroid(
   // Enable SDK location module when location.enabled is true
   if (location?.enabled === true) {
     config = withLocationGradleProperties(config, { location });
+  }
+
+  // Enable SDK geofence module when geofence.enabled is true (geofence implies location).
+  if (geofence?.enabled === true) {
+    config = withGeofenceGradleProperties(config, { geofence });
   }
 
   return config;

--- a/plugin/src/android/withGeofenceGradleProperties.ts
+++ b/plugin/src/android/withGeofenceGradleProperties.ts
@@ -1,0 +1,48 @@
+import type { ConfigPlugin } from '@expo/config-plugins';
+import { withGradleProperties } from '@expo/config-plugins';
+import type { PropertiesItem } from '@expo/config-plugins/build/android/Properties';
+
+import type { CustomerIOPluginGeofenceOptions } from '../types/cio-types';
+
+const CUSTOMERIO_GEOFENCE_ENABLED_KEY = 'customerio_geofence_enabled';
+
+export function modifyGeofenceGradleProperties(
+  items: PropertiesItem[]
+): PropertiesItem[] {
+  const existingIndex = items.findIndex(
+    (item) => item.type === 'property' && item.key === CUSTOMERIO_GEOFENCE_ENABLED_KEY
+  );
+
+  const newItem: PropertiesItem = {
+    type: 'property',
+    key: CUSTOMERIO_GEOFENCE_ENABLED_KEY,
+    value: 'true',
+  };
+
+  if (existingIndex >= 0) {
+    items[existingIndex] = newItem;
+  } else {
+    items.push(newItem);
+  }
+
+  return items;
+}
+
+/**
+ * Adds or updates customerio_geofence_enabled in android/gradle.properties when geofence.enabled is true.
+ * The Customer.io React Native SDK reads this to enable the geofence native module; geofence implies location,
+ * so the SDK also enables the location module from this flag alone.
+ */
+export const withGeofenceGradleProperties: ConfigPlugin<{
+  geofence?: CustomerIOPluginGeofenceOptions;
+}> = (config, props) => {
+  if (props?.geofence?.enabled !== true) {
+    return config;
+  }
+
+  return withGradleProperties(config, (config) => {
+    const items = config.modResults as PropertiesItem[];
+    config.modResults = modifyGeofenceGradleProperties(items);
+    return config;
+  });
+};

--- a/plugin/src/helpers/utils/injectCIOPodfileCode.ts
+++ b/plugin/src/helpers/utils/injectCIOPodfileCode.ts
@@ -7,7 +7,9 @@ import { FileManagement } from './fileManagement';
 export type InjectCIOPodfileOptions = {
   /** When true, add the location subspec. When false/omit, use single push subspec only. */
   locationEnabled?: boolean;
-  /** When false and locationEnabled, inject only :subspecs => ['location']. When true, use push + location. */
+  /** When true, add the geofence subspec (implies location). */
+  geofenceEnabled?: boolean;
+  /** When false, omit the push provider subspec (location/geofence-only). When true/omit, include it. */
   hasPush?: boolean;
 };
 
@@ -29,17 +31,25 @@ export function buildHostAppPodSnippet(
 ): string {
   const resolvedPath = getRelativePathToRNSDK(iosPath);
   const locationEnabled = options?.locationEnabled === true;
+  const geofenceEnabled = options?.geofenceEnabled === true;
   const hasPush = options?.hasPush !== false;
-
-  if (!locationEnabled) {
-    const subspec = isFcmPushProvider ? 'fcm' : 'apn';
-    return `pod 'customerio-reactnative/${subspec}', :path => '${resolvedPath}'`;
-  }
-  if (!hasPush) {
-    return `pod 'customerio-reactnative', :subspecs => ['location'], :path => '${resolvedPath}'`;
-  }
   const pushSubspec = isFcmPushProvider ? 'fcm' : 'apn';
-  return `pod 'customerio-reactnative', :subspecs => ['${pushSubspec}', 'location'], :path => '${resolvedPath}'`;
+
+  // No optional modules: keep the single push-provider subspec form. hasPush is intentionally
+  // not checked here — callers only pass hasPush:false alongside an enabled location/geofence module.
+  if (!locationEnabled && !geofenceEnabled) {
+    return `pod 'customerio-reactnative/${pushSubspec}', :path => '${resolvedPath}'`;
+  }
+
+  // Geofence pulls in Location transitively (and defines CIO_LOCATION_ENABLED), so the
+  // 'location' subspec is redundant when geofence is enabled.
+  const subspecs = [
+    ...(hasPush ? [pushSubspec] : []),
+    ...(locationEnabled && !geofenceEnabled ? ['location'] : []),
+    ...(geofenceEnabled ? ['geofence'] : []),
+  ];
+  const subspecList = subspecs.map((s) => `'${s}'`).join(', ');
+  return `pod 'customerio-reactnative', :subspecs => [${subspecList}], :path => '${resolvedPath}'`;
 }
 
 const HOST_APP_BLOCK_START = '# --- CustomerIO Host App START ---';

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -26,6 +26,15 @@ function withCustomerIOPlugin(
     );
   }
 
+  // Geofence relies on the Swift AppDelegate background-delivery bootstrap, which the
+  // plugin only injects on Swift projects (Expo SDK 53+).
+  if (props.geofence?.enabled && !isExpoVersion53OrHigher(config)) {
+    throw new Error(
+      'CustomerIO geofence requires Expo SDK 53 or higher. ' +
+      'Please upgrade to Expo SDK 53+ to enable geofence.'
+    );
+  }
+
   // Belt-and-suspenders write of the plugin version into the RN SDK's
   // package.json. The postinstall hook does the same write at install time;
   // this covers installs where postinstall didn't run cleanly (pnpm with
@@ -33,8 +42,8 @@ function withCustomerIOPlugin(
   config = withExpoVersion(config);
 
   // Apply platform specific modifications
-  config = withCIOIos(config, props.config, props.ios, props.location);
-  config = withCIOAndroid(config, props.config, props.android, props.location);
+  config = withCIOIos(config, props.config, props.ios, props.location, props.geofence);
+  config = withCIOAndroid(config, props.config, props.android, props.location, props.geofence);
 
   return config;
 }

--- a/plugin/src/ios/withCIOIos.ts
+++ b/plugin/src/ios/withCIOIos.ts
@@ -4,6 +4,7 @@ import type {
   CustomerIOPluginOptionsIOS,
   CustomerIOPluginPushNotificationOptions,
   CustomerIOPluginLocationOptions,
+  CustomerIOPluginGeofenceOptions,
   NativeSDKConfig,
 } from '../types/cio-types';
 import { mergeConfigWithEnvValues } from '../utils/config';
@@ -12,6 +13,7 @@ import { validatePushNotificationOptions } from '../utils/validation';
 import { isExpoVersion53OrHigher } from './utils';
 import { withAppDelegateModifications } from './withAppDelegateModifications';
 import { withCIOIosSwift } from './withCIOIosSwift';
+import { withGeofenceAppDelegate } from './withGeofenceAppDelegate';
 import { withGoogleServicesJsonFile } from './withGoogleServicesJsonFile';
 import { withCioNotificationsXcodeProject } from './withNotificationsXcodeProject';
 import { withCioXcodeProject } from './withXcodeProject';
@@ -21,10 +23,14 @@ export function withCIOIos(
   sdkConfig?: NativeSDKConfig,
   props?: CustomerIOPluginOptionsIOS,
   location?: CustomerIOPluginLocationOptions,
+  geofence?: CustomerIOPluginGeofenceOptions,
 ) {
   const isSwiftProject = isExpoVersion53OrHigher(config);
   const platformConfig = mergeDeprecatedPropertiesAndLogWarnings(props);
   const locationEnabled = location?.enabled === true;
+  const geofenceEnabled = geofence?.enabled === true;
+  // Geofence and location share the same optional native module wiring on iOS.
+  const optionalModulesEnabled = locationEnabled || geofenceEnabled;
 
   if (platformConfig?.pushNotification) {
     validatePushNotificationOptions(platformConfig.pushNotification);
@@ -43,6 +49,7 @@ export function withCIOIos(
       ...platformConfig,
       podfileOptions: {
         locationEnabled,
+        geofenceEnabled,
         hasPush: true,
       },
     });
@@ -62,18 +69,27 @@ export function withCIOIos(
     }
   } else if (sdkConfig && isSwiftProject) {
     config = withCIOIosSwift(config, sdkConfig, platformConfig, location);
-    if (locationEnabled) {
+    if (optionalModulesEnabled) {
       config = withCioXcodeProject(config, {
         ...platformConfig,
-        podfileOptions: { locationEnabled: true, hasPush: false },
+        podfileOptions: { locationEnabled, geofenceEnabled, hasPush: false },
       });
     }
-  } else if (locationEnabled) {
-    // Location-only: no push, no config. Still add Podfile location subspec so CIO_LOCATION_ENABLED is set and native location code is included.
+  } else if (optionalModulesEnabled) {
+    // Location/geofence-only: no push, no config. Still add the Podfile subspec so the
+    // native flags (CIO_LOCATION_ENABLED / CIO_GEOFENCE_ENABLED) are set and native code is included.
     config = withCioXcodeProject(config, {
       ...platformConfig,
-      podfileOptions: { locationEnabled: true, hasPush: false },
+      podfileOptions: { locationEnabled, geofenceEnabled, hasPush: false },
     });
+  }
+
+  // Geofence requires the iOS AppDelegate background-delivery bootstrap so cold-wake
+  // transitions are delivered even when the JS runtime isn't running. Inject it whenever
+  // geofence is enabled, independent of push/auto-init. Geofence is gated to Swift
+  // projects (Expo SDK 53+) at the plugin entry point.
+  if (geofenceEnabled && isSwiftProject) {
+    config = withGeofenceAppDelegate(config);
   }
 
   return config;

--- a/plugin/src/ios/withGeofenceAppDelegate.ts
+++ b/plugin/src/ios/withGeofenceAppDelegate.ts
@@ -1,0 +1,105 @@
+import type { ConfigPlugin } from '@expo/config-plugins';
+import { withAppDelegate } from '@expo/config-plugins';
+
+import { logger } from '../utils/logger';
+
+// Per-step idempotency markers. The two injections are guarded independently: the import marker
+// is added by addGeofenceImport and the bootstrap marker by injectGeofenceBootstrap. Keying both
+// steps off a single symbol would let a partial application (import added, bootstrap injection
+// failed) look "done" on the next prebuild, permanently skipping the missing bootstrap.
+const GEOFENCE_IMPORT_MARKER = 'import CioLocationGeofence';
+const GEOFENCE_BOOTSTRAP_MARKER = 'GeofenceModule.bootstrapForBackgroundDelivery';
+
+const GEOFENCE_IMPORT_SNIPPET = `#if canImport(CioLocationGeofence)
+import CioLocationGeofence
+#endif`;
+
+const GEOFENCE_BOOTSTRAP_SNIPPET = `    #if canImport(CioLocationGeofence)
+    // iOS can cold-launch the app for a geofence transition without the JS runtime, so bootstrap
+    // background delivery here rather than relying on CustomerIO.initialize. Safe alongside normal init.
+    GeofenceModule.bootstrapForBackgroundDelivery(launchOptions: launchOptions)
+    #endif
+`;
+
+/**
+ * Adds the geofence module import after the last top-level import statement.
+ * The import is compiled out via `#if canImport` when the geofence subspec is absent.
+ */
+const addGeofenceImport = (contents: string): string => {
+  if (contents.includes(GEOFENCE_IMPORT_MARKER)) {
+    return contents;
+  }
+
+  const importRegex = /^(?:@_exported\s+)?(?:internal\s+)?import\s+.+$/gm;
+  let lastMatchEnd = -1;
+  let match: RegExpExecArray | null;
+  while ((match = importRegex.exec(contents)) !== null) {
+    lastMatchEnd = match.index + match[0].length;
+  }
+
+  if (lastMatchEnd < 0) {
+    logger.warn('Could not find an import statement in AppDelegate.swift; skipping geofence import');
+    return contents;
+  }
+
+  return (
+    contents.substring(0, lastMatchEnd) +
+    `\n\n${GEOFENCE_IMPORT_SNIPPET}` +
+    contents.substring(lastMatchEnd)
+  );
+};
+
+/**
+ * Injects the geofence background-delivery bootstrap at the top of didFinishLaunchingWithOptions,
+ * before React Native is started (the Expo template calls `factory.startReactNative(...)` later in
+ * this method). Cold-wake delivery must not depend on the JS runtime, so it has to run first —
+ * matching the SDK's reference AppDelegate integration.
+ */
+const injectGeofenceBootstrap = (contents: string): string => {
+  if (contents.includes(GEOFENCE_BOOTSTRAP_MARKER)) {
+    return contents;
+  }
+
+  const methodRegex =
+    /(func\s+application\s*\(\s*_\s+application\s*:\s*UIApplication\s*,\s*didFinishLaunchingWithOptions[\s\S]*?\)\s*->\s*Bool\s*\{)/;
+  const match = contents.match(methodRegex);
+
+  if (!match) {
+    logger.warn(
+      'Could not find didFinishLaunchingWithOptions in AppDelegate.swift; skipping geofence bootstrap'
+    );
+    return contents;
+  }
+
+  const insertPosition = (match.index ?? 0) + match[0].length;
+  return (
+    contents.substring(0, insertPosition) +
+    `\n${GEOFENCE_BOOTSTRAP_SNIPPET}` +
+    contents.substring(insertPosition)
+  );
+};
+
+/**
+ * Pure string transform: adds the geofence import and background-delivery bootstrap
+ * to the Swift AppDelegate. Each step is independently idempotent, so a re-run after a
+ * partial application injects only the missing piece.
+ *
+ * Exported for tests.
+ */
+export function modifyAppDelegateForGeofenceBootstrap(contents: string): string {
+  return injectGeofenceBootstrap(addGeofenceImport(contents));
+}
+
+/**
+ * Injects the geofence background-delivery bootstrap into the Swift AppDelegate.
+ * Runs whenever geofence is enabled, independent of push/auto-init, so cold-wake
+ * background geofence transitions are delivered even when the JS runtime isn't running.
+ */
+export const withGeofenceAppDelegate: ConfigPlugin = (config) => {
+  return withAppDelegate(config, (appDelegateConfig) => {
+    appDelegateConfig.modResults.contents = modifyAppDelegateForGeofenceBootstrap(
+      appDelegateConfig.modResults.contents
+    );
+    return appDelegateConfig;
+  });
+};

--- a/plugin/src/types/cio-types.ts
+++ b/plugin/src/types/cio-types.ts
@@ -129,6 +129,17 @@ export type CustomerIOPluginLocationOptions = {
 };
 
 /**
+ * Geofence is off by default. When true, enables the Customer.io SDK geofence native module (iOS Podfile geofence subspec,
+ * Android gradle.properties flag) and injects the iOS AppDelegate background-delivery bootstrap. Geofence implies location,
+ * so enabling it also enables the location module. Permissions and privacy keys (Info.plist, AndroidManifest)
+ * remain the host app's responsibility.
+ * @public
+ */
+export type CustomerIOPluginGeofenceOptions = {
+  enabled?: boolean;
+};
+
+/**
  * Combined plugin options for both iOS and Android platforms
  * @public
  */
@@ -141,6 +152,12 @@ export type CustomerIOPluginOptions = {
    * gradle.properties). Host apps must add their own location permissions and privacy usage strings.
    */
   location?: CustomerIOPluginLocationOptions;
+  /**
+   * Geofence is off by default. When geofence.enabled is true, the plugin adds SDK build-time setup (Podfile geofence subspec,
+   * gradle.properties) and the iOS AppDelegate background-delivery bootstrap. Geofence implies location. Host apps must add
+   * their own location permissions and privacy usage strings.
+   */
+  geofence?: CustomerIOPluginGeofenceOptions;
 };
 
 /**


### PR DESCRIPTION
## Summary

First PR in the geofence stack. Adds **build-time enablement** of the Customer.io geofence native module via a new `geofence.enabled` plugin option. This wires the native module into the build and works with **manual initialization** — no auto-init (`config`) required. Auto-init config and the sample-app flow land in follow-up PRs.

Ticket: https://linear.app/customerio/issue/MBL-1787

> Targets `feature/geofence-on-device` (not `main`). This is part of a stacked series; the feature branch accumulates the geofence work until the native SDKs ship.

## What's included

**Plugin option**
- New `geofence?: { enabled?: boolean }` on `CustomerIOPluginOptions`. Off by default.
- Gated to **Expo SDK 53+** (Swift projects) — the plugin throws a clear error on older SDKs, since geofence relies on the Swift AppDelegate bootstrap.

**iOS**
- Adds the `geofence` subspec to the host-app Podfile. Geofence pulls in Location transitively, so the `location` subspec is omitted when geofence is enabled (avoids a redundant entry).
- Injects a `GeofenceModule.bootstrapForBackgroundDelivery(launchOptions:)` call at the top of `didFinishLaunchingWithOptions`, plus the `CioLocationGeofence` import. Both are wrapped in `#if canImport(CioLocationGeofence)` so they compile out when the subspec is absent. This is required so iOS cold-wake background geofence transitions are delivered even when the JS runtime isn't running. Injection is idempotent and handles the `internal import` variant (Expo 54).

**Android**
- Sets `customerio_geofence_enabled=true` in `gradle.properties`. The RN SDK enables the location module from this flag alone (geofence implies location), so no separate location flag is needed.

**Behavior notes**
- Geofence implies location on both platforms.
- Permissions and privacy keys (Info.plist `NSLocation*`, `UIBackgroundModes`; AndroidManifest location permissions) remain the **host app's responsibility** — the plugin injects none, matching the Location module and the SDK's "never request permission itself" contract.

## Tests
- `withGeofenceAppDelegate`: import placement, bootstrap-before-RN, `canImport` guards, `internal import` variant, idempotency.
- `withGeofenceGradleProperties`: add / update / disabled / omitted.
- `injectCIOPodfileCode`: full subspec matrix incl. geofence + push, geofence-implies-location.
- `withCIOIos`: geofence-only, geofence+location, geofence+push, disabled.
- `index`: Expo <53 throw, forwarding, disabled-no-throw.
- API report regenerated (adds `CustomerIOPluginGeofenceOptions` + the `geofence` option).

All green; `lint`, `tsc`, and the API-change check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes native build wiring and modifies AppDelegate launch order for background geofence delivery; mistakes could affect cold-start behavior on iOS, though changes are gated to Expo 53+ and heavily tested.
> 
> **Overview**
> Adds a **`geofence?: { enabled?: boolean }`** plugin option (off by default) so Expo apps can compile in the Customer.io geofence native module without auto-init. **`geofence.enabled` requires Expo SDK 53+**; the entry plugin throws on older SDKs because geofence depends on Swift AppDelegate changes.
> 
> On **iOS**, when enabled, the Podfile gains the **`geofence`** subspec (combined with push subspecs as needed), and the redundant **`location`** subspec is skipped because geofence implies location. **`withGeofenceAppDelegate`** injects a **`#if canImport`-guarded** `CioLocationGeofence` import and **`GeofenceModule.bootstrapForBackgroundDelivery`** at the start of **`didFinishLaunchingWithOptions`**, before React Native starts, with independent idempotency for import vs bootstrap.
> 
> On **Android**, **`customerio_geofence_enabled=true`** is written to **`gradle.properties`** when geofence is on (same add/update pattern as location). Permissions and privacy strings are still the host app’s responsibility.
> 
> Public types and API extractor output are updated; tests cover Gradle properties, Podfile subspec matrix, iOS wiring, AppDelegate injection, and Expo version gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88ddf3b37dccc1dc397c490e7224e60bdfb8f2d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->