### PR TITLE
chore: add geofence auto initialization

### DIFF
--- a/__tests__/utils/patchGeofenceCode.test.ts
+++ b/__tests__/utils/patchGeofenceCode.test.ts
@@ -1,0 +1,103 @@
+import { PLATFORM } from '../../plugin/src/helpers/constants/common';
+import { patchGeofencePlaceholders } from '../../plugin/src/helpers/utils/patchGeofenceCode';
+
+const IOS_TEMPLATE = `import CioMessagingInApp
+{{GEOFENCE_MODULE_IMPORT}}
+
+class Init {
+    static func initialize() {
+        let builder = SDKConfigBuilder(cdpApiKey: "x")
+        {{GEOFENCE_MODULE_INIT}}
+        CustomerIO.initialize(withConfig: builder.build())
+    }
+}
+`;
+
+const ANDROID_TEMPLATE = `import io.customer.reactnative.sdk.messaginginapp.ReactInAppEventListener
+{{GEOFENCE_MODULE_IMPORT}}
+import io.customer.sdk.CustomerIOBuilder
+
+object Init {
+    fun initialize() {
+        addCustomerIOModule(x)
+        {{GEOFENCE_MODULE_INIT}}
+
+        build()
+    }
+}
+`;
+
+describe('patchGeofencePlaceholders', () => {
+  describe('iOS', () => {
+    it('strips placeholders when geofence is disabled', () => {
+      const out = patchGeofencePlaceholders(IOS_TEMPLATE, PLATFORM.IOS, { enabled: false });
+      expect(out).not.toContain('{{GEOFENCE_MODULE_IMPORT}}');
+      expect(out).not.toContain('{{GEOFENCE_MODULE_INIT}}');
+      expect(out).not.toContain('CioLocationGeofence');
+      expect(out).not.toContain('GeofenceModule');
+      // The geofence init line is removed without leaving a stray blank line.
+      expect(out).toContain('"x")\n        CustomerIO.initialize');
+    });
+
+    it('strips placeholders when options are omitted', () => {
+      const out = patchGeofencePlaceholders(IOS_TEMPLATE, PLATFORM.IOS);
+      expect(out).not.toContain('{{GEOFENCE');
+      expect(out).not.toContain('GeofenceModule');
+    });
+
+    it('omits locationMode when unset (defers to SDK default), background delivery on', () => {
+      const out = patchGeofencePlaceholders(IOS_TEMPLATE, PLATFORM.IOS, { enabled: true });
+      expect(out).toContain('import CioLocationGeofence');
+      expect(out).toContain('GeofenceModule(config: GeofenceModuleConfig())');
+      expect(out).not.toContain('locationMode:');
+      expect(out).toContain('builder.allowBackgroundDelivery(true)');
+    });
+
+    it('honors MANUAL locationMode and explicit allowBackgroundDelivery=false', () => {
+      const out = patchGeofencePlaceholders(IOS_TEMPLATE, PLATFORM.IOS, {
+        enabled: true,
+        locationMode: 'MANUAL',
+        allowBackgroundDelivery: false,
+      });
+      expect(out).toContain('GeofenceModuleConfig(locationMode: .manual)');
+      expect(out).toContain('builder.allowBackgroundDelivery(false)');
+    });
+
+    it('omits locationMode for an unknown value (defers to SDK default)', () => {
+      const out = patchGeofencePlaceholders(IOS_TEMPLATE, PLATFORM.IOS, {
+        enabled: true,
+        locationMode: 'bogus' as never,
+      });
+      expect(out).toContain('GeofenceModuleConfig()');
+      expect(out).not.toContain('locationMode:');
+    });
+  });
+
+  describe('Android', () => {
+    it('strips placeholders when geofence is disabled', () => {
+      const out = patchGeofencePlaceholders(ANDROID_TEMPLATE, PLATFORM.ANDROID, { enabled: false });
+      expect(out).not.toContain('{{GEOFENCE_MODULE_IMPORT}}');
+      expect(out).not.toContain('{{GEOFENCE_MODULE_INIT}}');
+      expect(out).not.toContain('io.customer.geofence');
+      // Blank line before build() is preserved.
+      expect(out).toContain('addCustomerIOModule(x)\n\n        build()');
+    });
+
+    it('injects ModuleGeofence guarded by CIO_GEOFENCE_ENABLED when enabled', () => {
+      const out = patchGeofencePlaceholders(ANDROID_TEMPLATE, PLATFORM.ANDROID, {
+        enabled: true,
+        locationMode: 'MANUAL',
+      });
+      expect(out).toContain('import io.customer.geofence.ModuleGeofence');
+      expect(out).toContain('io.customer.reactnative.sdk.BuildConfig.CIO_GEOFENCE_ENABLED');
+      expect(out).toContain('GeofenceLocationMode.MANUAL');
+    });
+
+    it('omits setLocationMode and its import when locationMode is unset', () => {
+      const out = patchGeofencePlaceholders(ANDROID_TEMPLATE, PLATFORM.ANDROID, { enabled: true });
+      expect(out).toContain('GeofenceModuleConfig.Builder().build()');
+      expect(out).not.toContain('setLocationMode');
+      expect(out).not.toContain('import io.customer.geofence.GeofenceLocationMode');
+    });
+  });
+});

--- a/__tests__/utils/patchPluginNativeCode.test.ts
+++ b/__tests__/utils/patchPluginNativeCode.test.ts
@@ -254,6 +254,104 @@ describe('Native SDK Configuration Patching', () => {
       });
     });
 
+    describe('iOS geofence module', () => {
+      test('when geofence not enabled, omits geofence import and module', () => {
+        const result = patchNativeSDKInitializer(
+          swiftTemplateContent,
+          PLATFORM.IOS,
+          baseSdkConfig
+        );
+        expect(result).not.toContain('CioLocationGeofence');
+        expect(result).not.toContain('GeofenceModule');
+        expect(result).not.toContain('allowBackgroundDelivery');
+      });
+
+      test('when geofence enabled without a locationMode, omits it (SDK default) and turns on background delivery', () => {
+        const result = patchNativeSDKInitializer(
+          swiftTemplateContent,
+          PLATFORM.IOS,
+          baseSdkConfig,
+          { enabled: true, trackingMode: 'MANUAL' },
+          { enabled: true }
+        );
+        expect(result).toContain('import CioLocationGeofence');
+        expect(result).toContain('_ = builder.addModule(GeofenceModule(config: GeofenceModuleConfig()))');
+        expect(result).not.toContain('GeofenceModuleConfig(locationMode:');
+        expect(result).toContain('_ = builder.allowBackgroundDelivery(true)');
+      });
+
+      test('when geofence locationMode MANUAL, uses .manual', () => {
+        const result = patchNativeSDKInitializer(
+          swiftTemplateContent,
+          PLATFORM.IOS,
+          baseSdkConfig,
+          { enabled: true },
+          { enabled: true, locationMode: 'MANUAL' }
+        );
+        expect(result).toContain('GeofenceModuleConfig(locationMode: .manual)');
+      });
+
+      test('when allowBackgroundDelivery explicitly false, uses false', () => {
+        const result = patchNativeSDKInitializer(
+          swiftTemplateContent,
+          PLATFORM.IOS,
+          baseSdkConfig,
+          { enabled: true },
+          { enabled: true, allowBackgroundDelivery: false }
+        );
+        expect(result).toContain('_ = builder.allowBackgroundDelivery(false)');
+      });
+
+      test('geofence enabled also registers the location module (geofence implies location)', () => {
+        const result = patchNativeSDKInitializer(
+          swiftTemplateContent,
+          PLATFORM.IOS,
+          baseSdkConfig,
+          { enabled: true, trackingMode: 'MANUAL' },
+          { enabled: true }
+        );
+        expect(result).toContain('LocationModule(config: LocationConfig(mode: .manual))');
+        expect(result).toContain('GeofenceModule');
+      });
+    });
+
+    describe('Android geofence module', () => {
+      test('when geofence not enabled, omits geofence import and module', () => {
+        const result = patchNativeSDKInitializer(
+          kotlinTemplateContent,
+          PLATFORM.ANDROID,
+          baseSdkConfig
+        );
+        expect(result).not.toContain('io.customer.geofence');
+        expect(result).not.toContain('ModuleGeofence');
+      });
+
+      test('when geofence enabled, adds ModuleGeofence guarded by CIO_GEOFENCE_ENABLED', () => {
+        const result = patchNativeSDKInitializer(
+          kotlinTemplateContent,
+          PLATFORM.ANDROID,
+          baseSdkConfig,
+          { enabled: true },
+          { enabled: true, locationMode: 'AUTOMATIC' }
+        );
+        expect(result).toContain('import io.customer.geofence.ModuleGeofence');
+        expect(result).toContain('BuildConfig.CIO_GEOFENCE_ENABLED');
+        expect(result).toContain('GeofenceLocationMode.AUTOMATIC');
+        expect(result).toContain('ModuleGeofence(');
+      });
+    });
+
+    test('leaves no unreplaced geofence placeholders on either platform', () => {
+      const iosDisabled = patchNativeSDKInitializer(swiftTemplateContent, PLATFORM.IOS, baseSdkConfig);
+      const iosEnabled = patchNativeSDKInitializer(swiftTemplateContent, PLATFORM.IOS, baseSdkConfig, { enabled: true }, { enabled: true });
+      const androidDisabled = patchNativeSDKInitializer(kotlinTemplateContent, PLATFORM.ANDROID, baseSdkConfig);
+      const androidEnabled = patchNativeSDKInitializer(kotlinTemplateContent, PLATFORM.ANDROID, baseSdkConfig, { enabled: true }, { enabled: true });
+      for (const out of [iosDisabled, iosEnabled, androidDisabled, androidEnabled]) {
+        expect(out).not.toContain('{{GEOFENCE_MODULE_IMPORT}}');
+        expect(out).not.toContain('{{GEOFENCE_MODULE_INIT}}');
+      }
+    });
+
     describe('snapshots', () => {
       test('iOS complete', () => {
         const config = {

--- a/api-extractor-output/customerio-expo-plugin.api.md
+++ b/api-extractor-output/customerio-expo-plugin.api.md
@@ -79,6 +79,9 @@ export type CustomerIOPluginPushNotificationOptions = {
 };
 
 // @public
+export type GeofenceLocationMode = 'AUTOMATIC' | 'MANUAL';
+
+// @public
 export type LocationTrackingMode = 'OFF' | 'MANUAL' | 'ON_APP_START';
 
 // @public
@@ -93,6 +96,12 @@ export type NativeSDKConfig = {
     migrationSiteId?: string;
     location?: {
         trackingMode?: LocationTrackingMode;
+    };
+    geofence?: {
+        locationMode?: GeofenceLocationMode;
+    };
+    ios?: {
+        allowBackgroundDelivery?: boolean;
     };
 };
 

--- a/plugin/src/android/withCIOAndroid.ts
+++ b/plugin/src/android/withCIOAndroid.ts
@@ -39,7 +39,7 @@ export function withCIOAndroid(
 
   // Add auto initialization if sdkConfig is provided
   if (sdkConfig) {
-    config = withMainApplicationModifications(config, { sdkConfig, location });
+    config = withMainApplicationModifications(config, { sdkConfig, location, geofence });
   }
 
   // Update project strings for user agent metadata

--- a/plugin/src/android/withMainApplicationModifications.ts
+++ b/plugin/src/android/withMainApplicationModifications.ts
@@ -6,6 +6,7 @@ import { PLATFORM } from '../helpers/constants/common';
 import { patchNativeSDKInitializer } from '../helpers/utils/patchPluginNativeCode';
 import type {
   CustomerIOPluginLocationOptions,
+  CustomerIOPluginGeofenceOptions,
   NativeSDKConfig,
 } from '../types/cio-types';
 import { addCodeToMethod, addImportToFile, copyTemplateFile } from '../utils/android';
@@ -14,11 +15,12 @@ import { logger } from '../utils/logger';
 type MainApplicationModParams = {
   sdkConfig: NativeSDKConfig;
   location?: CustomerIOPluginLocationOptions;
+  geofence?: CustomerIOPluginGeofenceOptions;
 };
 
-export const withMainApplicationModifications: ConfigPlugin<MainApplicationModParams> = (configOuter, { sdkConfig, location }) => {
+export const withMainApplicationModifications: ConfigPlugin<MainApplicationModParams> = (configOuter, { sdkConfig, location, geofence }) => {
   return withMainApplication(configOuter, async (config) => {
-    const content = setupCustomerIOSDKInitializer(config, sdkConfig, location);
+    const content = setupCustomerIOSDKInitializer(config, sdkConfig, location, geofence);
     config.modResults.contents = content;
     return config;
   });
@@ -26,14 +28,28 @@ export const withMainApplicationModifications: ConfigPlugin<MainApplicationModPa
 
 /**
  * Build location options for native initializer from plugin config.
- * trackingMode comes from config.location.trackingMode (only used when location.enabled is true).
+ * trackingMode comes from config.location.trackingMode. Geofence implies location, so the
+ * location module is registered whenever location or geofence is enabled.
  */
 const getLocationInitOptions = (
   location?: CustomerIOPluginLocationOptions,
+  geofence?: CustomerIOPluginGeofenceOptions,
   sdkConfig?: NativeSDKConfig
 ) => ({
-  enabled: location?.enabled === true,
+  enabled: location?.enabled === true || geofence?.enabled === true,
   trackingMode: sdkConfig?.location?.trackingMode,
+});
+
+/**
+ * Build geofence options for native initializer from plugin config.
+ * locationMode comes from config.geofence.locationMode (only used when geofence.enabled is true).
+ */
+const getGeofenceInitOptions = (
+  geofence?: CustomerIOPluginGeofenceOptions,
+  sdkConfig?: NativeSDKConfig
+) => ({
+  enabled: geofence?.enabled === true,
+  locationMode: sdkConfig?.geofence?.locationMode,
 });
 
 const SDK_INITIALIZER_CLASS = 'CustomerIOSDKInitializer';
@@ -67,13 +83,15 @@ const setupCustomerIOSDKInitializer = (
   config: ExportedConfigWithProps<ApplicationProjectFile>,
   sdkConfig: NativeSDKConfig,
   location?: CustomerIOPluginLocationOptions,
+  geofence?: CustomerIOPluginGeofenceOptions,
 ): string => {
-  const locationOptions = getLocationInitOptions(location, sdkConfig);
+  const locationOptions = getLocationInitOptions(location, geofence, sdkConfig);
+  const geofenceOptions = getGeofenceInitOptions(geofence, sdkConfig);
 
   try {
     // Always regenerate the CustomerIOSDKInitializer file to reflect config changes
     copyTemplateFile(config, SDK_INITIALIZER_FILE, SDK_INITIALIZER_PACKAGE, (content) =>
-      patchNativeSDKInitializer(content, PLATFORM.ANDROID, sdkConfig, locationOptions)
+      patchNativeSDKInitializer(content, PLATFORM.ANDROID, sdkConfig, locationOptions, geofenceOptions)
     );
     return injectCustomerIOInitializerIntoMainApplication(config.modResults.contents);
   } catch (error) {

--- a/plugin/src/helpers/native-files/android/CustomerIOSDKInitializer.kt
+++ b/plugin/src/helpers/native-files/android/CustomerIOSDKInitializer.kt
@@ -8,6 +8,7 @@ import io.customer.messagingpush.MessagingPushModuleConfig
 import io.customer.messagingpush.ModuleMessagingPushFCM
 import io.customer.reactnative.sdk.messaginginapp.ReactInAppEventListener
 {{LOCATION_MODULE_IMPORT}}
+{{GEOFENCE_MODULE_IMPORT}}
 import io.customer.sdk.CustomerIOBuilder
 import io.customer.sdk.core.util.CioLogLevel
 import io.customer.sdk.data.model.Region
@@ -43,6 +44,7 @@ object CustomerIOSDKInitializer {
             )
         )
         {{LOCATION_MODULE_INIT}}
+        {{GEOFENCE_MODULE_INIT}}
 
         build()
     }

--- a/plugin/src/helpers/native-files/ios/CustomerIOSDKInitializer.swift
+++ b/plugin/src/helpers/native-files/ios/CustomerIOSDKInitializer.swift
@@ -2,6 +2,7 @@ import CioDataPipelines
 import CioInternalCommon
 import CioMessagingInApp
 {{LOCATION_MODULE_IMPORT}}
+{{GEOFENCE_MODULE_IMPORT}}
 
 class CustomerIOSDKInitializer {
     static func initialize() {
@@ -25,6 +26,7 @@ class CustomerIOSDKInitializer {
         setIfDefined(value: {{MIGRATION_SITE_ID}}, thenPassItTo: builder.migrationSiteId)
 
         {{LOCATION_MODULE_INIT}}
+        {{GEOFENCE_MODULE_INIT}}
         CustomerIO.initialize(withConfig: builder.build())
 
         if let siteId = siteId {

--- a/plugin/src/helpers/utils/patchGeofenceCode.ts
+++ b/plugin/src/helpers/utils/patchGeofenceCode.ts
@@ -1,0 +1,92 @@
+import type { GeofenceLocationMode } from '../../types/cio-types';
+import { PLATFORM, type Platform } from '../constants/common';
+
+const VALID_LOCATION_MODES: GeofenceLocationMode[] = ['AUTOMATIC', 'MANUAL'];
+
+/** Options for geofence module in generated native initializer */
+export type GeofenceInitOptions = {
+  enabled: boolean;
+  locationMode?: GeofenceLocationMode;
+  /** iOS-only. Defaults to true when geofence is enabled. */
+  allowBackgroundDelivery?: boolean;
+};
+
+// Returns the mode only when the customer set a valid value. When unset (or invalid) we return
+// undefined so the generated code omits the setter and defers to the native SDK's own default
+// (AUTOMATIC today) — the plugin never hard-codes a default the SDK might later change.
+function normalizeLocationMode(
+  rawMode: string | undefined
+): GeofenceLocationMode | undefined {
+  const upper = rawMode?.toUpperCase();
+  return upper && VALID_LOCATION_MODES.includes(upper as GeofenceLocationMode)
+    ? (upper as GeofenceLocationMode)
+    : undefined;
+}
+
+/**
+ * Replaces {{GEOFENCE_MODULE_IMPORT}} and {{GEOFENCE_MODULE_INIT}} placeholders
+ * in SDK initializer template content for the given platform. When geofence is
+ * disabled, the placeholders are stripped.
+ */
+export function patchGeofencePlaceholders(
+  content: string,
+  platform: Platform,
+  geofenceOptions?: GeofenceInitOptions
+): string {
+  const geofenceEnabled = geofenceOptions?.enabled === true;
+  const locationMode = normalizeLocationMode(geofenceOptions?.locationMode);
+
+  if (platform === PLATFORM.ANDROID) {
+    if (geofenceEnabled) {
+      // Only import GeofenceLocationMode / call setLocationMode when a mode was provided.
+      const imports = [
+        ...(locationMode ? ['import io.customer.geofence.GeofenceLocationMode'] : []),
+        'import io.customer.geofence.GeofenceModuleConfig',
+        'import io.customer.geofence.ModuleGeofence',
+      ].join('\n') + '\n';
+      const geofenceConfig = locationMode
+        ? `GeofenceModuleConfig.Builder()
+                        .setLocationMode(GeofenceLocationMode.${locationMode})
+                        .build()`
+        : 'GeofenceModuleConfig.Builder().build()';
+      return content
+        .replace(/\{\{GEOFENCE_MODULE_IMPORT\}\}/g, imports)
+        .replace(
+          /\{\{GEOFENCE_MODULE_INIT\}\}/g,
+          `if (io.customer.reactnative.sdk.BuildConfig.CIO_GEOFENCE_ENABLED) {
+            addCustomerIOModule(
+                ModuleGeofence(
+                    ${geofenceConfig}
+                )
+            )
+        }
+        `
+        );
+    }
+    return content
+      .replace(/\n\{\{GEOFENCE_MODULE_IMPORT\}\}\n/g, '\n')
+      .replace(/\n[ \t]*\{\{GEOFENCE_MODULE_INIT\}\}\n/g, '\n');
+  }
+
+  // iOS
+  if (geofenceEnabled) {
+    // Only pass locationMode when provided; otherwise defer to GeofenceModuleConfig's default.
+    const geofenceConfig = locationMode
+      ? `GeofenceModuleConfig(locationMode: ${locationMode === 'MANUAL' ? '.manual' : '.automatic'})`
+      : 'GeofenceModuleConfig()';
+    // Background delivery lets geofence transitions be sent while the app is backgrounded, so we
+    // default it on when the geofence module is added — it gives better delivery of geofence events.
+    // Customers can still override it, and non-geofence apps don't need it, so it stays off otherwise.
+    const allowBackgroundDelivery = geofenceOptions?.allowBackgroundDelivery ?? true;
+    return content
+      .replace(/\{\{GEOFENCE_MODULE_IMPORT\}\}/g, 'import CioLocationGeofence\n')
+      .replace(
+        /\{\{GEOFENCE_MODULE_INIT\}\}/g,
+        `_ = builder.addModule(GeofenceModule(config: ${geofenceConfig}))
+        _ = builder.allowBackgroundDelivery(${allowBackgroundDelivery})`
+      );
+  }
+  return content
+    .replace(/\n\{\{GEOFENCE_MODULE_IMPORT\}\}\n/g, '\n')
+    .replace(/\n[ \t]*\{\{GEOFENCE_MODULE_INIT\}\}\n/g, '\n');
+}

--- a/plugin/src/helpers/utils/patchPluginNativeCode.ts
+++ b/plugin/src/helpers/utils/patchPluginNativeCode.ts
@@ -3,11 +3,15 @@ import { getPluginVersion } from '../../utils/plugin';
 import { validateNativeSDKConfig } from '../../utils/validation';
 import { PLATFORM, type Platform } from '../constants/common';
 import {
+  type GeofenceInitOptions,
+  patchGeofencePlaceholders,
+} from './patchGeofenceCode';
+import {
   type LocationInitOptions,
   patchLocationPlaceholders,
 } from './patchLocationCode';
 
-export type { LocationInitOptions };
+export type { GeofenceInitOptions, LocationInitOptions };
 
 /**
  * Shared utility function to perform common SDK config replacements
@@ -17,7 +21,8 @@ export function patchNativeSDKInitializer(
   rawContent: string,
   platform: Platform,
   sdkConfig: NativeSDKConfig,
-  locationOptions?: LocationInitOptions
+  locationOptions?: LocationInitOptions,
+  geofenceOptions?: GeofenceInitOptions
 ): string {
   // Validate SDK configuration to ensure all fields are present and 
   // correct at the time of patching in prebuild
@@ -106,6 +111,7 @@ export function patchNativeSDKInitializer(
   );
 
   content = patchLocationPlaceholders(content, platform, locationOptions);
+  content = patchGeofencePlaceholders(content, platform, geofenceOptions);
 
   return content;
 }

--- a/plugin/src/ios/withCIOIos.ts
+++ b/plugin/src/ios/withCIOIos.ts
@@ -35,7 +35,7 @@ export function withCIOIos(
   if (platformConfig?.pushNotification) {
     validatePushNotificationOptions(platformConfig.pushNotification);
     if (isSwiftProject) {
-      config = withCIOIosSwift(config, sdkConfig, platformConfig, location);
+      config = withCIOIosSwift(config, sdkConfig, platformConfig, location, geofence);
     } else {
       // Auto initialization is only supported in Swift projects (Expo SDK 53+)
       // Legacy Objective-C projects only support push notifications
@@ -68,7 +68,7 @@ export function withCIOIos(
       });
     }
   } else if (sdkConfig && isSwiftProject) {
-    config = withCIOIosSwift(config, sdkConfig, platformConfig, location);
+    config = withCIOIosSwift(config, sdkConfig, platformConfig, location, geofence);
     if (optionalModulesEnabled) {
       config = withCioXcodeProject(config, {
         ...platformConfig,

--- a/plugin/src/ios/withCIOIosSwift.ts
+++ b/plugin/src/ios/withCIOIosSwift.ts
@@ -20,6 +20,7 @@ import { patchNativeSDKInitializer } from '../helpers/utils/patchPluginNativeCod
 import type {
   CustomerIOPluginOptionsIOS,
   CustomerIOPluginLocationOptions,
+  CustomerIOPluginGeofenceOptions,
   NativeSDKConfig,
 } from '../types/cio-types';
 import { logger } from '../utils/logger';
@@ -39,6 +40,7 @@ const copyAndConfigureAppDelegateHandler = (
   sdkConfig?: NativeSDKConfig,
   props?: CustomerIOPluginOptionsIOS,
   location?: CustomerIOPluginLocationOptions,
+  geofence?: CustomerIOPluginGeofenceOptions,
 ): ExportedConfigWithProps<XcodeProject> => {
   // Destination path in the iOS project
   const projectName = config.modRequest.projectName || '';
@@ -65,6 +67,7 @@ const copyAndConfigureAppDelegateHandler = (
       sdkConfig,
       props,
       location,
+      geofence,
     });
   } else if (sdkConfig) {
     // Copy only CustomerIOSDKInitializer.swift for auto-init without push notifications
@@ -75,6 +78,7 @@ const copyAndConfigureAppDelegateHandler = (
       projectName,
       sdkConfig,
       location,
+      geofence,
     });
   }
 
@@ -89,6 +93,7 @@ const copyAndConfigurePushAppDelegateHandler = ({
   sdkConfig,
   props,
   location,
+  geofence,
 }: {
   xcodeProject: XcodeProject;
   group: XcodeProject['pbxCreateGroup'];
@@ -97,6 +102,7 @@ const copyAndConfigurePushAppDelegateHandler = ({
   sdkConfig: NativeSDKConfig | undefined;
   props: CustomerIOPluginOptionsIOS;
   location?: CustomerIOPluginLocationOptions;
+  geofence?: CustomerIOPluginGeofenceOptions;
 }) => {
   const useFcm = isFcmPushProvider(props);
 
@@ -175,7 +181,7 @@ const copyAndConfigurePushAppDelegateHandler = ({
   // Add auto initialization if sdkConfig is provided
   if (sdkConfig) {
     // Also copy CustomerIOSDKInitializer.swift for auto-initialization
-    copyAndConfigureNativeSDKInitializer({ xcodeProject, group, iosProjectRoot, projectName, sdkConfig, location });
+    copyAndConfigureNativeSDKInitializer({ xcodeProject, group, iosProjectRoot, projectName, sdkConfig, location, geofence });
 
     // Inject auto initialization call before MessagingPush initialization
     handlerFileContent = handlerFileContent.replace(CIO_MESSAGING_PUSH_APP_DELEGATE_INIT_REGEX, CIO_NATIVE_SDK_INITIALIZE_SNIPPET + '$1');
@@ -191,6 +197,7 @@ const copyAndConfigureNativeSDKInitializer = ({
   projectName,
   sdkConfig,
   location,
+  geofence,
 }: {
   xcodeProject: XcodeProject;
   group: XcodeProject['pbxCreateGroup'];
@@ -198,10 +205,19 @@ const copyAndConfigureNativeSDKInitializer = ({
   projectName: string;
   sdkConfig: NativeSDKConfig;
   location?: CustomerIOPluginLocationOptions;
+  geofence?: CustomerIOPluginGeofenceOptions;
 }) => {
-  const locationOptions = location
-    ? { enabled: location.enabled === true, trackingMode: sdkConfig?.location?.trackingMode }
-    : undefined;
+  const geofenceEnabled = geofence?.enabled === true;
+  // Geofence implies location: register the location module whenever location or geofence is enabled.
+  const locationOptions = {
+    enabled: location?.enabled === true || geofenceEnabled,
+    trackingMode: sdkConfig?.location?.trackingMode,
+  };
+  const geofenceOptions = {
+    enabled: geofenceEnabled,
+    locationMode: sdkConfig?.geofence?.locationMode,
+    allowBackgroundDelivery: sdkConfig?.ios?.allowBackgroundDelivery,
+  };
   const filename = 'CustomerIOSDKInitializer.swift';
   const sourcePath = path.join(getIosNativeFilesPath(), filename);
   // Add the CustomerIOSDKInitializer.swift file to the same Xcode group as CioSdkAppDelegateHandler
@@ -212,7 +228,7 @@ const copyAndConfigureNativeSDKInitializer = ({
     sourceFilePath: sourcePath,
     targetFileName: filename,
     transform: (content) =>
-      patchNativeSDKInitializer(content, PLATFORM.IOS, sdkConfig, locationOptions),
+      patchNativeSDKInitializer(content, PLATFORM.IOS, sdkConfig, locationOptions, geofenceOptions),
     customerIOGroup: group,
   });
 };
@@ -222,10 +238,11 @@ export const withCIOIosSwift = (
   sdkConfig?: NativeSDKConfig,
   props?: CustomerIOPluginOptionsIOS,
   location?: CustomerIOPluginLocationOptions,
+  geofence?: CustomerIOPluginGeofenceOptions,
 ) => {
   // First, copy required swift files to iOS folder and add it to Xcode project
   configOuter = withXcodeProject(configOuter, async (config) => {
-    return copyAndConfigureAppDelegateHandler(config, sdkConfig, props, location);
+    return copyAndConfigureAppDelegateHandler(config, sdkConfig, props, location, geofence);
   });
 
   // Modify the AppDelegate based on configuration

--- a/plugin/src/types/cio-types.ts
+++ b/plugin/src/types/cio-types.ts
@@ -96,6 +96,15 @@ export type CustomerIOPluginOptionsAndroid = {
 export type LocationTrackingMode = 'OFF' | 'MANUAL' | 'ON_APP_START';
 
 /**
+ * Geofence location mode for the Customer.io SDK geofence module.
+ * Geofence is off by default. Only used when geofence is enabled (plugin option geofence.enabled: true).
+ * 'AUTOMATIC' (SDK refreshes geofences on its own, default) or 'MANUAL' (host app drives refreshes via
+ * CustomerIO.geofence.refreshFromCurrentLocation()).
+ * @public
+ */
+export type GeofenceLocationMode = 'AUTOMATIC' | 'MANUAL';
+
+/**
  * SDK configuration options for auto initialization
  * @public
  */
@@ -109,12 +118,29 @@ export type NativeSDKConfig = {
   siteId?: string; // Optional, if only siteId defined, migrationSiteId = siteId
   migrationSiteId?: string; // Optional, if only migrationSiteId defined, siteId should be null
   /**
-   * Location module config. Location is off by default; only applied when plugin option location.enabled is true.
-   * trackingMode: 'MANUAL' (host app controls when location is captured, default),
+   * Location module config. Location is off by default. Applied whenever the location module is
+   * registered — when location.enabled is true, or when geofence.enabled is true (geofence implies
+   * location). trackingMode: 'MANUAL' (host app controls when location is captured, default),
    * 'ON_APP_START' (SDK captures once per launch when app becomes active), or 'OFF'.
    */
   location?: {
     trackingMode?: LocationTrackingMode;
+  };
+  /**
+   * Geofence module config. Geofence is off by default; only applied when plugin option geofence.enabled is true.
+   * Geofence implies location, so the location module is registered automatically when geofence is enabled.
+   * locationMode: 'AUTOMATIC' (default) or 'MANUAL'.
+   */
+  geofence?: {
+    locationMode?: GeofenceLocationMode;
+  };
+  /**
+   * iOS-only SDK config.
+   * allowBackgroundDelivery: enables background delivery of geofence transitions. Defaults to true when
+   * geofence is enabled, false otherwise. Set explicitly to override.
+   */
+  ios?: {
+    allowBackgroundDelivery?: boolean;
   };
 };
 


### PR DESCRIPTION
## Summary

Second PR in the geofence stack. Adds **auto-initialization** support for geofence: when the app uses the `config` property (auto-init), the plugin now generates the geofence module registration into the native `CustomerIOSDKInitializer`. Builds on PR1's build-time enablement.

Ticket: https://linear.app/customerio/issue/MBL-1787

> **Stacked on #368** — targets `mbl-1787-geofence-manual-init`, not `main`. Review/merge #368 first; this diff shows only the auto-init changes. I'll retarget to `feature/geofence-on-device` once PR1 lands.

## What's included

**Config**
- `config.geofence.locationMode`: `'AUTOMATIC'` (default) or `'MANUAL'`. Only applied when `geofence.enabled` is true.
- `config.ios.allowBackgroundDelivery`: iOS-only. Defaults to `true` when geofence is enabled; set explicitly to override.

**Generated native init** (via `{{GEOFENCE_MODULE_IMPORT}}` / `{{GEOFENCE_MODULE_INIT}}` placeholders in the SDK initializer templates)
- **iOS**: `builder.addModule(GeofenceModule(config: GeofenceModuleConfig(locationMode: .automatic|.manual)))` + `builder.allowBackgroundDelivery(...)`.
- **Android**: `addCustomerIOModule(ModuleGeofence(GeofenceModuleConfig.Builder().setLocationMode(...).build()))`, guarded by `BuildConfig.CIO_GEOFENCE_ENABLED`.
- When geofence is disabled, the placeholders are stripped cleanly (no stray imports, no leftover whitespace).

**Behavior**
- Geofence implies location: enabling geofence also registers the location module in the generated initializer (mirrors the Podfile subspec / gradle flag behavior from PR1).
- `patchGeofenceCode` runs after `patchLocationCode` in the shared patcher; the disabled-strip is horizontal-whitespace-scoped so it composes with the location strip without collapsing blank lines. Locked by snapshot tests.

## Tests
- `patchGeofenceCode`: enabled/disabled/omitted, MANUAL mode, `allowBackgroundDelivery=false`, unknown-mode → AUTOMATIC fallback, whitespace.
- `patchPluginNativeCode`: real iOS + Android templates, geofence-implies-location, "no leftover placeholders" guard, plus regenerated snapshots.
- API report adds `GeofenceLocationMode` and the `NativeSDKConfig.geofence` / `NativeSDKConfig.ios` fields.

All green; `lint`, `tsc`, and the API-change check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes generated native startup code and background delivery defaults for geofence-enabled apps; behavior is config-gated and covered by unit/snapshot tests, but mistakes in patching could affect location/geofence at runtime.
> 
> **Overview**
> Adds **geofence auto-init** when apps use top-level `config`: prebuild now patches `CustomerIOSDKInitializer` templates with geofence module registration on iOS and Android.
> 
> **Public config:** `NativeSDKConfig` gains `geofence.locationMode` (`AUTOMATIC` | `MANUAL`) and `ios.allowBackgroundDelivery` (defaults on when geofence is enabled). New `patchGeofencePlaceholders` fills or strips `{{GEOFENCE_MODULE_IMPORT}}` / `{{GEOFENCE_MODULE_INIT}}` — iOS adds `GeofenceModule` plus `allowBackgroundDelivery`; Android wraps `ModuleGeofence` in `CIO_GEOFENCE_ENABLED`. Invalid/unset `locationMode` omits explicit SDK setters so native defaults apply.
> 
> **Wiring:** `patchNativeSDKInitializer` takes a fifth `geofenceOptions` argument; iOS/Android auto-init paths pass `geofence` from plugin options. **Geofence implies location:** location module init runs when `geofence.enabled` is true even if `location.enabled` is false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 660a361939c5e9f703fe2669f00a180247a12e11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->