### PR TITLE
chore(test-app): add geofence permission flow and demo

### DIFF
--- a/test-app/app.json
+++ b/test-app/app.json
@@ -16,6 +16,10 @@
       },
       "infoPlist": {
         "NSLocationWhenInUseUsageDescription": "This app uses location to test Customer.io location features.",
+        "NSLocationAlwaysAndWhenInUseUsageDescription": "This app uses location in the background to test Customer.io geofence features.",
+        "UIBackgroundModes": [
+          "location"
+        ],
         "CFBundleURLTypes": [
           {
             "CFBundleURLSchemes": [
@@ -35,6 +39,12 @@
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
       "package": "io.customer.testbed.expo",
+      "permissions": [
+        "android.permission.ACCESS_FINE_LOCATION",
+        "android.permission.ACCESS_COARSE_LOCATION",
+        "android.permission.ACCESS_BACKGROUND_LOCATION",
+        "android.permission.RECEIVE_BOOT_COMPLETED"
+      ],
       "intentFilters": [
         {
           "action": "VIEW",
@@ -89,6 +99,9 @@
             "logLevel": "debug",
             "location": {
               "trackingMode": "MANUAL"
+            },
+            "geofence": {
+              "locationMode": "AUTOMATIC"
             }
           },
           "android": {
@@ -120,6 +133,9 @@
             }
           },
           "location": {
+            "enabled": true
+          },
+          "geofence": {
             "enabled": true
           }
         }

--- a/test-app/screens/Location.js
+++ b/test-app/screens/Location.js
@@ -1,8 +1,9 @@
 import { CustomerIO } from 'customerio-reactnative';
 import * as Location from 'expo-location';
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Alert,
+  AppState,
   Linking,
   ScrollView,
   StyleSheet,
@@ -39,6 +40,114 @@ export default function LocationScreen() {
   const [lastSetLocation, setLastSetLocation] = useState(null);
   const [sdkRequestingLabel, setSdkRequestingLabel] = useState(false);
   const [useCurrentLocationLoading, setUseCurrentLocationLoading] = useState(false);
+  // Geofence: 'notDetermined' | 'foregroundOnly' | 'backgroundGranted' | 'denied' | 'backgroundDenied'
+  const [geofenceStatus, setGeofenceStatus] = useState('notDetermined');
+  // Mirrors geofenceStatus for the AppState listener, whose closure would otherwise see a stale value.
+  const geofenceStatusRef = useRef(geofenceStatus);
+  useEffect(() => {
+    geofenceStatusRef.current = geofenceStatus;
+  }, [geofenceStatus]);
+
+  // Geofence transitions only fire in the background once "Always"/"Allow all the time" is granted.
+  // The SDK never requests location permission itself, so the app owns the permission flow and tells
+  // the SDK to refresh once permission changes (the SDK's own fetch runs once per process).
+  const refreshGeofences = useCallback(() => {
+    try {
+      CustomerIO.geofence.refreshFromCurrentLocation();
+    } catch (e) {
+      Alert.alert('Error', (e && e.message) || String(e));
+    }
+  }, []);
+
+  const readGeofenceStatus = useCallback(async () => {
+    const foreground = await Location.getForegroundPermissionsAsync();
+    if (foreground.status !== 'granted') {
+      const next = foreground.canAskAgain ? 'notDetermined' : 'denied';
+      setGeofenceStatus(next);
+      return next;
+    }
+    const background = await Location.getBackgroundPermissionsAsync();
+    let next;
+    if (background.status === 'granted') {
+      next = 'backgroundGranted';
+    } else {
+      // Distinguish "can still prompt" (foregroundOnly) from "permanently blocked" (Settings only).
+      next = background.canAskAgain ? 'foregroundOnly' : 'backgroundDenied';
+    }
+    setGeofenceStatus(next);
+    return next;
+  }, []);
+
+  // Re-check on mount and whenever the app returns to the foreground (e.g. back from Settings).
+  // Refresh only when background access was *newly* granted, not on every resume.
+  useEffect(() => {
+    readGeofenceStatus();
+    const sub = AppState.addEventListener('change', async (state) => {
+      if (state !== 'active') {
+        return;
+      }
+      const previous = geofenceStatusRef.current;
+      const next = await readGeofenceStatus();
+      if (next === 'backgroundGranted' && previous !== 'backgroundGranted') {
+        refreshGeofences();
+      }
+    });
+    return () => sub.remove();
+  }, [readGeofenceStatus, refreshGeofences]);
+
+  const handleGeofencePermissionTap = async () => {
+    try {
+      if (geofenceStatus === 'denied' || geofenceStatus === 'backgroundDenied') {
+        showLocationPermissionAlert();
+        return;
+      }
+      if (geofenceStatus === 'notDetermined') {
+        const foreground = await Location.requestForegroundPermissionsAsync();
+        if (foreground.status !== 'granted') {
+          setGeofenceStatus(foreground.canAskAgain ? 'notDetermined' : 'denied');
+          return;
+        }
+        // Re-read rather than assume foregroundOnly — background may already be granted.
+        const next = await readGeofenceStatus();
+        if (next === 'backgroundGranted') {
+          refreshGeofences();
+        }
+        return;
+      }
+      if (geofenceStatus === 'foregroundOnly') {
+        Alert.alert(
+          'Allow location "Always"',
+          'Geofence transitions only fire in the background. Grant "Always" (iOS) or ' +
+          '"Allow all the time" (Android) so the SDK can monitor regions while the app is closed.',
+          [
+            { text: 'Cancel', style: 'cancel' },
+            {
+              text: 'Continue',
+              onPress: async () => {
+                await Location.requestBackgroundPermissionsAsync();
+                const next = await readGeofenceStatus();
+                if (next === 'backgroundGranted') {
+                  refreshGeofences();
+                } else if (next === 'backgroundDenied') {
+                  showLocationPermissionAlert();
+                }
+              },
+            },
+          ]
+        );
+      }
+    } catch (e) {
+      Alert.alert('Error', (e && e.message) || String(e));
+    }
+  };
+
+  const geofencePermissionLabel = {
+    notDetermined: 'Grant location access',
+    foregroundOnly: 'Upgrade to "Always" / "Allow all the time"',
+    backgroundGranted: 'Background location granted ✓',
+    denied: 'Open Settings',
+    backgroundDenied: 'Open Settings',
+  }[geofenceStatus];
 
   const setLocation = (lat, lng, source) => {
     try {
@@ -207,6 +316,27 @@ export default function LocationScreen() {
           </View>
           <Button title="Set Location" onPress={handleManualSet} />
           <ThemedText style={styles.hint}>Enter custom coordinates</ThemedText>
+        </ThemedView>
+
+        <View style={styles.orRow}>
+          <View style={styles.orLine} />
+          <ThemedText style={styles.orText}>GEOFENCE</ThemedText>
+          <View style={styles.orLine} />
+        </View>
+
+        <ThemedView style={styles.sectionCard}>
+          <ThemedText style={styles.sectionHeading}>OPTION 5: GEOFENCE MONITORING</ThemedText>
+          <Button
+            title={geofencePermissionLabel}
+            onPress={handleGeofencePermissionTap}
+            disabled={geofenceStatus === 'backgroundGranted'}
+          />
+          <Button title="Refresh geofences from current location" onPress={refreshGeofences} />
+          <ThemedText style={styles.hint}>
+            Geofence transitions fire in the background once "Always" location is granted. The SDK
+            never requests permission itself; the app grants it, then calls
+            CustomerIO.geofence.refreshFromCurrentLocation() to (re)evaluate nearby geofences.
+          </ThemedText>
         </ThemedView>
 
         <ThemedView style={styles.statusCard}>


### PR DESCRIPTION
## Summary

Third PR in the geofence stack. Adds a geofence demo to the sample **test-app** — the permission flow and refresh wiring a customer app needs, mirroring what we did for React Native. No plugin source changes.

Ticket: https://linear.app/customerio/issue/MBL-1787

> **Stacked on #369** — targets `mbl-1787-geofence-auto-init`, not `main`. Review/merge #369 first; this diff shows only the sample-app changes. I'll retarget to `feature/geofence-on-device` as the stack lands.

## What's included

**`test-app/screens/Location.js`** — a geofence section:
- Permission flow that mirrors the RN sample: request foreground first, then escalate to **"Always" / "Allow all the time"** (background), since geofence transitions only fire in the background. Status state machine: `notDetermined → foregroundOnly → backgroundGranted` (or `denied` → deep-link to Settings), driven by `expo-location`.
- "Refresh geofences from current location" → `CustomerIO.geofence.refreshFromCurrentLocation()`.
- `AppState` listener that re-checks permission and nudges a refresh when the app returns to foreground (e.g. back from Settings with background access newly granted).

**`test-app/app.json`**:
- Plugin config: `geofence: { enabled: true }` and `config.geofence.locationMode: "AUTOMATIC"`.
- iOS: `NSLocationWhenInUse` / `NSLocationAlwaysAndWhenInUse` usage strings + `UIBackgroundModes: [location]`.
- Android: fine/coarse/background location + `RECEIVE_BOOT_COMPLETED` permissions.

Permissions stay entirely in the host app (`app.json`) — the plugin injects none; the SDK never requests them itself.

## Not in this PR (intentionally, until native SDKs ship)
The peer bump to `customerio-reactnative` 6.7.0 and the TEMP snapshot/branch workaround are kept as local commits, unpublished — so nothing pre-release lands on the feature branch. Full native builds of the test-app therefore require those local commits until 6.7.0 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sample-app and manifest/demo UI only; no production SDK or plugin logic changes.
> 
> **Overview**
> Adds **geofence testing** to the Expo test-app only (no plugin changes).
> 
> **`test-app/app.json`** turns on Customer.io geofence (`geofence.enabled`, `locationMode: "AUTOMATIC"`) and declares the host-app permissions/plists needed for background location: iOS **Always** usage string + `UIBackgroundModes: location`; Android fine/coarse/background location and `RECEIVE_BOOT_COMPLETED`.
> 
> **`test-app/screens/Location.js`** adds **Option 5: Geofence monitoring** — an app-owned permission state machine (`expo-location`: foreground → **Always / Allow all the time**), UI to escalate or open Settings, manual **`CustomerIO.geofence.refreshFromCurrentLocation()`**, and an **`AppState`** hook that re-reads permissions and refreshes geofences only when background access is newly granted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 164525332f1b9ad6f1cb78b2a47d0e7a3d82d38a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->