### PR TITLE
chore: fix register CustomerIO Xcode group by key

### DIFF
--- a/__tests__/utils/xcode.test.ts
+++ b/__tests__/utils/xcode.test.ts
@@ -1,0 +1,81 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const xcode = require('xcode');
+import { copyFileToXcode, getOrCreateCustomerIOGroup } from '../../plugin/src/utils/xcode';
+import { getFixturePath } from '../utils';
+
+jest.mock('../../plugin/src/helpers/utils/fileManagement', () => ({
+  FileManagement: {
+    readFile: jest.fn(() => 'source contents'),
+    writeFile: jest.fn(),
+  },
+}));
+
+const PROJECT_NAME = 'ExpoTestbed';
+
+type Project = ReturnType<typeof xcode.project>;
+
+const loadProject = (name = 'vanilla'): Project => {
+  const project = xcode.project(getFixturePath('ios/pbxproj', `${name}.pbxproj`));
+  project.parseSync();
+  return project;
+};
+
+// Delete the fixture's pre-existing CustomerIO group (object + comment entries) so the
+// create branch runs.
+const removeCustomerIOGroup = (project: Project): void => {
+  const groups = project.hash.project.objects.PBXGroup;
+  for (const key of Object.keys(groups)) {
+    const value = groups[key];
+    const isComment = value === 'CustomerIO';
+    const isGroup = value && typeof value === 'object' && value.name === 'CustomerIO';
+    if (isComment || isGroup) {
+      delete groups[key];
+    }
+  }
+};
+
+describe('getOrCreateCustomerIOGroup', () => {
+  // Regression for the object-vs-key bug: the existing-group branch must return the group KEY,
+  // not the group object. Passing the object to addSourceFile crashes on pbxproj files without a
+  // PBXVariantGroup section (Expo SDK 55). withCIOIosSwift's test mocks this helper, so it can't
+  // catch a regression here.
+  it('returns the existing CustomerIO group key, not the object', () => {
+    const project = loadProject();
+    const result = getOrCreateCustomerIOGroup(project, PROJECT_NAME);
+    expect(typeof result).toBe('string');
+    expect(project.getPBXGroupByKey(result)?.name).toBe('CustomerIO');
+  });
+
+  it('creates the CustomerIO group and returns its key when none exists', () => {
+    const project = loadProject();
+    removeCustomerIOGroup(project);
+    expect(project.pbxGroupByName('CustomerIO')).toBeFalsy();
+
+    const result = getOrCreateCustomerIOGroup(project, PROJECT_NAME);
+    expect(typeof result).toBe('string');
+    expect(project.getPBXGroupByKey(result)?.name).toBe('CustomerIO');
+  });
+});
+
+describe('copyFileToXcode', () => {
+  it('passes the CustomerIO group key (not object) to addSourceFile', () => {
+    const project = loadProject();
+    const addSourceFile = jest
+      .spyOn(project, 'addSourceFile')
+      .mockImplementation(() => ({}));
+    const groupKey = getOrCreateCustomerIOGroup(project, PROJECT_NAME);
+
+    copyFileToXcode({
+      xcodeProject: project,
+      iosProjectRoot: '/tmp/ios',
+      projectName: PROJECT_NAME,
+      sourceFilePath: '/tmp/Src.swift',
+      targetFileName: 'Src.swift',
+      transform: (content) => content,
+      customerIOGroup: groupKey,
+    });
+
+    expect(addSourceFile).toHaveBeenCalledWith('ExpoTestbed/Src.swift', null, groupKey);
+    expect(typeof addSourceFile.mock.calls[0][2]).toBe('string');
+  });
+});

--- a/plugin/src/ios/withCIOIosSwift.ts
+++ b/plugin/src/ios/withCIOIosSwift.ts
@@ -96,7 +96,7 @@ const copyAndConfigurePushAppDelegateHandler = ({
   geofence,
 }: {
   xcodeProject: XcodeProject;
-  group: XcodeProject['pbxCreateGroup'];
+  group: string;
   iosProjectRoot: string;
   projectName: string;
   sdkConfig: NativeSDKConfig | undefined;
@@ -200,7 +200,7 @@ const copyAndConfigureNativeSDKInitializer = ({
   geofence,
 }: {
   xcodeProject: XcodeProject;
-  group: XcodeProject['pbxCreateGroup'];
+  group: string;
   iosProjectRoot: string;
   projectName: string;
   sdkConfig: NativeSDKConfig;

--- a/plugin/src/utils/xcode.ts
+++ b/plugin/src/utils/xcode.ts
@@ -7,20 +7,21 @@ import { logger } from './logger';
  * Gets an existing CustomerIO group or creates a new one in the Xcode project
  * @param xcodeProject The Xcode project instance
  * @param projectName The iOS project name
- * @returns The CustomerIO group reference
+ * @returns The CustomerIO group key
  */
 export function getOrCreateCustomerIOGroup(
   xcodeProject: XcodeProject,
   projectName: string,
-): XcodeProject['pbxCreateGroup'] {
-  // Check if CustomerIO group already exists
-  let customerIOGroup = xcodeProject.pbxGroupByName('CustomerIO');
-  if (customerIOGroup) {
-    return customerIOGroup;
+): string {
+  // Return the group key (not the group object): addSourceFile expects a key, and passing the
+  // object throws on pbxproj files that have no PBXVariantGroup section (e.g. Expo SDK 55).
+  const existingKey = xcodeProject.findPBXGroupKey({ name: 'CustomerIO' });
+  if (existingKey) {
+    return existingKey;
   }
 
   // Create new CustomerIO group and add it to the project
-  customerIOGroup = xcodeProject.pbxCreateGroup('CustomerIO');
+  const customerIOGroup = xcodeProject.pbxCreateGroup('CustomerIO');
   const projectGroupKey = xcodeProject.findPBXGroupKey({ name: projectName });
   xcodeProject.addToPbxGroup(customerIOGroup, projectGroupKey);
   return customerIOGroup;
@@ -52,7 +53,7 @@ export function copyFileToXcode({
   sourceFilePath: string;
   targetFileName: string;
   transform: (content: string) => string;
-  customerIOGroup?: XcodeProject['pbxCreateGroup'];
+  customerIOGroup?: string;
 }): string {
   // Construct the full destination path within the iOS project directory
   const destinationPath = path.join(


### PR DESCRIPTION
## What

`getOrCreateCustomerIOGroup` now returns the CustomerIO **group key** in both branches. Previously the create branch returned a key (correct) but the existing-group branch returned the group **object**.

## Why

`xcodeProject.addSourceFile(path, opt, group)` expects `group` to be a **key string**. When passed the object, the lookup falls through to `getPBXVariantGroupByKey`, which throws `Cannot read properties of undefined` on any `project.pbxproj` that has no `PBXVariantGroup` section — the case for the Expo SDK 55 template.

Today push is the only caller (creates the group once, reuses the key), so the bug is latent. It surfaces the moment a **second** caller finds the already-created group and gets the object back — which is exactly what the upcoming geofence AppDelegate handler does. This lands the fix first so that change stacks cleanly.

## Verification

- `expo prebuild` on Expo SDK 55 (test-app, RN 0.83.6): ✔ finishes; push handler registered (build file + file ref + CustomerIO group + Sources phase).
- lint, api-extractor (no public API change), and unit tests green (baseline pre-existing fcm/postInstall failures only).

Ticket: https://linear.app/customerio/issue/MBL-1787

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Expo config-plugin iOS `pbxproj` mutation during prebuild; incorrect group handling can break source registration, but the change is a narrow bugfix with targeted tests.
> 
> **Overview**
> Fixes iOS Expo prebuild so the CustomerIO Xcode group is always passed to `addSourceFile` as a **group key string**, not a group object.
> 
> `getOrCreateCustomerIOGroup` now resolves an existing group via `findPBXGroupKey` and returns that key; the create path still returns the key from `pbxCreateGroup`. `copyFileToXcode` and `withCIOIosSwift` typings are updated to treat the group as `string`, matching what `xcodeProject.addSourceFile` expects.
> 
> Adds **`__tests__/utils/xcode.test.ts`** with fixture-based regression tests for the existing-group branch and for `copyFileToXcode` passing a string into `addSourceFile`—covering the Expo SDK 55 case where missing `PBXVariantGroup` caused a crash when the object was passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5255d4616f2a63a98cb69a4c6fa0041c150f37b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->