### PR TITLE
chore: move geofence AppDelegate bootstrap into CioGeofenceAppDelegateHandler

### DIFF
--- a/__tests__/ios/withGeofenceAppDelegate.test.ts
+++ b/__tests__/ios/withGeofenceAppDelegate.test.ts
@@ -35,67 +35,39 @@ class AppDelegate: ExpoAppDelegate {
 }
 `;
 
-// Expo SDK 54 uses `internal import Expo`.
-const APP_DELEGATE_INTERNAL_IMPORT = PRISTINE_APP_DELEGATE.replace(
-  'import Expo',
-  'internal import Expo'
-);
-
 describe('modifyAppDelegateForGeofenceBootstrap', () => {
-  it('adds the geofence import guarded by canImport', () => {
+  it('adds the handler property to the AppDelegate class', () => {
     const result = modifyAppDelegateForGeofenceBootstrap(PRISTINE_APP_DELEGATE);
-    expect(result).toContain('#if canImport(CioLocationGeofence)');
-    expect(result).toContain('import CioLocationGeofence');
-    // Import lands after the existing imports, before the class declaration.
-    expect(result.indexOf('import CioLocationGeofence')).toBeLessThan(
-      result.indexOf('class AppDelegate')
-    );
+    expect(result).toContain('let cioGeofenceHandler = CioGeofenceAppDelegateHandler()');
+    // Property is declared inside the class, before the method.
+    expect(result.indexOf('let cioGeofenceHandler')).toBeGreaterThan(result.indexOf('class AppDelegate'));
+    expect(result.indexOf('let cioGeofenceHandler')).toBeLessThan(result.indexOf('func application'));
   });
 
-  it('injects the bootstrap at the top of didFinishLaunchingWithOptions, before React Native starts', () => {
+  it('injects the handler call at the top of didFinishLaunchingWithOptions, before React Native starts', () => {
     const result = modifyAppDelegateForGeofenceBootstrap(PRISTINE_APP_DELEGATE);
     expect(result).toContain(
-      'GeofenceModule.bootstrapForBackgroundDelivery(launchOptions: launchOptions)'
+      'cioGeofenceHandler.application(application, didFinishLaunchingWithOptions: launchOptions)'
     );
-    // Cold-wake delivery must not depend on the JS runtime, so the bootstrap has to run before
+    // Cold-wake delivery must not depend on the JS runtime, so the call runs before
     // factory.startReactNative(...) boots React Native (and before the delegate is created).
-    const bootstrapIdx = result.indexOf('bootstrapForBackgroundDelivery');
-    expect(bootstrapIdx).toBeGreaterThan(-1);
-    expect(bootstrapIdx).toBeLessThan(result.indexOf('let delegate = ReactNativeDelegate()'));
-    expect(bootstrapIdx).toBeLessThan(result.indexOf('factory.startReactNative'));
+    const callIdx = result.indexOf('cioGeofenceHandler.application(');
+    expect(callIdx).toBeGreaterThan(-1);
+    expect(callIdx).toBeLessThan(result.indexOf('let delegate = ReactNativeDelegate()'));
+    expect(callIdx).toBeLessThan(result.indexOf('factory.startReactNative'));
   });
 
-  it('guards the bootstrap call with canImport', () => {
+  it('does not inject a CioLocationGeofence import into the AppDelegate (the handler owns it)', () => {
     const result = modifyAppDelegateForGeofenceBootstrap(PRISTINE_APP_DELEGATE);
-    const guardCount = (result.match(/#if canImport\(CioLocationGeofence\)/g) || []).length;
-    // One guard for the import, one for the bootstrap call.
-    expect(guardCount).toBe(2);
-  });
-
-  it('handles the `internal import` variant', () => {
-    const result = modifyAppDelegateForGeofenceBootstrap(APP_DELEGATE_INTERNAL_IMPORT);
-    expect(result).toContain('import CioLocationGeofence');
-    expect(result).toContain('bootstrapForBackgroundDelivery');
+    expect(result).not.toContain('import CioLocationGeofence');
+    expect(result).not.toContain('GeofenceModule.bootstrapForBackgroundDelivery');
   });
 
   it('is idempotent', () => {
     const once = modifyAppDelegateForGeofenceBootstrap(PRISTINE_APP_DELEGATE);
     const twice = modifyAppDelegateForGeofenceBootstrap(once);
     expect(twice).toBe(once);
-    expect((twice.match(/bootstrapForBackgroundDelivery/g) || []).length).toBe(1);
-  });
-
-  it('injects the bootstrap on re-run when only the import was applied previously', () => {
-    // Simulates a prior prebuild that added the import but failed to inject the bootstrap:
-    // the re-run must add the missing bootstrap without duplicating the import.
-    const importOnly = PRISTINE_APP_DELEGATE.replace(
-      'import ReactAppDependencyProvider',
-      'import ReactAppDependencyProvider\n\n#if canImport(CioLocationGeofence)\nimport CioLocationGeofence\n#endif'
-    );
-    const result = modifyAppDelegateForGeofenceBootstrap(importOnly);
-    expect(result).toContain(
-      'GeofenceModule.bootstrapForBackgroundDelivery(launchOptions: launchOptions)'
-    );
-    expect((result.match(/import CioLocationGeofence/g) || []).length).toBe(1);
+    expect((twice.match(/cioGeofenceHandler\.application\(/g) || []).length).toBe(1);
+    expect((twice.match(/let cioGeofenceHandler =/g) || []).length).toBe(1);
   });
 });

--- a/plugin/src/helpers/native-files/ios/CioGeofenceAppDelegateHandler.swift
+++ b/plugin/src/helpers/native-files/ios/CioGeofenceAppDelegateHandler.swift
@@ -1,0 +1,25 @@
+import Foundation
+import UIKit
+#if canImport(CioLocationGeofence)
+import CioLocationGeofence
+#endif
+
+/// Bridges the host app's AppDelegate to the Customer.io geofence background-delivery bootstrap.
+///
+/// The Expo config plugin injects a single `application(_:didFinishLaunchingWithOptions:)` call into
+/// the app's AppDelegate. Keeping the logic here means the AppDelegate edit stays a one-liner and the
+/// geofence wiring can evolve without re-touching the app's AppDelegate.
+@objc public class CioGeofenceAppDelegateHandler: NSObject {
+    @objc public func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) {
+        #if canImport(CioLocationGeofence)
+        // iOS can cold-launch the app for a geofence transition without the JS runtime, so bootstrap
+        // background delivery here rather than relying on CustomerIO.initialize. The plugin injects the
+        // call before React Native starts, mirroring the SDK's reference AppDelegate — it reads persisted
+        // state and re-arms region monitoring independently of the JS runtime, and is safe on every launch.
+        GeofenceModule.bootstrapForBackgroundDelivery(launchOptions: launchOptions)
+        #endif
+    }
+}

--- a/plugin/src/ios/withGeofenceAppDelegate.ts
+++ b/plugin/src/ios/withGeofenceAppDelegate.ts
@@ -1,72 +1,57 @@
 import type { ConfigPlugin } from '@expo/config-plugins';
-import { withAppDelegate } from '@expo/config-plugins';
+import { withAppDelegate, withXcodeProject } from '@expo/config-plugins';
+import path from 'path';
 
+import { getIosNativeFilesPath } from '../utils/plugin';
+import { copyFileToXcode, getOrCreateCustomerIOGroup } from '../utils/xcode';
 import { logger } from '../utils/logger';
 
-// Per-step idempotency markers. The two injections are guarded independently: the import marker
-// is added by addGeofenceImport and the bootstrap marker by injectGeofenceBootstrap. Keying both
-// steps off a single symbol would let a partial application (import added, bootstrap injection
-// failed) look "done" on the next prebuild, permanently skipping the missing bootstrap.
-const GEOFENCE_IMPORT_MARKER = 'import CioLocationGeofence';
-const GEOFENCE_BOOTSTRAP_MARKER = 'GeofenceModule.bootstrapForBackgroundDelivery';
-
-const GEOFENCE_IMPORT_SNIPPET = `#if canImport(CioLocationGeofence)
-import CioLocationGeofence
-#endif`;
-
-const GEOFENCE_BOOTSTRAP_SNIPPET = `    #if canImport(CioLocationGeofence)
-    // iOS can cold-launch the app for a geofence transition without the JS runtime, so bootstrap
-    // background delivery here rather than relying on CustomerIO.initialize. Safe alongside normal init.
-    GeofenceModule.bootstrapForBackgroundDelivery(launchOptions: launchOptions)
-    #endif
-`;
+const HANDLER_CLASS = 'CioGeofenceAppDelegateHandler';
+const HANDLER_FILE = `${HANDLER_CLASS}.swift`;
+const HANDLER_PROPERTY = `let cioGeofenceHandler = ${HANDLER_CLASS}()`;
+const HANDLER_CALL = `cioGeofenceHandler.application(application, didFinishLaunchingWithOptions: launchOptions)`;
 
 /**
- * Adds the geofence module import after the last top-level import statement.
- * The import is compiled out via `#if canImport` when the geofence subspec is absent.
+ * Adds the `let cioGeofenceHandler = CioGeofenceAppDelegateHandler()` property to the AppDelegate
+ * class. Idempotent. The handler type ships with the plugin and lives in the app target, so no import
+ * is needed here.
  */
-const addGeofenceImport = (contents: string): string => {
-  if (contents.includes(GEOFENCE_IMPORT_MARKER)) {
+const addHandlerProperty = (contents: string): string => {
+  if (contents.includes(HANDLER_PROPERTY)) {
     return contents;
   }
 
-  const importRegex = /^(?:@_exported\s+)?(?:internal\s+)?import\s+.+$/gm;
-  let lastMatchEnd = -1;
-  let match: RegExpExecArray | null;
-  while ((match = importRegex.exec(contents)) !== null) {
-    lastMatchEnd = match.index + match[0].length;
-  }
-
-  if (lastMatchEnd < 0) {
-    logger.warn('Could not find an import statement in AppDelegate.swift; skipping geofence import');
+  const classRegex = /class\s+AppDelegate\s*:\s*[^\n{]*\{/;
+  const match = contents.match(classRegex);
+  if (!match) {
+    logger.warn('Could not find AppDelegate class declaration; skipping geofence handler property');
     return contents;
   }
 
+  const insertPosition = (match.index ?? 0) + match[0].length;
   return (
-    contents.substring(0, lastMatchEnd) +
-    `\n\n${GEOFENCE_IMPORT_SNIPPET}` +
-    contents.substring(lastMatchEnd)
+    contents.substring(0, insertPosition) +
+    `\n  ${HANDLER_PROPERTY}\n` +
+    contents.substring(insertPosition)
   );
 };
 
 /**
- * Injects the geofence background-delivery bootstrap at the top of didFinishLaunchingWithOptions,
- * before React Native is started (the Expo template calls `factory.startReactNative(...)` later in
- * this method). Cold-wake delivery must not depend on the JS runtime, so it has to run first —
- * matching the SDK's reference AppDelegate integration.
+ * Injects the single geofence handler call at the top of didFinishLaunchingWithOptions, before
+ * React Native is started (the Expo template calls `factory.startReactNative(...)` later in this
+ * method). Idempotent.
  */
-const injectGeofenceBootstrap = (contents: string): string => {
-  if (contents.includes(GEOFENCE_BOOTSTRAP_MARKER)) {
+const addHandlerCall = (contents: string): string => {
+  if (contents.includes(HANDLER_CALL)) {
     return contents;
   }
 
   const methodRegex =
     /(func\s+application\s*\(\s*_\s+application\s*:\s*UIApplication\s*,\s*didFinishLaunchingWithOptions[\s\S]*?\)\s*->\s*Bool\s*\{)/;
   const match = contents.match(methodRegex);
-
   if (!match) {
     logger.warn(
-      'Could not find didFinishLaunchingWithOptions in AppDelegate.swift; skipping geofence bootstrap'
+      'Could not find didFinishLaunchingWithOptions in AppDelegate.swift; skipping geofence handler call'
     );
     return contents;
   }
@@ -74,28 +59,51 @@ const injectGeofenceBootstrap = (contents: string): string => {
   const insertPosition = (match.index ?? 0) + match[0].length;
   return (
     contents.substring(0, insertPosition) +
-    `\n${GEOFENCE_BOOTSTRAP_SNIPPET}` +
+    `\n    ${HANDLER_CALL}\n` +
     contents.substring(insertPosition)
   );
 };
 
 /**
- * Pure string transform: adds the geofence import and background-delivery bootstrap
- * to the Swift AppDelegate. Each step is independently idempotent, so a re-run after a
- * partial application injects only the missing piece.
+ * Pure string transform: adds the geofence handler property and its didFinishLaunchingWithOptions
+ * call to the Swift AppDelegate. Each step is independently idempotent.
  *
  * Exported for tests.
  */
 export function modifyAppDelegateForGeofenceBootstrap(contents: string): string {
-  return injectGeofenceBootstrap(addGeofenceImport(contents));
+  return addHandlerCall(addHandlerProperty(contents));
 }
 
+/** Copies CioGeofenceAppDelegateHandler.swift into the app target and registers it with Xcode. */
+const withGeofenceHandlerFile: ConfigPlugin = (config) =>
+  withXcodeProject(config, (xcodeConfig) => {
+    const projectName = xcodeConfig.modRequest.projectName || '';
+    if (!projectName) {
+      logger.warn('Project name is undefined; cannot copy CioGeofenceAppDelegateHandler.swift');
+      return xcodeConfig;
+    }
+
+    const iosProjectRoot = path.join(xcodeConfig.modRequest.projectRoot, 'ios');
+    const group = getOrCreateCustomerIOGroup(xcodeConfig.modResults, projectName);
+    copyFileToXcode({
+      xcodeProject: xcodeConfig.modResults,
+      iosProjectRoot,
+      projectName,
+      sourceFilePath: path.join(getIosNativeFilesPath(), HANDLER_FILE),
+      targetFileName: HANDLER_FILE,
+      transform: (content) => content,
+      customerIOGroup: group,
+    });
+    return xcodeConfig;
+  });
+
 /**
- * Injects the geofence background-delivery bootstrap into the Swift AppDelegate.
- * Runs whenever geofence is enabled, independent of push/auto-init, so cold-wake
- * background geofence transitions are delivered even when the JS runtime isn't running.
+ * Wires geofence cold-wake background delivery: ships CioGeofenceAppDelegateHandler.swift and adds a
+ * single call to it from the Swift AppDelegate. Runs whenever geofence is enabled, independent of
+ * push/auto-init. Geofence is gated to Swift projects (Expo SDK 53+) at the plugin entry point.
  */
 export const withGeofenceAppDelegate: ConfigPlugin = (config) => {
+  config = withGeofenceHandlerFile(config);
   return withAppDelegate(config, (appDelegateConfig) => {
     appDelegateConfig.modResults.contents = modifyAppDelegateForGeofenceBootstrap(
       appDelegateConfig.modResults.contents


### PR DESCRIPTION
Follow-up to #368 addressing @mahmoud-elmorabea's review.

> ⚠️ Stacked on #372 (`fix: register CustomerIO Xcode group by key`). Review/merge that first — this PR depends on it and its base will auto-retarget to `feature/geofence-on-device` once #372 merges.

## What

Replaces the inline AppDelegate injection of the geofence background-delivery bootstrap with a dedicated `CioGeofenceAppDelegateHandler.swift`, mirroring the existing push `CioSdkAppDelegateHandler` pattern:

- Ships `CioGeofenceAppDelegateHandler.swift` and registers it in the Xcode project.
- Reduces the AppDelegate edit to a single call at the top of `didFinishLaunchingWithOptions` plus a handler property — no `import` / `#if` injected into AppDelegate.
- The "why the bootstrap must run before React Native starts" rationale now lives in the handler's doc comment (review comment 2).

## Why the handler pattern

Extensible and consistent with push. The bootstrap stays at the top of `didFinishLaunchingWithOptions` (before `factory.startReactNative(...)`), matching the SDK reference AppDelegate — geofence background delivery must be wired independently of the JS runtime.

## Verification

- `expo prebuild` on Expo SDK 55 (test-app, RN 0.83.6): ✔ finishes; `CioGeofenceAppDelegateHandler.swift` copied into the app target and registered (build file + file ref + CustomerIO group + Sources phase); AppDelegate gets the property and the call before RN starts. (Requires #372 — otherwise prebuild crashes in the push handler.)
- lint, api-extractor (no public API change), unit tests green (baseline pre-existing failures only).

Ticket: https://linear.app/customerio/issue/MBL-1787

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes iOS launch-time geofence background bootstrap wiring; behavior should be equivalent but mis-injection or Xcode registration could break cold-wake delivery.
> 
> **Overview**
> Refactors geofence **cold-wake** wiring so the Expo plugin no longer injects `import CioLocationGeofence`, `#if canImport`, or `GeofenceModule.bootstrapForBackgroundDelivery` directly into **AppDelegate**.
> 
> Instead it ships **`CioGeofenceAppDelegateHandler.swift`** (registered via `withXcodeProject` / `copyFileToXcode`, same pattern as push’s `CioSdkAppDelegateHandler`) and only patches AppDelegate with a **`cioGeofenceHandler` property** plus a **single** `didFinishLaunchingWithOptions` call still placed **before** React Native starts. The handler owns the geofence import guards and bootstrap logic.
> 
> Unit tests are updated to match the slimmer AppDelegate edits and drop the old “import-only partial prebuild” recovery case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0fde78fa1c079e31f764a0b176cda0d887dcad2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->