### PR TITLE
chore: mark geofence AppDelegate handler @MainActor

### DIFF
--- a/plugin/src/helpers/native-files/ios/CioGeofenceAppDelegateHandler.swift
+++ b/plugin/src/helpers/native-files/ios/CioGeofenceAppDelegateHandler.swift
@@ -4,25 +4,16 @@ import UIKit
 import CioLocationGeofence
 #endif
 
-/// Bridges the host app's AppDelegate to the Customer.io geofence background-delivery bootstrap.
-///
-/// The Expo config plugin injects a single `application(_:didFinishLaunchingWithOptions:)` call into
-/// the app's AppDelegate. Keeping the logic here means the AppDelegate edit stays a one-liner and the
-/// geofence wiring can evolve without re-touching the app's AppDelegate.
+/// Customer.io geofence background-delivery bridge. Injected into the app's AppDelegate by the Expo plugin.
 @objc public class CioGeofenceAppDelegateHandler: NSObject {
-    // Main-actor isolated because the plugin injects the call into the host AppDelegate's
-    // (main-actor) didFinishLaunchingWithOptions, and GeofenceModule.bootstrapForBackgroundDelivery
-    // is itself @MainActor. Mirrors the SDK's reference AppDelegate, which calls it directly.
+    // @MainActor: GeofenceModule.bootstrapForBackgroundDelivery is main-actor isolated.
     @MainActor
     @objc public func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) {
         #if canImport(CioLocationGeofence)
-        // iOS can cold-launch the app for a geofence transition without the JS runtime, so bootstrap
-        // background delivery here rather than relying on CustomerIO.initialize. The plugin injects the
-        // call before React Native starts, mirroring the SDK's reference AppDelegate — it reads persisted
-        // state and re-arms region monitoring independently of the JS runtime, and is safe on every launch.
+        // Re-arm geofence background delivery on cold launch, before React Native starts.
         GeofenceModule.bootstrapForBackgroundDelivery(launchOptions: launchOptions)
         #endif
     }

--- a/plugin/src/helpers/native-files/ios/CioGeofenceAppDelegateHandler.swift
+++ b/plugin/src/helpers/native-files/ios/CioGeofenceAppDelegateHandler.swift
@@ -10,6 +10,10 @@ import CioLocationGeofence
 /// the app's AppDelegate. Keeping the logic here means the AppDelegate edit stays a one-liner and the
 /// geofence wiring can evolve without re-touching the app's AppDelegate.
 @objc public class CioGeofenceAppDelegateHandler: NSObject {
+    // Main-actor isolated because the plugin injects the call into the host AppDelegate's
+    // (main-actor) didFinishLaunchingWithOptions, and GeofenceModule.bootstrapForBackgroundDelivery
+    // is itself @MainActor. Mirrors the SDK's reference AppDelegate, which calls it directly.
+    @MainActor
     @objc public func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil


### PR DESCRIPTION
## What

Marks `CioGeofenceAppDelegateHandler.application(_:didFinishLaunchingWithOptions:)` as `@MainActor`.

## ⚠️ Expected CI: `build-sample-apps` iOS (apn/fcm) will fail — not this change

`feature/geofence-on-device` doesn't yet have the unreleased geofence native SDK, so the geofence pod can't resolve and the iOS sample-app build fails at `pod install` (the exact gap #371's snapshot overlay exists to fill). That failure is pre-existing on the feature branch and unrelated to this diff.

This change was verified where the SDK **is** present — see Verification below. The meaningful checks here (Lint & TypeScript, API, unit/scenario, Expo-latest compat) should pass.

## Why

`GeofenceModule.bootstrapForBackgroundDelivery(launchOptions:)` is `@MainActor`-isolated in the SDK. Our handler method was nonisolated, so under strict concurrency (Xcode 26.x / RN 0.86) the call fails to compile:

```
error: call to main actor-isolated static method 'bootstrapForBackgroundDelivery(launchOptions:)'
       in a synchronous nonisolated context
```

The plugin injects the handler call into the host AppDelegate's `didFinishLaunchingWithOptions`, which is already `@MainActor` (UIKit annotates `UIApplicationDelegate`). Marking the handler method `@MainActor` restores that context — mirroring the SDK's own reference AppDelegate, which calls `bootstrapForBackgroundDelivery` directly from the main-actor AppDelegate. (The SDK's `@MainActor` is intentional; the fix belongs on our side, not the SDK.)

Slipped through originally because #373's handler was verified via `expo prebuild` only, never a real `xcodebuild`.

## Verification

Verified on CI via the #371 snapshot branch (which pulls the geofence SDK): the `build-sample-apps` iOS builds (apn + fcm) that previously **failed** compiling `CioGeofenceAppDelegateHandler.swift` now **pass** with this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small concurrency annotation on an existing launch-time bootstrap path; aligns with UIKit’s main-actor AppDelegate context and does not change runtime logic.
> 
> **Overview**
> Adds **`@MainActor`** to `CioGeofenceAppDelegateHandler.application(_:didFinishLaunchingWithOptions:)` so the injected AppDelegate hook can call **`GeofenceModule.bootstrapForBackgroundDelivery`** under strict Swift concurrency (Xcode 26.x / RN 0.86), where that SDK entry point is main-actor isolated.
> 
> Comment text in the handler is shortened; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 905f180fd0ad9b03fc0c63f2258f54523e2f754c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->