### PR TITLE
fix: write expoVersion atomically to avoid ERR_INVALID_PACKAGE_CONFIG on parallel installs

### DIFF
--- a/plugin/src/postInstallHelper.js
+++ b/plugin/src/postInstallHelper.js
@@ -73,10 +73,20 @@ function runPostInstall() {
     }
 
     reactNativePackage.expoVersion = expoPackageJson.version;
-    fs.writeFileSync(
-      reactNativePackageJsonFile,
-      JSON.stringify(reactNativePackage, null, 2)
+    // Write atomically: write to a temp file in the same directory, then rename
+    // it into place. rename(2) is atomic on the same filesystem, so a concurrent
+    // reader during npm's parallel install (notably customerio-reactnative's own
+    // `node src/postInstall.js` reading this package.json at Node startup) always
+    // sees either the old or the new complete manifest — never a half-written
+    // one. A plain writeFileSync truncates-then-writes and can be observed
+    // mid-write, which surfaces as `ERR_INVALID_PACKAGE_CONFIG` and
+    // intermittently fails installs (e.g. EAS Workflow repack jobs).
+    const tmpFile = path.join(
+      path.dirname(reactNativePackageJsonFile),
+      `.package.json.${process.pid}.${Date.now()}.tmp`
     );
+    fs.writeFileSync(tmpFile, JSON.stringify(reactNativePackage, null, 2));
+    fs.renameSync(tmpFile, reactNativePackageJsonFile);
   } catch (error) {
     console.warn(
       'customerio-expo-plugin postinstall: failed to write expoVersion into customerio-reactnative/package.json. ' +


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-path change in install-time postinstall helper; behavior and payload are unchanged aside from safer I/O.
> 
> **Overview**
> **Fixes intermittent `ERR_INVALID_PACKAGE_CONFIG` during parallel installs** (e.g. EAS Workflow repack) when another lifecycle script reads `customerio-reactnative/package.json` while the expo plugin postinstall is updating it.
> 
> The postinstall helper no longer overwrites `package.json` in place. It writes the updated manifest to a same-directory temp file (`.package.json.<pid>.<timestamp>.tmp`), then **`renameSync`** into `customerio-reactnative/package.json` so readers always see a complete old or new file, not a truncated JSON body from `writeFileSync`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01b465153df417e96bd1ad252ec00d429a79efc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->