### PR TITLE
feat(test-app): Live Notifications screen driven by auto-init config

### DIFF
--- a/test-app/android-renderers/RideshareLiveNotification.kt
+++ b/test-app/android-renderers/RideshareLiveNotification.kt
@@ -1,0 +1,76 @@
+package com.customerio.testbed.livenotifications
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import io.customer.messagingpush.data.communication.CustomerIOLiveNotificationsCallback
+import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
+
+/**
+ * Renders the custom `rideshare` live notification, the Android counterpart to
+ * `ios-widgets/RideshareLiveActivity.swift`.
+ *
+ * The plugin copies this file into the generated Android project and registers the class, because
+ * `liveNotifications.customRenderer` names it in app.json. A custom activity type has no built-in
+ * SDK template on either platform, so the app draws it: SwiftUI on iOS, a `Notification` here.
+ *
+ * Returning null for any other type lets the SDK fall back to its built-in templates.
+ */
+class RideshareLiveNotificationCallback : CustomerIOLiveNotificationsCallback {
+    override fun createLiveNotification(
+        payload: CustomerIOParsedPushPayload,
+        context: Context,
+    ): Notification? {
+        // Template fields arrive flattened in `extras`; the activity type is under the reserved
+        // "notification_type" key.
+        val extras = payload.extras
+        if (extras.getString("notification_type") != RIDESHARE_TYPE) return null
+
+        // The SDK re-invokes this on the "end" event. Return a terminal, non-ongoing notification
+        // then so it can be dismissed instead of sticking around forever.
+        val ended = extras.getString("event") == "end"
+
+        val driverName = extras.getString("driverName") ?: "Your driver"
+        val status = extras.getString("status") ?: ""
+        // Every custom value crosses the bridge as a string; parse what you need.
+        val etaMinutes = extras.getString("etaMinutes")?.toDoubleOrNull()?.toInt()
+
+        // Same fields the SwiftUI shows, in the same order: status leads as the title, then the
+        // driver and the ETA. `status` is not repeated in the body since it is already the title.
+        val body = listOfNotNull(
+            driverName,
+            etaMinutes?.let { "ETA $it min" },
+        ).joinToString(" • ")
+
+        ensureChannel(context)
+        return NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(context.applicationInfo.icon)
+            .setContentTitle(status.ifEmpty { if (ended) "Arrived" else "Rideshare" })
+            .setContentText(body)
+            .setOngoing(!ended)
+            .setOnlyAlertOnce(true)
+            .build()
+    }
+
+    private fun ensureChannel(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (manager.getNotificationChannel(CHANNEL_ID) == null) {
+            manager.createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_ID,
+                    "Rideshare",
+                    NotificationManager.IMPORTANCE_DEFAULT,
+                ),
+            )
+        }
+    }
+
+    private companion object {
+        const val RIDESHARE_TYPE = "com.customerio.testbed.rideshare"
+        const val CHANNEL_ID = "rideshare_live_notification"
+    }
+}

--- a/test-app/app.json
+++ b/test-app/app.json
@@ -100,7 +100,8 @@
                 "accentColorHex": "#00A0DF",
                 "backgroundColorHex": "#101010",
                 "textColorHex": "#FFFFFF"
-              }
+              },
+              "customType": "com.customerio.testbed.rideshare"
             }
           },
           "android": {
@@ -133,6 +134,12 @@
           },
           "location": {
             "enabled": true
+          },
+          "liveNotifications": {
+            "customWidget": {
+              "sourceFile": "./ios-widgets/RideshareLiveActivity.swift",
+              "structName": "RideshareLiveActivity"
+            }
           }
         }
       ],

--- a/test-app/app.json
+++ b/test-app/app.json
@@ -139,6 +139,10 @@
             "customWidget": {
               "sourceFile": "./ios-widgets/RideshareLiveActivity.swift",
               "structName": "RideshareLiveActivity"
+            },
+            "customRenderer": {
+              "sourceFile": "./android-renderers/RideshareLiveNotification.kt",
+              "className": "RideshareLiveNotificationCallback"
             }
           }
         }

--- a/test-app/app.json
+++ b/test-app/app.json
@@ -89,6 +89,18 @@
             "logLevel": "debug",
             "location": {
               "trackingMode": "MANUAL"
+            },
+            "liveNotifications": {
+              "types": [
+                "io.customer.livenotifications.segments",
+                "io.customer.livenotifications.countdowntimer"
+              ],
+              "branding": {
+                "companyName": "Customer.io Expo Testbed",
+                "accentColorHex": "#00A0DF",
+                "backgroundColorHex": "#101010",
+                "textColorHex": "#FFFFFF"
+              }
             }
           },
           "android": {

--- a/test-app/app.json
+++ b/test-app/app.json
@@ -95,12 +95,6 @@
                 "io.customer.livenotifications.segments",
                 "io.customer.livenotifications.countdowntimer"
               ],
-              "branding": {
-                "companyName": "Customer.io Expo Testbed",
-                "accentColorHex": "#00A0DF",
-                "backgroundColorHex": "#101010",
-                "textColorHex": "#FFFFFF"
-              },
               "customType": "com.customerio.testbed.rideshare"
             }
           },
@@ -136,6 +130,12 @@
             "enabled": true
           },
           "liveNotifications": {
+            "branding": {
+              "companyName": "Customer.io Expo Testbed",
+              "accentColorHex": "#00A0DF",
+              "backgroundColorHex": "#101010",
+              "textColorHex": "#FFFFFF"
+            },
             "customWidget": {
               "sourceFile": "./ios-widgets/RideshareLiveActivity.swift",
               "structName": "RideshareLiveActivity"

--- a/test-app/app/_layout.tsx
+++ b/test-app/app/_layout.tsx
@@ -19,6 +19,7 @@ export default function RootLayout() {
         <Stack.Screen name="nav-test" options={{ title: "Navigation Test" }} />
         <Stack.Screen name="inline-examples" options={{ title: "Inline Examples" }} />
         <Stack.Screen name="location" options={{ title: "Location" }} />
+        <Stack.Screen name="live-activities" options={{ title: "Live Activities" }} />
       </Stack>
       <StatusBar style="auto" />
     </ThemeProvider>

--- a/test-app/app/live-activities.tsx
+++ b/test-app/app/live-activities.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import LiveActivitiesScreen from '../screens/LiveActivities';
+
+export default function LiveActivitiesRoute() {
+  return <LiveActivitiesScreen />;
+}

--- a/test-app/fastlane/Appfile
+++ b/test-app/fastlane/Appfile
@@ -1,6 +1,7 @@
 app_identifier([
   "io.customer.testbed.expo.apn",
   "io.customer.testbed.expo.apn.richpush",
+  "io.customer.testbed.expo.apn.CIOLiveActivityWidget",
 ])
 
 package_name("io.customer.testbed.expo")

--- a/test-app/fastlane/Fastfile
+++ b/test-app/fastlane/Fastfile
@@ -78,6 +78,16 @@ platform :ios do
       profile: ENV["sigh_io.customer.testbed.expo.apn.richpush_adhoc_profile-path"]
     )
 
+    # The Live Activity widget extension the plugin generates. Its target name comes from
+    # CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME, and its bundle id is that name suffixed onto the host
+    # app's. Without this the widget is the one embedded binary left without a profile, and the
+    # archive fails on it rather than on anything the app itself did.
+    update_project_provisioning(
+      xcodeproj: xcodeproj_path,
+      target_filter: "CIOLiveActivityWidget",
+      profile: ENV["sigh_io.customer.testbed.expo.apn.CIOLiveActivityWidget_adhoc_profile-path"]
+    )
+
     update_project_team(
       path: xcodeproj_path,
       teamid: "2YC97BQN3N"

--- a/test-app/ios-widgets/RideshareLiveActivity.swift
+++ b/test-app/ios-widgets/RideshareLiveActivity.swift
@@ -1,0 +1,51 @@
+import ActivityKit
+import CioLiveActivities_Attributes
+import SwiftUI
+import WidgetKit
+
+/// A custom Live Activity the test app owns, rendered alongside the SDK's built-in templates.
+///
+/// The plugin copies this file into the widget extension it generates and adds
+/// `RideshareLiveActivity()` to that bundle, next to the built-in `CIOSegmentsLiveActivity()` and
+/// `CIOCountdownTimerLiveActivity()` — which is the point of the exercise: a custom template and the
+/// built-ins coexist in one widget target.
+///
+/// The attributes type comes from the SDK (`CIOCustomAttributes`), so nothing here has to define one.
+/// Its content-state is an untyped `[String: String]`, which is what lets JavaScript drive the
+/// activity without handing a Swift type across the bridge. The keys below are the ones
+/// `screens/LiveActivities.js` sends.
+@available(iOS 16.2, *)
+struct RideshareLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: CIOCustomAttributes.self) { context in
+            // Lock screen / banner presentation.
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Rideshare").font(.headline)
+                Text(context.state.data["driverName"] ?? "").font(.subheadline)
+                Text(context.state.data["status"] ?? "").font(.body)
+                Text("ETA \(context.state.data["etaMinutes"] ?? "—") min")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding()
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Text(context.state.data["driverName"] ?? "")
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text("\(context.state.data["etaMinutes"] ?? "—") min")
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text(context.state.data["status"] ?? "")
+                }
+            } compactLeading: {
+                Image(systemName: "car.fill")
+            } compactTrailing: {
+                Text("\(context.state.data["etaMinutes"] ?? "")m")
+            } minimal: {
+                Image(systemName: "car.fill")
+            }
+        }
+    }
+}

--- a/test-app/ios-widgets/RideshareLiveActivity.swift
+++ b/test-app/ios-widgets/RideshareLiveActivity.swift
@@ -28,6 +28,10 @@ struct RideshareLiveActivity: Widget {
                     .foregroundColor(.secondary)
             }
             .padding()
+            // Required on any custom template: this is what carries the tap URL the SDK
+            // reports `opened` from and routes the deep link with. The bundled templates do
+            // the same on both their lock screen and Dynamic Island.
+            .cioWidgetUrl(context.state.cioMetadata)
         } dynamicIsland: { context in
             DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
@@ -46,6 +50,7 @@ struct RideshareLiveActivity: Widget {
             } minimal: {
                 Image(systemName: "car.fill")
             }
+            .cioWidgetUrl(context.state.cioMetadata)
         }
     }
 }

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -15,7 +15,7 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.5.2",
+    "customerio-reactnative": "github:customerio/customerio-reactnative#live-activities-sdk",
     "dotenv": "^17.2.2",
     "expo": "~55.0.23",
     "expo-build-properties": "~55.0.13",

--- a/test-app/screens/Dashboard.js
+++ b/test-app/screens/Dashboard.js
@@ -55,6 +55,10 @@ export default function DashboardScreen() {
     router.push('/location');
   };
 
+  const handleNavigateToLiveActivitiesButtonPressed = () => {
+    router.push('/live-activities');
+  };
+
   const handleLogoutButtonPressed = () => {
     CustomerIO.clearIdentify();
   };
@@ -135,6 +139,13 @@ export default function DashboardScreen() {
         <Button
           title="Location"
           onPress={handleNavigateToLocationButtonPressed}
+        />
+      </ThemedView>
+
+      <ThemedView style={styles.section}>
+        <Button
+          title="Live Activities"
+          onPress={handleNavigateToLiveActivitiesButtonPressed}
         />
       </ThemedView>
 

--- a/test-app/screens/LiveActivities.js
+++ b/test-app/screens/LiveActivities.js
@@ -4,13 +4,17 @@ import { Alert, Button, ScrollView, StyleSheet, View } from 'react-native';
 import { ThemedText } from '../components/themed-text';
 import { ThemedView } from '../components/themed-view';
 
-// Activity types are registered by the plugin's native auto-init from
-// `config.liveNotifications.types` in app.json — no JavaScript initialization needed.
+// Activity types are registered by the plugin's native auto-init from app.json — the built-ins from
+// `config.liveNotifications.types` and the custom one from `config.liveNotifications.customType` —
+// so no JavaScript initialization is needed. On iOS all three are rendered by the single widget
+// extension the plugin generates: the SDK ships the SwiftUI for the built-ins, and
+// `liveNotifications.customWidget` points at the app's own file for the custom one.
 
 export default function LiveActivitiesScreen() {
   const [segmentsId, setSegmentsId] = useState(null);
   const [segmentsComplete, setSegmentsComplete] = useState(0);
   const [countdownId, setCountdownId] = useState(null);
+  const [customId, setCustomId] = useState(null);
 
   const segmentsTotal = 4;
 
@@ -92,6 +96,48 @@ export default function LiveActivitiesScreen() {
     }
   };
 
+  // MARK: - Custom
+
+  // The identifier comes from `config.liveNotifications.customType`; the SwiftUI that draws it comes
+  // from the top-level `liveNotifications.customWidget`. Values are strings — a bridge payload has no
+  // schema, so the widget parses what it needs.
+  const rideshare = (status, etaMinutes) => ({
+    type: LiveActivityTemplate.Custom,
+    data: { driverName: 'Alex', status, etaMinutes: String(etaMinutes) },
+  });
+
+  const startCustom = async () => {
+    try {
+      const id = await CustomerIO.liveActivities.start(rideshare('On the way', 5));
+      setCustomId(id);
+      Alert.alert('Success', `Rideshare started (${id})`);
+    } catch (e) {
+      Alert.alert('Error', (e && e.message) || String(e));
+    }
+  };
+
+  const updateCustom = async () => {
+    if (!customId) return;
+    try {
+      await CustomerIO.liveActivities.update(customId, rideshare('Almost there', 2));
+      Alert.alert('Success', 'Rideshare updated');
+    } catch (e) {
+      Alert.alert('Error', (e && e.message) || String(e));
+    }
+  };
+
+  const endCustom = async () => {
+    if (!customId) return;
+    try {
+      // A final content-state so the card reads as finished rather than freezing mid-trip.
+      await CustomerIO.liveActivities.end(customId, rideshare('Arrived', 0));
+      setCustomId(null);
+      Alert.alert('Info', 'Rideshare ended');
+    } catch (e) {
+      Alert.alert('Error', (e && e.message) || String(e));
+    }
+  };
+
   return (
     <ScrollView contentContainerStyle={styles.scrollContent}>
       <ThemedView style={styles.container}>
@@ -121,6 +167,20 @@ export default function LiveActivitiesScreen() {
           <Button title="End Countdown" onPress={endCountdown} disabled={!countdownId} />
           <ThemedText style={styles.hint}>
             {countdownId ? 'Running' : 'Not started'}
+          </ThemedText>
+        </ThemedView>
+
+        <ThemedView style={styles.sectionCard}>
+          <ThemedText style={styles.sectionHeading}>CUSTOM (RIDESHARE)</ThemedText>
+          <ThemedText style={styles.hint}>
+            An app-defined template rendered by RideshareLiveActivity.swift, in the same widget
+            bundle as the two built-ins above.
+          </ThemedText>
+          <Button title="Start Custom" onPress={startCustom} />
+          <Button title="Update Custom" onPress={updateCustom} disabled={!customId} />
+          <Button title="End Custom" onPress={endCustom} disabled={!customId} />
+          <ThemedText style={styles.hint}>
+            {customId ? 'Running' : 'Not started'}
           </ThemedText>
         </ThemedView>
       </ThemedView>

--- a/test-app/screens/LiveActivities.js
+++ b/test-app/screens/LiveActivities.js
@@ -176,6 +176,12 @@ export default function LiveActivitiesScreen() {
             An app-defined template rendered by RideshareLiveActivity.swift, in the same widget
             bundle as the two built-ins above.
           </ThemedText>
+          <ThemedText style={styles.hint}>
+            iOS only in this app. A custom type has no built-in template, so Android renders it
+            through CustomerIOLiveNotificationsCallback — which is native Kotlin set before SDK
+            initialization, not reachable from JavaScript. These buttons will report success on
+            Android and show nothing.
+          </ThemedText>
           <Button title="Start Custom" onPress={startCustom} />
           <Button title="Update Custom" onPress={updateCustom} disabled={!customId} />
           <Button title="End Custom" onPress={endCustom} disabled={!customId} />

--- a/test-app/screens/LiveActivities.js
+++ b/test-app/screens/LiveActivities.js
@@ -173,14 +173,15 @@ export default function LiveActivitiesScreen() {
         <ThemedView style={styles.sectionCard}>
           <ThemedText style={styles.sectionHeading}>CUSTOM (RIDESHARE)</ThemedText>
           <ThemedText style={styles.hint}>
-            An app-defined template rendered by RideshareLiveActivity.swift, in the same widget
-            bundle as the two built-ins above.
+            An app-defined template. A custom type has no built-in template on either platform, so
+            this app supplies both halves and the plugin wires them up: RideshareLiveActivity.swift
+            renders it on iOS, in the same widget bundle as the two built-ins above, and
+            RideshareLiveNotification.kt renders it on Android.
           </ThemedText>
           <ThemedText style={styles.hint}>
-            iOS only in this app. A custom type has no built-in template, so Android renders it
-            through CustomerIOLiveNotificationsCallback — which is native Kotlin set before SDK
-            initialization, not reachable from JavaScript. These buttons will report success on
-            Android and show nothing.
+            Configured with liveNotifications.customWidget and liveNotifications.customRenderer in
+            app.json. Neither is reachable from JavaScript — SwiftUI and Kotlin have to be compiled
+            in — which is why they are build-time options rather than SDK config.
           </ThemedText>
           <Button title="Start Custom" onPress={startCustom} />
           <Button title="Update Custom" onPress={updateCustom} disabled={!customId} />

--- a/test-app/screens/LiveActivities.js
+++ b/test-app/screens/LiveActivities.js
@@ -1,0 +1,153 @@
+import { CustomerIO, LiveActivityTemplate } from 'customerio-reactnative';
+import React, { useState } from 'react';
+import { Alert, Button, ScrollView, StyleSheet, View } from 'react-native';
+import { ThemedText } from '../components/themed-text';
+import { ThemedView } from '../components/themed-view';
+
+// Activity types are registered by the plugin's native auto-init from
+// `config.liveNotifications.types` in app.json — no JavaScript initialization needed.
+
+export default function LiveActivitiesScreen() {
+  const [segmentsId, setSegmentsId] = useState(null);
+  const [segmentsComplete, setSegmentsComplete] = useState(0);
+  const [countdownId, setCountdownId] = useState(null);
+
+  const segmentsTotal = 4;
+
+  // MARK: - Segments
+
+  const startSegments = async () => {
+    try {
+      const id = await CustomerIO.liveActivities.start({
+        type: LiveActivityTemplate.Segments,
+        header: 'Order #4021',
+        status: 'Preparing your order',
+        segmentsTotal,
+        segmentsComplete: 1,
+      });
+      setSegmentsId(id);
+      setSegmentsComplete(1);
+      Alert.alert('Success', `Segments started (${id})`);
+    } catch (e) {
+      Alert.alert('Error', (e && e.message) || String(e));
+    }
+  };
+
+  const advanceSegments = async () => {
+    if (!segmentsId) return;
+    const next = Math.min(segmentsComplete + 1, segmentsTotal);
+    try {
+      await CustomerIO.liveActivities.update(segmentsId, {
+        type: LiveActivityTemplate.Segments,
+        header: 'Order #4021',
+        status: next >= segmentsTotal ? 'Delivered' : 'Out for delivery',
+        segmentsTotal,
+        segmentsComplete: next,
+      });
+      setSegmentsComplete(next);
+      Alert.alert('Success', `Segments → ${next}/${segmentsTotal}`);
+    } catch (e) {
+      Alert.alert('Error', (e && e.message) || String(e));
+    }
+  };
+
+  const endSegments = async () => {
+    if (!segmentsId) return;
+    try {
+      await CustomerIO.liveActivities.end(segmentsId);
+      setSegmentsId(null);
+      setSegmentsComplete(0);
+      Alert.alert('Info', 'Segments ended');
+    } catch (e) {
+      Alert.alert('Error', (e && e.message) || String(e));
+    }
+  };
+
+  // MARK: - Countdown Timer
+
+  const startCountdown = async () => {
+    try {
+      const id = await CustomerIO.liveActivities.start({
+        type: LiveActivityTemplate.CountdownTimer,
+        header: 'Flash Sale',
+        title: '50% off ends in',
+        statusMessage: 'Hurry!',
+        endTime: Math.floor(Date.now() / 1000) + 3600, // epoch seconds, +1h
+      });
+      setCountdownId(id);
+      Alert.alert('Success', `Countdown started (${id})`);
+    } catch (e) {
+      Alert.alert('Error', (e && e.message) || String(e));
+    }
+  };
+
+  const endCountdown = async () => {
+    if (!countdownId) return;
+    try {
+      await CustomerIO.liveActivities.end(countdownId);
+      setCountdownId(null);
+      Alert.alert('Info', 'Countdown ended');
+    } catch (e) {
+      Alert.alert('Error', (e && e.message) || String(e));
+    }
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.scrollContent}>
+      <ThemedView style={styles.container}>
+        <ThemedView style={styles.sectionCard}>
+          <ThemedText style={styles.sectionHeading}>SEGMENTS</ThemedText>
+          <ThemedText style={styles.hint}>
+            A built-in template with a segmented progress bar.
+          </ThemedText>
+          <Button title="Start Segments" onPress={startSegments} />
+          <Button
+            title="Advance Segment (update)"
+            onPress={advanceSegments}
+            disabled={!segmentsId}
+          />
+          <Button title="End Segments" onPress={endSegments} disabled={!segmentsId} />
+          <ThemedText style={styles.hint}>
+            {segmentsId ? `Running: ${segmentsComplete}/${segmentsTotal}` : 'Not started'}
+          </ThemedText>
+        </ThemedView>
+
+        <ThemedView style={styles.sectionCard}>
+          <ThemedText style={styles.sectionHeading}>COUNTDOWN TIMER</ThemedText>
+          <ThemedText style={styles.hint}>
+            A built-in template counting down to a target time.
+          </ThemedText>
+          <Button title="Start Countdown (+1h)" onPress={startCountdown} />
+          <Button title="End Countdown" onPress={endCountdown} disabled={!countdownId} />
+          <ThemedText style={styles.hint}>
+            {countdownId ? 'Running' : 'Not started'}
+          </ThemedText>
+        </ThemedView>
+      </ThemedView>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    paddingBottom: 24,
+  },
+  container: {
+    padding: 16,
+  },
+  sectionCard: {
+    padding: 16,
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  sectionHeading: {
+    fontWeight: '700',
+    marginBottom: 8,
+  },
+  hint: {
+    opacity: 0.9,
+    marginTop: 8,
+    marginBottom: 8,
+    fontSize: 14,
+  },
+});


### PR DESCRIPTION
Exercises the plugin end to end: types and branding come from `config.liveNotifications`, so the screen needs no JavaScript initialization of its own.

Stacked on #377.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the test app, sample native renderers, and CI signing metadata; no production SDK or plugin logic in this diff.
> 
> **Overview**
> Adds an end-to-end **Live Activities** flow in the Expo test app so the plugin’s `liveNotifications` auto-init (types, branding, custom widget/renderer) can be exercised without extra JS setup.
> 
> **`app.json`** now registers built-in segment/countdown types plus a custom rideshare type, with branding and pointers to `RideshareLiveActivity.swift` and `RideshareLiveNotification.kt`. A new **`LiveActivities`** screen drives `CustomerIO.liveActivities` start/update/end for all three templates; navigation is wired from the dashboard. **Fastlane** includes the generated `CIOLiveActivityWidget` extension for ad-hoc signing. **`customerio-reactnative`** is pinned to the `live-activities-sdk` branch for this demo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 340eb0da42459c8ec3814e5c9782041513213a39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->