### PR TITLE
feat: Enable Live Notifications feature

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -170,4 +170,39 @@ describe('withCustomerIOPlugin Live Notifications gating', () => {
 
     expect(warnSpy).not.toHaveBeenCalled();
   });
+
+  // The build-time artifacts and the generated native registration come from different inputs, so
+  // they have to be reconciled before the platform mods run. Leaving `config.liveNotifications` in
+  // place while `enabled: false` removes the pod subspec emits Swift that imports an unlinked module.
+  it('strips config.liveNotifications from both platforms when enabled is false', () => {
+    mockIsExpo53.mockReturnValue(true);
+
+    withCustomerIOPlugin(baseConfig, {
+      ...baseProps,
+      config: { cdpApiKey: 'key', liveNotifications: { types: ['io.customer.livenotifications.segments'] } },
+      liveNotifications: { enabled: false },
+    });
+
+    const iosSdkConfig = mockWithCIOIos.mock.calls[0][1];
+    const androidSdkConfig = mockWithCIOAndroid.mock.calls[0][1];
+
+    expect(iosSdkConfig?.liveNotifications).toBeUndefined();
+    expect(androidSdkConfig?.liveNotifications).toBeUndefined();
+    // Only Live Notifications is dropped — the rest of the config still has to reach the mods.
+    expect(iosSdkConfig?.cdpApiKey).toBe('key');
+    expect(androidSdkConfig?.cdpApiKey).toBe('key');
+  });
+
+  it('leaves config.liveNotifications intact when the feature is on', () => {
+    mockIsExpo53.mockReturnValue(true);
+
+    const liveNotificationsConfig = { types: ['io.customer.livenotifications.segments'] };
+    withCustomerIOPlugin(baseConfig, {
+      ...baseProps,
+      config: { cdpApiKey: 'key', liveNotifications: liveNotificationsConfig },
+    });
+
+    expect(mockWithCIOIos.mock.calls[0][1]?.liveNotifications).toEqual(liveNotificationsConfig);
+    expect(mockWithCIOAndroid.mock.calls[0][1]?.liveNotifications).toEqual(liveNotificationsConfig);
+  });
 });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -72,3 +72,102 @@ describe('withCustomerIOPlugin geofence gating', () => {
     ).not.toThrow();
   });
 });
+
+describe('withCustomerIOPlugin Live Notifications gating', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockWithExpoVersion.mockImplementation((c) => c);
+    mockWithCIOIos.mockImplementation((c) => c);
+    mockWithCIOAndroid.mockImplementation((c) => c as ExpoConfig);
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  // Pre-53 projects never reach withCIOIosSwift, so the AppDelegate is never wired to route a
+  // tapped activity's URL. Failing loudly beats shipping a widget whose taps go nowhere.
+  it('throws when liveNotifications.enabled on Expo < 53', () => {
+    mockIsExpo53.mockReturnValue(false);
+
+    expect(() =>
+      withCustomerIOPlugin(baseConfig, { ...baseProps, liveNotifications: { enabled: true } })
+    ).toThrow(/Live Notifications requires Expo SDK 53/);
+  });
+
+  it('does not throw when liveNotifications is disabled on Expo < 53', () => {
+    mockIsExpo53.mockReturnValue(false);
+
+    expect(() =>
+      withCustomerIOPlugin(baseConfig, { ...baseProps, liveNotifications: { enabled: false } })
+    ).not.toThrow();
+  });
+
+  it('forwards liveNotifications to both platform mods on Expo 53+', () => {
+    mockIsExpo53.mockReturnValue(true);
+
+    const liveNotifications = { enabled: true };
+    withCustomerIOPlugin(baseConfig, { ...baseProps, liveNotifications });
+
+    expect(mockWithCIOIos).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined,
+      baseProps.ios,
+      undefined,
+      undefined,
+      liveNotifications
+    );
+    expect(mockWithCIOAndroid).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined,
+      baseProps.android,
+      undefined,
+      undefined,
+      liveNotifications
+    );
+  });
+
+  // Auto initialization registers types from `config.liveNotifications`. Enabling the build-time
+  // setup without it generates the widget and the plist key but never adds the native module, so
+  // nothing is registered for push-to-start.
+  it('warns when enabled alongside a config that omits liveNotifications', () => {
+    mockIsExpo53.mockReturnValue(true);
+
+    withCustomerIOPlugin(baseConfig, {
+      ...baseProps,
+      config: { cdpApiKey: 'key' },
+      liveNotifications: { enabled: true },
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/config\.liveNotifications is missing/),
+    );
+  });
+
+  it('does not warn when the config declares liveNotifications', () => {
+    mockIsExpo53.mockReturnValue(true);
+
+    withCustomerIOPlugin(baseConfig, {
+      ...baseProps,
+      config: { cdpApiKey: 'key', liveNotifications: { types: [] } },
+      liveNotifications: { enabled: true },
+    });
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringMatching(/config\.liveNotifications is missing/),
+    );
+  });
+
+  // The JavaScript initialization path: no `config` at all, so `enabled` is the only way to ask for
+  // the native artifacts and there is nothing to warn about.
+  it('does not warn when there is no config at all', () => {
+    mockIsExpo53.mockReturnValue(true);
+
+    withCustomerIOPlugin(baseConfig, { ...baseProps, liveNotifications: { enabled: true } });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/ios/__snapshots__/withCIOIosSwift.test.ts.snap
+++ b/__tests__/ios/__snapshots__/withCIOIosSwift.test.ts.snap
@@ -67,6 +67,13 @@ public class AppDelegate: ExpoAppDelegate {
     cioSdkHandler.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
     super.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
   }
+
+  // Report a Live Activity tap and route the deep link it carries
+  public override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+    // Call CustomerIO SDK handler
+    guard let url = cioSdkHandler.application(app, open: url, options: options) else { return true }
+    return super.application(app, open: url, options: options)
+  }
 }"
 `;
 
@@ -136,6 +143,13 @@ public class AppDelegate: ExpoAppDelegate {
     // Call CustomerIO SDK handler
     cioSdkHandler.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
     super.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+  }
+
+  // Report a Live Activity tap and route the deep link it carries
+  public override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+    // Call CustomerIO SDK handler
+    guard let url = cioSdkHandler.application(app, open: url, options: options) else { return true }
+    return super.application(app, open: url, options: options)
   }
 }"
 `;

--- a/__tests__/ios/apn/__snapshots__/AppDelegate-swift.test.js.snap
+++ b/__tests__/ios/apn/__snapshots__/AppDelegate-swift.test.js.snap
@@ -59,6 +59,9 @@ class AppDelegate: ExpoAppDelegate {
     open url: URL,
     options: [UIApplication.OpenURLOptionsKey: Any] = [:]
   ) -> Bool {
+    // Call CustomerIO SDK handler
+    guard let url = cioSdkHandler.application(app, open: url, options: options) else { return true }
+
     return super.application(app, open: url, options: options) || RCTLinkingManager.application(app, open: url, options: options)
   }
 

--- a/__tests__/ios/apn/__snapshots__/CioSdkAppDelegateHandler-swift.test.js.snap
+++ b/__tests__/ios/apn/__snapshots__/CioSdkAppDelegateHandler-swift.test.js.snap
@@ -5,6 +5,11 @@ exports[`Expo 53 CioSdkAppDelegateHandler tests Plugin creates expected CioSdkAp
 import UIKit
 import UserNotifications
 import CioMessagingPushAPN
+// Live Activities pods are only present when the feature is enabled in the plugin config.
+#if canImport(CioLiveActivities)
+import CioDataPipelines
+import CioLiveActivities
+#endif
 #if canImport(EXNotifications)
 import EXNotifications
 import ExpoModulesCore
@@ -68,6 +73,20 @@ public class CioSdkAppDelegateHandler: NSObject {
     
   public func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
     cioAppDelegate.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+  }
+
+  /// Reports an \`opened\` metric when the app is launched from a tapped Live Activity, and returns
+  /// the URL that should actually be routed.
+  ///
+  /// For a Customer.io widget URL this is the customer's deep link (\`nil\` when the activity carried
+  /// none, so there is nothing to open). Any other URL is returned unchanged, leaving the app's
+  /// existing deep-link handling untouched.
+  public func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> URL? {
+    #if canImport(CioLiveActivities)
+    return CustomerIO.liveActivities.handleWidgetUrl(url)
+    #else
+    return url
+    #endif
   }
 }
 "

--- a/__tests__/ios/fcm/__snapshots__/AppDelegate-swift.test.js.snap
+++ b/__tests__/ios/fcm/__snapshots__/AppDelegate-swift.test.js.snap
@@ -59,6 +59,9 @@ class AppDelegate: ExpoAppDelegate {
     open url: URL,
     options: [UIApplication.OpenURLOptionsKey: Any] = [:]
   ) -> Bool {
+    // Call CustomerIO SDK handler
+    guard let url = cioSdkHandler.application(app, open: url, options: options) else { return true }
+
     return super.application(app, open: url, options: options) || RCTLinkingManager.application(app, open: url, options: options)
   }
 

--- a/__tests__/ios/fcm/__snapshots__/CioSdkAppDelegateHandler-swift.test.js.snap
+++ b/__tests__/ios/fcm/__snapshots__/CioSdkAppDelegateHandler-swift.test.js.snap
@@ -3,6 +3,11 @@
 exports[`Expo 53 FCM CioSdkAppDelegateHandler tests Plugin creates expected CioSdkAppDelegateHandler.swift 1`] = `
 "import Foundation
 import CioMessagingPushFCM
+// Live Activities pods are only present when the feature is enabled in the plugin config.
+#if canImport(CioLiveActivities)
+import CioDataPipelines
+import CioLiveActivities
+#endif
 import CioFirebaseWrapper
 @_spi(Internal) import CioMessagingPush
 import FirebaseCore
@@ -81,6 +86,20 @@ public class CioSdkAppDelegateHandler: NSObject {
     
   public func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
     
+  }
+
+  /// Reports an \`opened\` metric when the app is launched from a tapped Live Activity, and returns
+  /// the URL that should actually be routed.
+  ///
+  /// For a Customer.io widget URL this is the customer's deep link (\`nil\` when the activity carried
+  /// none, so there is nothing to open). Any other URL is returned unchanged, leaving the app's
+  /// existing deep-link handling untouched.
+  public func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> URL? {
+    #if canImport(CioLiveActivities)
+    return CustomerIO.liveActivities.handleWidgetUrl(url)
+    #else
+    return url
+    #endif
   }
 }
 "

--- a/__tests__/ios/liveActivityWidgetFailure.test.ts
+++ b/__tests__/ios/liveActivityWidgetFailure.test.ts
@@ -1,0 +1,46 @@
+import type { ExpoConfig } from '@expo/config-types';
+
+// Invoke the mod's callback directly so the failure inside it surfaces to the caller.
+jest.mock('@expo/config-plugins', () => ({
+  withXcodeProject: (
+    config: Record<string, unknown>,
+    callback: (c: Record<string, unknown>) => unknown,
+  ) =>
+    callback({
+      ...config,
+      modResults: {},
+      modRequest: { projectName: 'TestApp', platformProjectRoot: '/test/ios', projectRoot: '/test' },
+    }),
+}));
+
+// The first thing the widget injection does is append its Podfile target, so failing it here stands
+// in for any runtime failure part-way through building the extension.
+jest.mock('../../plugin/src/helpers/utils/injectCIOPodfileCode', () => ({
+  injectCIOLiveActivityWidgetPodfileCode: jest.fn(() =>
+    Promise.reject(new Error('Podfile not found')),
+  ),
+}));
+
+import { withCioLiveActivityWidgetXcodeProject } from '../../plugin/src/ios/withCioLiveActivityWidgetXcodeProject';
+
+const config = {
+  name: 'Test App',
+  slug: 'test-app',
+  version: '1.0.0',
+  ios: { bundleIdentifier: 'com.test.app' },
+} as ExpoConfig;
+
+describe('withCioLiveActivityWidgetXcodeProject failure handling', () => {
+  // NSSupportsLiveActivities and the `liveactivities` pod subspec are applied by mods that have
+  // already run by this point. Logging and returning the config would leave a project advertising
+  // Live Activities support with no extension to render them — configured-looking, permanently
+  // silent. Failing the prebuild is what makes the problem visible.
+  it('fails the prebuild instead of leaving the app half-configured', async () => {
+    await expect(
+      withCioLiveActivityWidgetXcodeProject(config, {
+        props: { iosPath: '/test/ios' },
+        liveNotifications: { types: [] },
+      }) as unknown as Promise<unknown>,
+    ).rejects.toThrow(/Live Activity widget failed: .*Podfile not found/);
+  });
+});

--- a/__tests__/ios/withCIOIos.test.ts
+++ b/__tests__/ios/withCIOIos.test.ts
@@ -249,14 +249,16 @@ describe('withCIOIos', () => {
   describe('live activities', () => {
     it('injects the widget target and Info.plist, adding the liveactivities subspec (no push/config)', () => {
       // Live Notifications without push is supported: an app can obtain a device token elsewhere and
-      // hand it to Customer.io for backend-driven activities. The tap route is installed on this path
-      // too (see withCIOIosSwift), so nothing here is half-wired.
+      // hand it to Customer.io for backend-driven activities. withCIOIosSwift has to run on this path
+      // too — it is what routes a tapped activity's URL through the SDK, so without it the `opened`
+      // metric is lost and the deep link is never forwarded.
       const props: CustomerIOPluginOptionsIOS = {
         iosPath: '/test/ios',
       };
 
       withCIOIos(mockConfig, undefined, props, undefined, undefined, { enabled: true });
 
+      expect(mockWithCIOIosSwift).toHaveBeenCalledTimes(1);
       expect(mockWithLiveActivityInfoPlist).toHaveBeenCalledTimes(1);
       expect(mockWithCioLiveActivityWidgetXcodeProject).toHaveBeenCalledTimes(1);
       expect(mockWithCioNotificationsXcodeProject).not.toHaveBeenCalled();
@@ -317,6 +319,7 @@ describe('withCIOIos', () => {
     it('injects the widget and Info.plist when there is no ios props block at all', () => {
       withCIOIos(mockConfig, undefined, undefined, undefined, undefined, { enabled: true });
 
+      expect(mockWithCIOIosSwift).toHaveBeenCalledTimes(1);
       expect(mockWithLiveActivityInfoPlist).toHaveBeenCalledTimes(1);
       expect(mockWithCioLiveActivityWidgetXcodeProject).toHaveBeenCalledTimes(1);
       expect(mockWithCioXcodeProject).toHaveBeenCalledWith(mockConfig, {

--- a/__tests__/ios/withCIOIos.test.ts
+++ b/__tests__/ios/withCIOIos.test.ts
@@ -7,6 +7,8 @@ const mockWithCIOIosSwift = jest.fn((config: ExpoConfig) => config);
 const mockWithAppDelegateModifications = jest.fn((config: ExpoConfig) => config);
 const mockWithCioNotificationsXcodeProject = jest.fn((config: ExpoConfig) => config);
 const mockWithGoogleServicesJsonFile = jest.fn((config: ExpoConfig) => config);
+const mockWithLiveActivityInfoPlist = jest.fn((config: ExpoConfig) => config);
+const mockWithCioLiveActivityWidgetXcodeProject = jest.fn((config: ExpoConfig) => config);
 const mockWithEntitlementsPlist = jest.fn((config: ExpoConfig, callback: (c: unknown) => unknown) => {
   callback({ ios: { bundleIdentifier: 'com.test.app' }, modResults: {} });
   return config;
@@ -35,6 +37,14 @@ jest.mock('../../plugin/src/ios/withNotificationsXcodeProject', () => ({
 jest.mock('../../plugin/src/ios/withGoogleServicesJsonFile', () => ({
   withGoogleServicesJsonFile: (config: ExpoConfig) =>
     mockWithGoogleServicesJsonFile(config),
+}));
+jest.mock('../../plugin/src/ios/withLiveActivityInfoPlist', () => ({
+  withLiveActivityInfoPlist: (config: ExpoConfig) =>
+    mockWithLiveActivityInfoPlist(config),
+}));
+jest.mock('../../plugin/src/ios/withCioLiveActivityWidgetXcodeProject', () => ({
+  withCioLiveActivityWidgetXcodeProject: (config: ExpoConfig) =>
+    mockWithCioLiveActivityWidgetXcodeProject(config),
 }));
 jest.mock('../../plugin/src/ios/utils', () => ({
   isExpoVersion53OrHigher: jest.fn(() => true),
@@ -65,7 +75,11 @@ describe('withCIOIos', () => {
       expect(mockWithCioNotificationsXcodeProject).not.toHaveBeenCalled();
       expect(mockWithCioXcodeProject).toHaveBeenCalledTimes(1);
       expect(mockWithCioXcodeProject).toHaveBeenCalledWith(mockConfig, {
-        podfileOptions: { locationEnabled: true, hasPush: false },
+        podfileOptions: {
+          locationEnabled: true,
+          hasPush: false,
+          liveNotificationsEnabled: false,
+        },
       });
     });
 
@@ -159,6 +173,67 @@ describe('withCIOIos', () => {
       withCIOIos(mockConfig, undefined, { iosPath: '/test/ios' });
 
       expect(mockWithEntitlementsPlist).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('live activities', () => {
+    it('injects the widget target and Info.plist, adding the liveactivities subspec (no push/config)', () => {
+      // Live Notifications without push is supported: an app can obtain a device token elsewhere and
+      // hand it to Customer.io for backend-driven activities. The tap route is installed on this path
+      // too (see withCIOIosSwift), so nothing here is half-wired.
+      const props: CustomerIOPluginOptionsIOS = {
+        iosPath: '/test/ios',
+      };
+
+      withCIOIos(mockConfig, undefined, props, undefined, { enabled: true });
+
+      expect(mockWithLiveActivityInfoPlist).toHaveBeenCalledTimes(1);
+      expect(mockWithCioLiveActivityWidgetXcodeProject).toHaveBeenCalledTimes(1);
+      expect(mockWithCioNotificationsXcodeProject).not.toHaveBeenCalled();
+      expect(mockWithCioXcodeProject).toHaveBeenCalledWith(mockConfig, {
+        ...props,
+        podfileOptions: {
+          locationEnabled: false,
+          hasPush: false,
+          liveNotificationsEnabled: true,
+        },
+      });
+    });
+
+    it('adds the liveactivities subspec alongside push when both are enabled', () => {
+      const props: CustomerIOPluginOptionsIOS = {
+        iosPath: '/test/ios',
+        pushNotification: { provider: 'apn' },
+      };
+
+      withCIOIos(mockConfig, undefined, props, undefined, { enabled: true });
+
+      expect(mockWithLiveActivityInfoPlist).toHaveBeenCalledTimes(1);
+      expect(mockWithCioLiveActivityWidgetXcodeProject).toHaveBeenCalledTimes(1);
+      expect(mockWithCioXcodeProject).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          podfileOptions: {
+            locationEnabled: false,
+            hasPush: true,
+            liveNotificationsEnabled: true,
+          },
+        }),
+      );
+    });
+
+    it('does not inject the widget when liveNotifications.enabled is false', () => {
+      withCIOIos(
+        mockConfig,
+        undefined,
+        { iosPath: '/test/ios' },
+        undefined,
+        { enabled: false },
+      );
+
+      expect(mockWithLiveActivityInfoPlist).not.toHaveBeenCalled();
+      expect(mockWithCioLiveActivityWidgetXcodeProject).not.toHaveBeenCalled();
+      expect(mockWithCioXcodeProject).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/ios/withCIOIos.test.ts
+++ b/__tests__/ios/withCIOIos.test.ts
@@ -309,6 +309,56 @@ describe('withCIOIos', () => {
       expect(mockWithCioLiveActivityWidgetXcodeProject).not.toHaveBeenCalled();
       expect(mockWithCioXcodeProject).not.toHaveBeenCalled();
     });
+
+    // app.json is untyped, so `ios` being required in CustomerIOPluginOptions doesn't stop an app
+    // from omitting it. Gating the widget on its presence added the subspec but skipped the plist key
+    // and the target, so nothing could start or render an activity — silently. Location and geofence
+    // already work without an `ios` block; this keeps Live Notifications consistent with them.
+    it('injects the widget and Info.plist when there is no ios props block at all', () => {
+      withCIOIos(mockConfig, undefined, undefined, undefined, undefined, { enabled: true });
+
+      expect(mockWithLiveActivityInfoPlist).toHaveBeenCalledTimes(1);
+      expect(mockWithCioLiveActivityWidgetXcodeProject).toHaveBeenCalledTimes(1);
+      expect(mockWithCioXcodeProject).toHaveBeenCalledWith(mockConfig, {
+        podfileOptions: {
+          locationEnabled: false,
+          geofenceEnabled: false,
+          hasPush: false,
+          liveNotificationsEnabled: true,
+        },
+      });
+    });
+
+    it('injects the widget on the auto-init path with no ios props block', () => {
+      const sdkConfig = {
+        cdpApiKey: 'key',
+        liveNotifications: { types: ['io.customer.livenotifications.segments'] },
+      };
+
+      withCIOIos(mockConfig, sdkConfig, undefined);
+
+      expect(mockWithCIOIosSwift).toHaveBeenCalledTimes(1);
+      expect(mockWithLiveActivityInfoPlist).toHaveBeenCalledTimes(1);
+      expect(mockWithCioLiveActivityWidgetXcodeProject).toHaveBeenCalledTimes(1);
+    });
+
+    // `enabled: false` is an explicit opt-out, so it has to win over an SDK config that would
+    // otherwise imply the feature. Without this an app could not turn the build-time setup off
+    // without also deleting its type list.
+    it('treats enabled:false as a kill switch over config.liveNotifications', () => {
+      const sdkConfig = {
+        cdpApiKey: 'key',
+        liveNotifications: { types: ['io.customer.livenotifications.segments'] },
+      };
+
+      withCIOIos(mockConfig, sdkConfig, { iosPath: '/test/ios' }, undefined, undefined, {
+        enabled: false,
+      });
+
+      expect(mockWithLiveActivityInfoPlist).not.toHaveBeenCalled();
+      expect(mockWithCioLiveActivityWidgetXcodeProject).not.toHaveBeenCalled();
+      expect(mockWithCioXcodeProject).not.toHaveBeenCalled();
+    });
   });
 
     it('adds both subspecs when geofence and live activities are enabled together', () => {

--- a/__tests__/ios/withCIOIosSwift.test.ts
+++ b/__tests__/ios/withCIOIosSwift.test.ts
@@ -449,6 +449,23 @@ public class AppDelegate: ExpoAppDelegate {
 
     expect(modifyAppDelegateForLiveActivityUrl(withPushHandler)).toBe(withPushHandler);
   });
+
+  // The push path preserves whichever parameter spelling the AppDelegate used, so a template naming
+  // it `_ application` leaves an `application, open:` marker. Checking only the `app,` spelling meant
+  // an app that dropped push and re-ran prebuild got a second guard inside the same method.
+  test('defers to the push handler that used the `application` parameter spelling', () => {
+    const withPushHandler = `import Expo
+
+public class AppDelegate: ExpoAppDelegate {
+  public override func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+    guard let url = cioSdkHandler.application(application, open: url, options: options) else { return true }
+    return super.application(application, open: url, options: options)
+  }
+}
+`;
+
+    expect(modifyAppDelegateForLiveActivityUrl(withPushHandler)).toBe(withPushHandler);
+  });
 });
 
 });

--- a/__tests__/ios/withCIOIosSwift.test.ts
+++ b/__tests__/ios/withCIOIosSwift.test.ts
@@ -1,5 +1,8 @@
 import type { ExpoConfig } from '@expo/config-types';
-import { withCIOIosSwift } from '../../plugin/src/ios/withCIOIosSwift';
+import {
+  modifyAppDelegateForLiveActivityUrl,
+  withCIOIosSwift,
+} from '../../plugin/src/ios/withCIOIosSwift';
 import type { CustomerIOPluginOptionsIOS, NativeSDKConfig } from '../../plugin/src/types/cio-types';
 
 // Mock dependencies
@@ -392,4 +395,60 @@ public class AppDelegate: ExpoAppDelegate {
       expect(occurrences).toBe(1);
     });
   });
+
+describe('modifyAppDelegateForLiveActivityUrl (Live Notifications without push)', () => {
+  // React Native 0.83 / Expo SDK 55 emit `internal import Expo` as the very first line. An
+  // expression anchored to a bare `import` at offset 0 matches nothing here, so the imports were
+  // silently skipped and the injected `CustomerIO.` reference failed to compile.
+  const RN_083_APP_DELEGATE = `internal import Expo
+import React
+import ReactAppDependencyProvider
+
+@UIApplicationMain
+public class AppDelegate: ExpoAppDelegate {
+  public override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+    return super.application(app, open: url, options: options)
+  }
+}
+`;
+
+  test('injects both imports after a leading modifier import', () => {
+    const out = modifyAppDelegateForLiveActivityUrl(RN_083_APP_DELEGATE);
+
+    // CustomerIO is declared in CioInternalCommon, which only CioDataPipelines re-exports.
+    expect(out).toContain('import CioDataPipelines');
+    expect(out).toContain('import CioLiveActivities');
+    expect(out).toContain('CustomerIO.liveActivities.handleWidgetUrl(url)');
+    // Placed after the existing imports, not before them.
+    expect(out.indexOf('import CioDataPipelines')).toBeGreaterThan(
+      out.indexOf('internal import Expo')
+    );
+  });
+
+  test('is idempotent', () => {
+    const once = modifyAppDelegateForLiveActivityUrl(RN_083_APP_DELEGATE);
+    const twice = modifyAppDelegateForLiveActivityUrl(once);
+
+    expect(twice).toBe(once);
+    expect(
+      (twice.match(/CustomerIO\.liveActivities\.handleWidgetUrl/g) || []).length
+    ).toBe(1);
+    expect((twice.match(/import CioDataPipelines/g) || []).length).toBe(1);
+  });
+
+  test('defers to the push handler when it already owns the method', () => {
+    const withPushHandler = `import Expo
+
+public class AppDelegate: ExpoAppDelegate {
+  public override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+    guard let url = cioSdkHandler.application(app, open: url, options: options) else { return true }
+    return super.application(app, open: url, options: options)
+  }
+}
+`;
+
+    expect(modifyAppDelegateForLiveActivityUrl(withPushHandler)).toBe(withPushHandler);
+  });
+});
+
 });

--- a/__tests__/ios/withCIOIosSwift.test.ts
+++ b/__tests__/ios/withCIOIosSwift.test.ts
@@ -1,6 +1,7 @@
 import type { ExpoConfig } from '@expo/config-types';
 import {
   modifyAppDelegateForLiveActivityUrl,
+  modifyAppDelegateForPushHandler,
   withCIOIosSwift,
 } from '../../plugin/src/ios/withCIOIosSwift';
 import type { CustomerIOPluginOptionsIOS, NativeSDKConfig } from '../../plugin/src/types/cio-types';
@@ -465,6 +466,76 @@ public class AppDelegate: ExpoAppDelegate {
 `;
 
     expect(modifyAppDelegateForLiveActivityUrl(withPushHandler)).toBe(withPushHandler);
+  });
+});
+
+// An app can be prebuilt with Live Notifications and no push, then add a push provider. The push
+// handler routes activity URLs itself, so the direct call has to go — otherwise the tap is reported
+// twice and the same method carries two guards. These round-trip through the real injector so the
+// removal cannot drift from the text it removes.
+describe('enabling push after a Live-Notifications-only prebuild', () => {
+  const APP_DELEGATE_WITH_METHOD = `internal import Expo
+import React
+
+@UIApplicationMain
+public class AppDelegate: ExpoAppDelegate {
+  public override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+    return super.application(app, open: url, options: options)
+  }
+}
+`;
+
+  // The injector creates the method itself when the template has none. The push regex still matches
+  // that generated method, so this shape stacks guards too.
+  const APP_DELEGATE_WITHOUT_METHOD = `internal import Expo
+import React
+
+@UIApplicationMain
+public class AppDelegate: ExpoAppDelegate {
+  public override func applicationDidBecomeActive(_ application: UIApplication) {}
+}
+`;
+
+  const props: CustomerIOPluginOptionsIOS = {
+    iosPath: '/test/ios',
+    pushNotification: { provider: 'apn' },
+  };
+
+  it.each([
+    ['a template that already had the method', APP_DELEGATE_WITH_METHOD],
+    ['a method the Live Activity injector created', APP_DELEGATE_WITHOUT_METHOD],
+  ])('replaces the Live Activity guard with the push handler for %s', (_label, template) => {
+    const liveNotificationsOnly = modifyAppDelegateForLiveActivityUrl(template);
+    expect(liveNotificationsOnly).toContain('CustomerIO.liveActivities.handleWidgetUrl');
+
+    const withPush = modifyAppDelegateForPushHandler(liveNotificationsOnly, props);
+
+    // Exactly one guard, and it is the push handler's.
+    expect(
+      (withPush.match(/CustomerIO\.liveActivities\.handleWidgetUrl/g) || []).length
+    ).toBe(0);
+    expect((withPush.match(/cioSdkHandler\.application\([a-z]+, open:/g) || []).length).toBe(1);
+  });
+
+  it('leaves no orphaned comment when the guard came from an existing method', () => {
+    const withPush = modifyAppDelegateForPushHandler(
+      modifyAppDelegateForLiveActivityUrl(APP_DELEGATE_WITH_METHOD),
+      props
+    );
+
+    // Only meaningful for this shape: the push injector re-emits the same comment when it has to
+    // create the method itself.
+    expect(withPush).not.toContain('Report a Live Activity tap');
+  });
+
+  it('is idempotent once push has taken over', () => {
+    const once = modifyAppDelegateForPushHandler(
+      modifyAppDelegateForLiveActivityUrl(APP_DELEGATE_WITH_METHOD),
+      props
+    );
+    const twice = modifyAppDelegateForPushHandler(once, props);
+
+    expect(twice).toBe(once);
   });
 });
 

--- a/__tests__/scenarios/ios/appDelegateSwift.test.ts
+++ b/__tests__/scenarios/ios/appDelegateSwift.test.ts
@@ -53,6 +53,13 @@ describe('ios scenarios — modifyAppDelegateForPushHandler', () => {
           cioSdkHandler.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
           super.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
         }
+
+        // Report a Live Activity tap and route the deep link it carries
+        public override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+          // Call CustomerIO SDK handler
+          guard let url = cioSdkHandler.application(app, open: url, options: options) else { return true }
+          return super.application(app, open: url, options: options)
+        }
       }
       "
     `);
@@ -110,6 +117,13 @@ describe('ios scenarios — modifyAppDelegateForPushHandler', () => {
           // Call CustomerIO SDK handler
           cioSdkHandler.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
           super.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+        }
+
+        // Report a Live Activity tap and route the deep link it carries
+        public override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+          // Call CustomerIO SDK handler
+          guard let url = cioSdkHandler.application(app, open: url, options: options) else { return true }
+          return super.application(app, open: url, options: options)
         }
       }
       "

--- a/__tests__/scenarios/ios/appDelegateSwiftSdkVersions.test.ts
+++ b/__tests__/scenarios/ios/appDelegateSwiftSdkVersions.test.ts
@@ -81,6 +81,9 @@ describe('AppDelegate.swift — Expo SDK 54 vanilla baseline', () => {
           open url: URL,
           options: [UIApplication.OpenURLOptionsKey: Any] = [:]
         ) -> Bool {
+          // Call CustomerIO SDK handler
+          guard let url = cioSdkHandler.application(app, open: url, options: options) else { return true }
+
           return super.application(app, open: url, options: options) || RCTLinkingManager.application(app, open: url, options: options)
         }
 
@@ -197,6 +200,9 @@ describe('AppDelegate.swift — Expo SDK 55 vanilla baseline', () => {
           open url: URL,
           options: [UIApplication.OpenURLOptionsKey: Any] = [:]
         ) -> Bool {
+          // Call CustomerIO SDK handler
+          guard let url = cioSdkHandler.application(app, open: url, options: options) else { return true }
+
           return super.application(app, open: url, options: options) || RCTLinkingManager.application(app, open: url, options: options)
         }
 

--- a/__tests__/scenarios/ios/liveActivityWidgetXcodeProject.test.ts
+++ b/__tests__/scenarios/ios/liveActivityWidgetXcodeProject.test.ts
@@ -1,0 +1,251 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const xcode = require('xcode');
+import {
+  addLiveActivityWidgetToXcodeProject,
+  type AddLiveActivityWidgetTargetOptions,
+} from '../../../plugin/src/ios/withCioLiveActivityWidgetXcodeProject';
+import { getFixturePath } from '../../utils';
+
+const WIDGET_TARGET_NAME = 'CIOLiveActivityWidget';
+
+const loadFixture = (name: string): { project: ReturnType<typeof xcode.project> } => {
+  const project = xcode.project(getFixturePath('ios/pbxproj', name));
+  project.parseSync();
+  return { project };
+};
+
+const targetNames = (project: ReturnType<typeof xcode.project>): string[] =>
+  Object.values(project.pbxNativeTargetSection())
+    .filter(
+      (t): t is { name: string } =>
+        typeof t === 'object' && t !== null && 'name' in (t as object),
+    )
+    .map((t) => (t.name as string).replace(/"/g, ''));
+
+const findTarget = (
+  project: ReturnType<typeof xcode.project>,
+  name: string,
+): { name: string; buildPhases: { value: string; comment?: string }[] } | undefined => {
+  const targets = project.pbxNativeTargetSection();
+  for (const key of Object.keys(targets)) {
+    const t = targets[key];
+    if (typeof t !== 'object' || t === null || !('name' in (t as object))) continue;
+    if ((t.name as string).replace(/"/g, '') === name) return t;
+  }
+  return undefined;
+};
+
+const buildPhaseTypesForTarget = (
+  project: ReturnType<typeof xcode.project>,
+  targetName: string,
+): string[] => {
+  const target = findTarget(project, targetName);
+  if (!target) return [];
+  const sections = project.hash.project.objects;
+  return target.buildPhases.map((bp) => {
+    for (const phaseType of [
+      'PBXSourcesBuildPhase',
+      'PBXResourcesBuildPhase',
+      'PBXFrameworksBuildPhase',
+    ]) {
+      if (sections[phaseType]?.[bp.value]) return phaseType;
+    }
+    return 'unknown';
+  });
+};
+
+/** File names compiled by the target's Sources phase, resolved through PBXBuildFile → PBXFileReference. */
+const sourceFileNamesForTarget = (
+  project: ReturnType<typeof xcode.project>,
+  targetName: string,
+): string[] => {
+  const target = findTarget(project, targetName);
+  if (!target) return [];
+  const sections = project.hash.project.objects;
+  const phaseUuid = target.buildPhases.find(
+    (bp) => sections.PBXSourcesBuildPhase?.[bp.value],
+  )?.value;
+  if (!phaseUuid) return [];
+
+  const files = sections.PBXSourcesBuildPhase[phaseUuid].files as {
+    value: string;
+  }[];
+  return files.map((file) => {
+    const fileRef = sections.PBXBuildFile[file.value].fileRef as string;
+    const reference = sections.PBXFileReference[fileRef] as {
+      path?: string;
+      name?: string;
+    };
+    return String(reference.path ?? reference.name ?? '').replace(/"/g, '');
+  });
+};
+
+/** Children of the widget's PBXGroup, as they appear in the Xcode navigator. */
+const groupChildNamesFor = (
+  project: ReturnType<typeof xcode.project>,
+  groupName: string,
+): string[] => {
+  const groups = project.hash.project.objects.PBXGroup;
+  const group = Object.keys(groups)
+    .map((key) => groups[key])
+    .find(
+      (candidate): candidate is { children: { comment?: string }[] } =>
+        typeof candidate === 'object' &&
+        candidate !== null &&
+        String((candidate as { name?: string }).name ?? '').replace(/"/g, '') ===
+          groupName,
+    );
+  return (group?.children ?? []).map((child) => String(child.comment ?? ''));
+};
+
+const buildSettingsForTarget = (
+  project: ReturnType<typeof xcode.project>,
+  targetName: string,
+): Record<string, Record<string, unknown>> => {
+  const configurations = project.pbxXCBuildConfigurationSection();
+  const out: Record<string, Record<string, unknown>> = {};
+  for (const key in configurations) {
+    const config = configurations[key];
+    if (
+      typeof config === 'object' &&
+      config?.buildSettings?.PRODUCT_NAME === `"${targetName}"`
+    ) {
+      out[config.name] = config.buildSettings;
+    }
+  }
+  return out;
+};
+
+const baseOptions: AddLiveActivityWidgetTargetOptions = {
+  appleTeamId: 'TESTTEAM1',
+  bundleIdentifier: 'io.customer.testbed.expo',
+};
+
+describe('ios scenarios — addLiveActivityWidgetToXcodeProject (vanilla pbxproj)', () => {
+  it('adds the widget target alongside the existing host-app target', () => {
+    const { project } = loadFixture('vanilla.pbxproj');
+    expect(targetNames(project)).toEqual(['ExpoTestbed']);
+
+    addLiveActivityWidgetToXcodeProject(project, baseOptions);
+
+    expect(targetNames(project).sort()).toEqual([
+      'CIOLiveActivityWidget',
+      'ExpoTestbed',
+    ]);
+  });
+
+  it('wires three build phases (Sources, Resources, Frameworks) on the new target', () => {
+    const { project } = loadFixture('vanilla.pbxproj');
+    addLiveActivityWidgetToXcodeProject(project, baseOptions);
+
+    expect(buildPhaseTypesForTarget(project, WIDGET_TARGET_NAME).sort()).toEqual([
+      'PBXFrameworksBuildPhase',
+      'PBXResourcesBuildPhase',
+      'PBXSourcesBuildPhase',
+    ]);
+  });
+
+  it('configures dev team, 16.2 deployment target (default), Swift 5.0, and prefixed bundle id', () => {
+    const { project } = loadFixture('vanilla.pbxproj');
+    addLiveActivityWidgetToXcodeProject(project, baseOptions);
+
+    const settings = Object.values(buildSettingsForTarget(project, WIDGET_TARGET_NAME));
+    expect(settings.length).toBeGreaterThan(0);
+    for (const buildSettings of settings) {
+      expect(buildSettings).toMatchObject({
+        DEVELOPMENT_TEAM: 'TESTTEAM1',
+        IPHONEOS_DEPLOYMENT_TARGET: '16.2',
+        TARGETED_DEVICE_FAMILY: '"1,2"',
+        CODE_SIGN_STYLE: 'Automatic',
+        SWIFT_VERSION: '5.0',
+      });
+      // App extension bundle id must be prefixed by the host app's bundle id.
+      expect(String(buildSettings.PRODUCT_BUNDLE_IDENTIFIER)).toContain(
+        'io.customer.testbed.expo.CIOLiveActivityWidget',
+      );
+    }
+  });
+
+  it('compiles only the generated bundle when no custom widget is configured', () => {
+    const { project } = loadFixture('vanilla.pbxproj');
+    addLiveActivityWidgetToXcodeProject(project, baseOptions);
+
+    expect(sourceFileNamesForTarget(project, WIDGET_TARGET_NAME)).toEqual([
+      'CIOLiveActivityWidgetBundle.swift',
+    ]);
+  });
+
+  // The app's own SwiftUI has to be compiled by the generated target — that is the whole point of
+  // handing the plugin a source file instead of owning a widget target.
+  it("compiles the app's custom widget sources alongside the generated bundle", () => {
+    const { project } = loadFixture('vanilla.pbxproj');
+    addLiveActivityWidgetToXcodeProject(project, {
+      ...baseOptions,
+      customSourceFilenames: ['RideshareLiveActivity.swift', 'RideshareViews.swift'],
+    });
+
+    expect(sourceFileNamesForTarget(project, WIDGET_TARGET_NAME)).toEqual([
+      'CIOLiveActivityWidgetBundle.swift',
+      'RideshareLiveActivity.swift',
+      'RideshareViews.swift',
+    ]);
+  });
+
+  it('lists the custom sources in the widget group so they show up in Xcode', () => {
+    const { project } = loadFixture('vanilla.pbxproj');
+    addLiveActivityWidgetToXcodeProject(project, {
+      ...baseOptions,
+      customSourceFilenames: ['RideshareLiveActivity.swift'],
+      assetCatalogFilename: 'Assets.xcassets',
+    });
+
+    expect(groupChildNamesFor(project, WIDGET_TARGET_NAME)).toEqual([
+      'CIOLiveActivityWidgetBundle.swift',
+      'RideshareLiveActivity.swift',
+      'CIOLiveActivityWidget-Info.plist',
+      'Assets.xcassets',
+    ]);
+  });
+
+  it('honors an explicit deployment target override', () => {
+    const { project } = loadFixture('vanilla.pbxproj');
+    addLiveActivityWidgetToXcodeProject(project, {
+      ...baseOptions,
+      iosDeploymentTarget: '17.2',
+    });
+
+    const settings = Object.values(buildSettingsForTarget(project, WIDGET_TARGET_NAME));
+    for (const buildSettings of settings) {
+      expect(buildSettings.IPHONEOS_DEPLOYMENT_TARGET).toEqual('17.2');
+    }
+  });
+});
+
+// The app's own SwiftUI is compiled into this target, so its floor has to be settable — but not
+// below where ActivityKit exists.
+
+describe('ios scenarios — addLiveActivityWidgetToXcodeProject (multi-target host)', () => {
+  it('adds the widget target without disturbing other pre-existing extension targets', () => {
+    const { project } = loadFixture('multi_target.pbxproj');
+    expect(targetNames(project).sort()).toEqual(['ExpoTestbed', 'Watch']);
+
+    addLiveActivityWidgetToXcodeProject(project, baseOptions);
+
+    expect(targetNames(project).sort()).toEqual([
+      'CIOLiveActivityWidget',
+      'ExpoTestbed',
+      'Watch',
+    ]);
+  });
+
+  it('leaves other targets untouched (no DEVELOPMENT_TEAM stamp on Watch)', () => {
+    const { project } = loadFixture('multi_target.pbxproj');
+    addLiveActivityWidgetToXcodeProject(project, baseOptions);
+
+    const watchSettings = Object.values(buildSettingsForTarget(project, 'Watch'));
+    expect(watchSettings.length).toBeGreaterThan(0);
+    for (const buildSettings of watchSettings) {
+      expect(buildSettings.DEVELOPMENT_TEAM).toBeUndefined();
+    }
+  });
+});

--- a/__tests__/scenarios/ios/liveNotificationsConfigMatrix.test.ts
+++ b/__tests__/scenarios/ios/liveNotificationsConfigMatrix.test.ts
@@ -120,6 +120,19 @@ describe('Live Notifications config matrix — feature off', () => {
 });
 
 describe('Live Notifications config matrix — auto initialization', () => {
+  // The one cell where the two dimensions disagree: SDK config asks for the feature and the
+  // build-time flag refuses it. An explicit `false` is an opt-out, so it wins — otherwise an app
+  // could not turn the native artifacts off without also deleting its type list.
+  test('enabled:false overrides an SDK config that would otherwise enable the feature', () => {
+    const config = { types: [SEGMENTS], customType: CUSTOM_TYPE };
+
+    expect(isLiveNotificationsEnabled(buildOptions({ enabled: false }), sdkConfig(config))).toBe(
+      false
+    );
+    // Omitting the flag still infers it from the config, which is the common auto-init case.
+    expect(isLiveNotificationsEnabled(buildOptions(), sdkConfig(config))).toBe(true);
+  });
+
   test('built-in templates: the bundle renders exactly the configured types', () => {
     const config = { types: [SEGMENTS] };
     expect(isLiveNotificationsEnabled(undefined, sdkConfig(config))).toBe(true);

--- a/__tests__/scenarios/ios/liveNotificationsConfigMatrix.test.ts
+++ b/__tests__/scenarios/ios/liveNotificationsConfigMatrix.test.ts
@@ -1,0 +1,301 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { resolveCustomLiveActivityWidget } from '../../../plugin/src/helpers/utils/liveNotificationCustomWidget';
+import { isLiveNotificationsEnabled } from '../../../plugin/src/helpers/utils/liveNotificationsEnabled';
+import {
+  generateWidgetBundleSwift,
+  resolveLiveNotificationTypes,
+} from '../../../plugin/src/helpers/utils/patchLiveNotificationCode';
+import type {
+  CustomerIOPluginLiveNotificationsOptions,
+  LiveNotificationsSDKConfig,
+  NativeSDKConfig,
+} from '../../../plugin/src/types/cio-types';
+import { logger } from '../../../plugin/src/utils/logger';
+
+/**
+ * Every combination of the three dimensions that change how Live Notifications are generated:
+ *
+ * - **initialization**: automatic (`config.liveNotifications` present) vs from JavaScript
+ *   (`liveNotifications.enabled`, no SDK config)
+ * - **feature**: off vs on
+ * - **templates**: built-in vs custom
+ *
+ * The dimensions interact, which is the reason for testing them as a grid rather than one at a
+ * time. Two behaviours only make sense as a consequence of a pair: a missing `customType` is a
+ * misconfiguration when the app auto-initializes and correct when it initializes from JavaScript,
+ * and the widget must render every built-in on the JavaScript path precisely because the plugin
+ * cannot know which ones the app will enable.
+ */
+
+const SEGMENTS = 'io.customer.livenotifications.segments';
+const COUNTDOWN = 'io.customer.livenotifications.countdowntimer';
+const CUSTOM_TYPE = 'com.myapp.rideshare';
+const STRUCT = 'RideshareLiveActivity';
+const BRANDING = { backgroundColorHex: '#101010', accentColorHex: '#00A0DF' };
+const WIDGET_SOURCE = `import SwiftUI\nstruct ${STRUCT}: Widget { var body: some WidgetConfiguration { fatalError() } }\n`;
+
+const cdpApiKey = 'test-key';
+
+let projectRoot: string;
+let warn: jest.SpyInstance;
+let consoleWarn: jest.SpyInstance;
+
+/** Build-time plugin options, i.e. the top-level `liveNotifications` key. */
+const buildOptions = (
+  overrides: Partial<CustomerIOPluginLiveNotificationsOptions> = {}
+): CustomerIOPluginLiveNotificationsOptions => ({ ...overrides });
+
+/** A `customWidget` pointing at a file that really exists in the temp project. */
+const customWidget = () => ({
+  sourceFile: './ios-widgets/RideshareLiveActivity.swift',
+  structName: STRUCT,
+});
+
+const sdkConfig = (
+  liveNotifications: LiveNotificationsSDKConfig | undefined
+): NativeSDKConfig => ({ cdpApiKey, liveNotifications }) as NativeSDKConfig;
+
+/** What the generated widget bundle ends up rendering, given a cell of the grid. */
+const bundleFor = (options: {
+  liveNotifications?: LiveNotificationsSDKConfig;
+  build?: CustomerIOPluginLiveNotificationsOptions;
+  autoInitializes: boolean;
+}) => {
+  const resolved = resolveCustomLiveActivityWidget({
+    liveNotifications: options.liveNotifications,
+    buildOptions: options.build,
+    autoInitializes: options.autoInitializes,
+    projectRoot,
+    reservedFilenames: [],
+  });
+  return generateWidgetBundleSwift(
+    resolveLiveNotificationTypes(options.liveNotifications?.types),
+    // Branding is a build-time option, not SDK config: it is compiled into this bundle, so it has
+    // to be readable on the JavaScript-initialization path too.
+    options.build?.branding,
+    resolved?.structName,
+    options.autoInitializes
+  );
+};
+
+beforeEach(() => {
+  projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cio-matrix-'));
+  fs.mkdirSync(path.join(projectRoot, 'ios-widgets'), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, 'ios-widgets/RideshareLiveActivity.swift'),
+    WIDGET_SOURCE
+  );
+  warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+  consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warn.mockRestore();
+  consoleWarn.mockRestore();
+  fs.rmSync(projectRoot, { recursive: true, force: true });
+});
+
+describe('Live Notifications config matrix — feature off', () => {
+  test('auto initialization, no liveNotifications config: nothing is generated', () => {
+    expect(isLiveNotificationsEnabled(undefined, sdkConfig(undefined))).toBe(false);
+  });
+
+  test('JavaScript initialization without enabled: nothing is generated', () => {
+    expect(isLiveNotificationsEnabled(buildOptions(), undefined)).toBe(false);
+    expect(isLiveNotificationsEnabled(buildOptions({ enabled: false }), undefined)).toBe(
+      false
+    );
+  });
+
+  test('a customWidget cannot switch the feature on by itself', () => {
+    // It describes how to render, never whether the feature is on — otherwise a leftover widget
+    // config would silently add a target to an app that had turned Live Notifications off.
+    expect(
+      isLiveNotificationsEnabled(buildOptions({ customWidget: customWidget() }), undefined)
+    ).toBe(false);
+  });
+});
+
+describe('Live Notifications config matrix — auto initialization', () => {
+  test('built-in templates: the bundle renders exactly the configured types', () => {
+    const config = { types: [SEGMENTS] };
+    expect(isLiveNotificationsEnabled(undefined, sdkConfig(config))).toBe(true);
+
+    const bundle = bundleFor({ liveNotifications: config, autoInitializes: true });
+    expect(bundle).toContain('CIOSegmentsLiveActivity()');
+    expect(bundle).not.toContain('CIOCountdownTimerLiveActivity()');
+    expect(bundle).not.toContain(`${STRUCT}()`);
+    expect(warn).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+
+  test('custom template: the bundle renders only the app struct', () => {
+    const config = { types: [], customType: CUSTOM_TYPE };
+    expect(isLiveNotificationsEnabled(undefined, sdkConfig(config))).toBe(true);
+
+    const bundle = bundleFor({
+      liveNotifications: config,
+      build: buildOptions({ customWidget: customWidget() }),
+      autoInitializes: true,
+    });
+    expect(bundle).toContain(`${STRUCT}()`);
+    expect(bundle).not.toContain('CIOSegmentsLiveActivity()');
+    // Both halves are present, so nothing to report.
+    expect(warn).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+
+  test('both: the bundle renders the configured types and the app struct', () => {
+    const config = { types: [SEGMENTS, COUNTDOWN], customType: CUSTOM_TYPE };
+    const bundle = bundleFor({
+      liveNotifications: config,
+      build: buildOptions({ customWidget: customWidget() }),
+      autoInitializes: true,
+    });
+    expect(bundle).toContain('CIOSegmentsLiveActivity()');
+    expect(bundle).toContain('CIOCountdownTimerLiveActivity()');
+    expect(bundle).toContain(`${STRUCT}()`);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('customType without a customWidget warns: the SDK would register a type nothing draws', () => {
+    const resolved = resolveCustomLiveActivityWidget({
+      liveNotifications: { customType: CUSTOM_TYPE },
+      buildOptions: undefined,
+      autoInitializes: true,
+      projectRoot,
+      reservedFilenames: [],
+    });
+    expect(resolved).toBeNull();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(CUSTOM_TYPE));
+  });
+
+  test('customWidget without a customType warns: the widget would draw a type nothing starts', () => {
+    const resolved = resolveCustomLiveActivityWidget({
+      liveNotifications: { types: [SEGMENTS] },
+      buildOptions: buildOptions({ customWidget: customWidget() }),
+      autoInitializes: true,
+      projectRoot,
+      reservedFilenames: [],
+    });
+    expect(resolved?.structName).toEqual(STRUCT);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('config.liveNotifications.customType is not set')
+    );
+  });
+});
+
+describe('Live Notifications config matrix — JavaScript initialization', () => {
+  test('built-in templates: every built-in is rendered, with no warning', () => {
+    const build = buildOptions({ enabled: true });
+    expect(isLiveNotificationsEnabled(build, undefined)).toBe(true);
+
+    const bundle = bundleFor({ build, autoInitializes: false });
+    expect(bundle).toContain('CIOSegmentsLiveActivity()');
+    expect(bundle).toContain('CIOCountdownTimerLiveActivity()');
+    // The app picks its types at runtime, so rendering all of them is correct rather than a
+    // fallback from a misconfiguration — warning here would fire on a supported setup.
+    expect(consoleWarn).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('custom template: the app struct renders alongside the built-ins', () => {
+    const build = buildOptions({ enabled: true, customWidget: customWidget() });
+    const bundle = bundleFor({ build, autoInitializes: false });
+
+    expect(bundle).toContain(`${STRUCT}()`);
+    // The built-ins have to be there too: the app may enable them from JavaScript, and the plugin
+    // has no way to know. Rendering only the custom struct would make those silently un-drawable.
+    expect(bundle).toContain('CIOSegmentsLiveActivity()');
+    expect(bundle).toContain('CIOCountdownTimerLiveActivity()');
+  });
+
+  test('a missing customType is not reported: it is supplied at runtime', () => {
+    const resolved = resolveCustomLiveActivityWidget({
+      liveNotifications: undefined,
+      buildOptions: buildOptions({ enabled: true, customWidget: customWidget() }),
+      autoInitializes: false,
+      projectRoot,
+      reservedFilenames: [],
+    });
+    expect(resolved?.structName).toEqual(STRUCT);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Branding cuts across the grid because it is the one value both platforms consume at build time:
+ * iOS compiles it into the widget's SwiftUI, and Android has it generated into the initializer.
+ * That is why it lives in the build-time options — SDK config only exists on the automatic path, and
+ * a widget already compiled cannot be branded afterwards.
+ */
+describe('Live Notifications config matrix — branding', () => {
+  test('auto initialization: branding is compiled into the built-in widgets', () => {
+    const bundle = bundleFor({
+      liveNotifications: { types: [SEGMENTS] },
+      build: buildOptions({ branding: BRANDING }),
+      autoInitializes: true,
+    });
+
+    expect(bundle).toContain(
+      'CIOSegmentsLiveActivity(branding: CIOSegmentsBranding(background: Color(hex: 0x101010)'
+    );
+    expect(bundle).toContain('progressCompleteStyle: Color(hex: 0x00A0DF)');
+    // The hex helper is only emitted when a generated color actually needs it.
+    expect(bundle).toContain('init(hex: UInt32)');
+  });
+
+  test('JavaScript initialization: branding still reaches the widget', () => {
+    // The point of the move. There is no SDK config on this path, so branding read from there would
+    // leave a JavaScript-initialized app permanently stuck with the SDK's default styling.
+    const bundle = bundleFor({
+      build: buildOptions({ enabled: true, branding: BRANDING }),
+      autoInitializes: false,
+    });
+
+    expect(bundle).toContain('CIOSegmentsLiveActivity(branding: CIOSegmentsBranding(');
+    expect(bundle).toContain('CIOCountdownTimerLiveActivity(branding: CIOCountdownTimerBranding(');
+    expect(bundle).toContain('background: Color(hex: 0x101010)');
+  });
+
+  test('a custom template takes no branding argument, on either path', () => {
+    // The app wrote that SwiftUI, so it styles itself; passing branding in would not compile.
+    for (const autoInitializes of [true, false]) {
+      const bundle = bundleFor({
+        liveNotifications: autoInitializes
+          ? { types: [SEGMENTS], customType: CUSTOM_TYPE }
+          : undefined,
+        build: buildOptions({
+          enabled: true,
+          branding: BRANDING,
+          customWidget: customWidget(),
+        }),
+        autoInitializes,
+      });
+
+      expect(bundle).toContain(`${STRUCT}()`);
+      expect(bundle).not.toContain(`${STRUCT}(branding`);
+      expect(bundle).toContain('CIOSegmentsLiveActivity(branding:');
+    }
+  });
+
+  test('no branding: the widgets use the SDK default styling and no hex helper is emitted', () => {
+    const bundle = bundleFor({
+      build: buildOptions({ enabled: true }),
+      autoInitializes: false,
+    });
+
+    expect(bundle).toContain('CIOSegmentsLiveActivity()');
+    expect(bundle).not.toContain('init(hex: UInt32)');
+  });
+
+  test('branding alone cannot switch the feature on', () => {
+    // Same reasoning as `customWidget`: it describes how templates look, never whether they run.
+    expect(isLiveNotificationsEnabled(buildOptions({ branding: BRANDING }), undefined)).toBe(
+      false
+    );
+  });
+});

--- a/__tests__/scenarios/ios/liveNotificationsConfigMatrix.test.ts
+++ b/__tests__/scenarios/ios/liveNotificationsConfigMatrix.test.ts
@@ -2,10 +2,15 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
+import { PLATFORM } from '../../../plugin/src/helpers/constants/common';
 import { resolveCustomLiveActivityWidget } from '../../../plugin/src/helpers/utils/liveNotificationCustomWidget';
-import { isLiveNotificationsEnabled } from '../../../plugin/src/helpers/utils/liveNotificationsEnabled';
+import {
+  isLiveNotificationsEnabled,
+  resolveSdkConfigForLiveNotifications,
+} from '../../../plugin/src/helpers/utils/liveNotificationsEnabled';
 import {
   generateWidgetBundleSwift,
+  patchLiveNotificationPlaceholders,
   resolveLiveNotificationTypes,
 } from '../../../plugin/src/helpers/utils/patchLiveNotificationCode';
 import type {
@@ -131,6 +136,36 @@ describe('Live Notifications config matrix — auto initialization', () => {
     );
     // Omitting the flag still infers it from the config, which is the common auto-init case.
     expect(isLiveNotificationsEnabled(buildOptions(), sdkConfig(config))).toBe(true);
+  });
+
+  // The opt-out has to reach the generated initializer as well as the build-time artifacts. If it
+  // only turned off the pod subspec, the Swift below would still `import CioLiveActivities` and
+  // construct a `LiveActivitiesModule` against a module the build no longer links.
+  test('enabled:false also clears the registration in the generated initializer', () => {
+    const config = { types: [SEGMENTS], customType: CUSTOM_TYPE };
+    const template =
+      'import CioDataPipelines\n{{LIVE_NOTIFICATION_MODULE_IMPORT}}\n\nlet builder = X()\n' +
+      '        {{LIVE_NOTIFICATION_MODULE_INIT}}\nCustomerIO.initialize()\n';
+
+    const enabled = resolveSdkConfigForLiveNotifications(buildOptions(), sdkConfig(config));
+    const optedOut = resolveSdkConfigForLiveNotifications(
+      buildOptions({ enabled: false }),
+      sdkConfig(config)
+    );
+
+    expect(
+      patchLiveNotificationPlaceholders(template, PLATFORM.IOS, enabled?.liveNotifications)
+    ).toContain('LiveActivitiesModule');
+    const optedOutSwift = patchLiveNotificationPlaceholders(
+      template,
+      PLATFORM.IOS,
+      optedOut?.liveNotifications
+    );
+    expect(optedOutSwift).not.toContain('LiveActivitiesModule');
+    expect(optedOutSwift).not.toContain('CioLiveActivities');
+    // Everything unrelated to Live Notifications survives untouched.
+    expect(optedOutSwift).toContain('import CioDataPipelines');
+    expect(optedOut?.cdpApiKey).toBe(cdpApiKey);
   });
 
   test('built-in templates: the bundle renders exactly the configured types', () => {

--- a/__tests__/scenarios/ios/podfileHostApp.test.ts
+++ b/__tests__/scenarios/ios/podfileHostApp.test.ts
@@ -119,6 +119,80 @@ describe('ios scenarios — injectHostAppPodfileCode', () => {
     `);
   });
 
+  it('injects subspecs (push + liveactivities) when liveNotificationsEnabled and hasPush', () => {
+    expect(
+      injectHostAppPodfileCode(baseline, IOS_PATH, false, {
+        liveNotificationsEnabled: true,
+        hasPush: true,
+      })
+    ).toMatchInlineSnapshot(`
+      "platform :ios, '13.0'
+      target 'TestApp' do
+        use_expo_modules!
+        config = use_native_modules!
+        use_react_native!(
+          :path => config[:reactNativePath],
+        )
+      end
+
+      # --- CustomerIO Host App START ---
+        pod 'customerio-reactnative', :subspecs => ['apn', 'liveactivities'], :path => '../node_modules/customerio-reactnative'
+        pod 'CustomerIO', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOCommon', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIODataPipelines', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOTrackingMigration', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOMessagingInApp', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOMessagingPush', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOMessagingPushAPN', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOLiveActivities', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOLiveActivitiesAttributes', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOLiveActivitiesTemplates', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+      # --- CustomerIO Host App END ---
+      post_install do |installer|
+        react_native_post_install(installer)
+      end
+      "
+    `);
+  });
+
+  it('injects push + location + liveactivities subspecs when all are enabled', () => {
+    expect(
+      injectHostAppPodfileCode(baseline, IOS_PATH, true, {
+        locationEnabled: true,
+        hasPush: true,
+        liveNotificationsEnabled: true,
+      })
+    ).toMatchInlineSnapshot(`
+      "platform :ios, '13.0'
+      target 'TestApp' do
+        use_expo_modules!
+        config = use_native_modules!
+        use_react_native!(
+          :path => config[:reactNativePath],
+        )
+      end
+
+      # --- CustomerIO Host App START ---
+        pod 'customerio-reactnative', :subspecs => ['fcm', 'location', 'liveactivities'], :path => '../node_modules/customerio-reactnative'
+        pod 'CustomerIO', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOCommon', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIODataPipelines', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOTrackingMigration', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOMessagingInApp', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOMessagingPush', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOMessagingPushFCM', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOLocation', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOLiveActivities', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOLiveActivitiesAttributes', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOLiveActivitiesTemplates', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+      # --- CustomerIO Host App END ---
+      post_install do |installer|
+        react_native_post_install(installer)
+      end
+      "
+    `);
+  });
+
   it('is a no-op when the host-app block is already present', () => {
     const once = injectHostAppPodfileCode(baseline, IOS_PATH, false);
     expect(injectHostAppPodfileCode(once, IOS_PATH, false)).toEqual(once);

--- a/__tests__/scenarios/ios/podfileLiveActivityTarget.test.ts
+++ b/__tests__/scenarios/ios/podfileLiveActivityTarget.test.ts
@@ -1,0 +1,72 @@
+import { appendLiveActivityWidgetTargetToPodfile } from '../../../plugin/src/helpers/utils/injectCIOPodfileCode';
+
+const baseline = [
+  "platform :ios, '13.0'",
+  "target 'TestApp' do",
+  '  use_expo_modules!',
+  'end',
+  '',
+  'post_install do |installer|',
+  '  react_native_post_install(installer)',
+  'end',
+  '',
+].join('\n');
+
+describe('ios scenarios — appendLiveActivityWidgetTargetToPodfile', () => {
+  it('appends the widget target block with use_frameworks: static', () => {
+    expect(appendLiveActivityWidgetTargetToPodfile(baseline, 'static'))
+      .toMatchInlineSnapshot(`
+      "platform :ios, '13.0'
+      target 'TestApp' do
+        use_expo_modules!
+      end
+
+      post_install do |installer|
+        react_native_post_install(installer)
+      end
+      # --- CustomerIO Live Activity START ---
+      target 'CIOLiveActivityWidget' do
+        use_frameworks! :linkage => :static
+        pod 'CustomerIOLiveActivitiesTemplates', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOLiveActivitiesAttributes', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+      end
+      # --- CustomerIO Live Activity END ---
+      "
+    `);
+  });
+
+  it('omits the use_frameworks line when useFrameworks is undefined', () => {
+    expect(appendLiveActivityWidgetTargetToPodfile(baseline, undefined))
+      .toMatchInlineSnapshot(`
+      "platform :ios, '13.0'
+      target 'TestApp' do
+        use_expo_modules!
+      end
+
+      post_install do |installer|
+        react_native_post_install(installer)
+      end
+      # --- CustomerIO Live Activity START ---
+      target 'CIOLiveActivityWidget' do
+        
+        pod 'CustomerIOLiveActivitiesTemplates', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+        pod 'CustomerIOLiveActivitiesAttributes', :git => 'https://github.com/customerio/customerio-ios.git', :branch => 'feat/live-activities'
+      end
+      # --- CustomerIO Live Activity END ---
+      "
+    `);
+  });
+
+  it('is a no-op when the widget target block is already present', () => {
+    const once = appendLiveActivityWidgetTargetToPodfile(baseline, 'static');
+    expect(appendLiveActivityWidgetTargetToPodfile(once, 'static')).toEqual(
+      once
+    );
+  });
+
+  it('is idempotent', () => {
+    const once = appendLiveActivityWidgetTargetToPodfile(baseline, 'static');
+    const twice = appendLiveActivityWidgetTargetToPodfile(once, 'static');
+    expect(twice).toEqual(once);
+  });
+});

--- a/__tests__/utils/liveNotificationCustomRenderer.test.ts
+++ b/__tests__/utils/liveNotificationCustomRenderer.test.ts
@@ -1,0 +1,222 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  installAndroidCustomLiveNotificationRenderer,
+  resolveCustomLiveNotificationRenderer,
+} from '../../plugin/src/helpers/utils/liveNotificationCustomRenderer';
+import type { LiveNotificationCustomRenderer } from '../../plugin/src/types/cio-types';
+
+// Like the widget resolver's tests, these run against a real project tree: the resolver's whole job
+// is deciding what is safe to copy into the app, which depends on what is actually on disk.
+
+const RENDERER_SOURCE = `package com.myapp.livenotifications
+
+import android.app.Notification
+import android.content.Context
+import io.customer.messagingpush.data.communication.CustomerIOLiveNotificationsCallback
+import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
+
+class RideshareLiveNotificationCallback : CustomerIOLiveNotificationsCallback {
+    override fun createLiveNotification(
+        payload: CustomerIOParsedPushPayload,
+        context: Context,
+    ): Notification? = null
+}
+`;
+
+let projectRoot: string;
+let warn: jest.SpyInstance;
+
+const resolve = (
+  input:
+    | { customType?: string; customRenderer?: LiveNotificationCustomRenderer }
+    | undefined,
+  silent = false
+) =>
+  resolveCustomLiveNotificationRenderer({
+    liveNotifications: input?.customType ? { customType: input.customType } : undefined,
+    buildOptions: input?.customRenderer
+      ? { customRenderer: input.customRenderer }
+      : undefined,
+    projectRoot,
+    silent,
+  });
+
+const writeProjectFile = (relativePath: string, contents = RENDERER_SOURCE): string => {
+  const absolute = path.join(projectRoot, relativePath);
+  fs.mkdirSync(path.dirname(absolute), { recursive: true });
+  fs.writeFileSync(absolute, contents);
+  return absolute;
+};
+
+beforeEach(() => {
+  projectRoot = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'cio-custom-renderer-'))
+  );
+  warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warn.mockRestore();
+  fs.rmSync(projectRoot, { recursive: true, force: true });
+});
+
+describe('resolveCustomLiveNotificationRenderer()', () => {
+  test('resolves a relative path and reads the package from the file', () => {
+    const absolute = writeProjectFile(
+      'android-renderers/RideshareLiveNotification.kt'
+    );
+
+    expect(
+      resolve({
+        customType: 'com.myapp.rideshare',
+        customRenderer: {
+          sourceFile: './android-renderers/RideshareLiveNotification.kt',
+          className: 'RideshareLiveNotificationCallback',
+        },
+      })
+    ).toEqual({
+      sourceFiles: [absolute],
+      packages: ['com.myapp.livenotifications'],
+      className: 'RideshareLiveNotificationCallback',
+      classPackage: 'com.myapp.livenotifications',
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('takes the class package from the file that declares it, not the first file', () => {
+    const helpers = writeProjectFile(
+      'renderers/Helpers.kt',
+      'package com.myapp.helpers\n\nobject Helpers\n'
+    );
+    const renderer = writeProjectFile('renderers/Rideshare.kt');
+
+    expect(
+      resolve({
+        customRenderer: {
+          sourceFile: ['./renderers/Helpers.kt', './renderers/Rideshare.kt'],
+          className: 'RideshareLiveNotificationCallback',
+        },
+      })
+    ).toEqual({
+      sourceFiles: [helpers, renderer],
+      packages: ['com.myapp.helpers', 'com.myapp.livenotifications'],
+      className: 'RideshareLiveNotificationCallback',
+      // The declaring file's package, so the generated import compiles.
+      classPackage: 'com.myapp.livenotifications',
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('warns when customType is set with no renderer to draw it', () => {
+    expect(resolve({ customType: 'com.myapp.rideshare' })).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('customRenderer'),
+      ...[]
+    );
+  });
+
+  test('skips a file that declares no Kotlin package', () => {
+    writeProjectFile('renderers/Rideshare.kt', 'class RideshareLiveNotificationCallback\n');
+
+    expect(
+      resolve({
+        customRenderer: {
+          sourceFile: './renderers/Rideshare.kt',
+          className: 'RideshareLiveNotificationCallback',
+        },
+      })
+    ).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('declares no Kotlin package'),
+      ...[]
+    );
+  });
+
+  test('skips a missing file, a non-Kotlin file, and a missing className', () => {
+    expect(
+      resolve({
+        customRenderer: {
+          sourceFile: './renderers/Missing.kt',
+          className: 'RideshareLiveNotificationCallback',
+        },
+      })
+    ).toBeNull();
+
+    writeProjectFile('renderers/Rideshare.swift', RENDERER_SOURCE);
+    expect(
+      resolve({
+        customRenderer: {
+          sourceFile: './renderers/Rideshare.swift',
+          className: 'RideshareLiveNotificationCallback',
+        },
+      })
+    ).toBeNull();
+
+    writeProjectFile('renderers/Rideshare.kt');
+    expect(
+      resolve({
+        customRenderer: { sourceFile: './renderers/Rideshare.kt', className: '  ' },
+      })
+    ).toBeNull();
+
+    expect(warn).toHaveBeenCalledTimes(3);
+  });
+
+  test('still resolves when the class is not found, warning about the assumed package', () => {
+    writeProjectFile(
+      'renderers/Rideshare.kt',
+      'package com.myapp.livenotifications\n\nclass SomethingElse\n'
+    );
+
+    expect(
+      resolve({
+        customRenderer: {
+          sourceFile: './renderers/Rideshare.kt',
+          className: 'RideshareLiveNotificationCallback',
+        },
+      })
+    ).toMatchObject({ classPackage: 'com.myapp.livenotifications' });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('was not found in any configured'),
+      ...[]
+    );
+  });
+
+  test('silent suppresses warnings but reaches the same verdict', () => {
+    // The copying mod and the code-generating mod both resolve; only one reports.
+    expect(resolve({ customType: 'com.myapp.rideshare' }, true)).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('installAndroidCustomLiveNotificationRenderer()', () => {
+  test('copies each file under the package it declares', () => {
+    writeProjectFile('renderers/Rideshare.kt');
+    writeProjectFile(
+      'renderers/Helpers.kt',
+      'package com.myapp.helpers\n\nobject Helpers\n'
+    );
+    const renderer = resolve({
+      customRenderer: {
+        sourceFile: ['./renderers/Rideshare.kt', './renderers/Helpers.kt'],
+        className: 'RideshareLiveNotificationCallback',
+      },
+    });
+    const androidPath = path.join(projectRoot, 'android');
+
+    expect(installAndroidCustomLiveNotificationRenderer(renderer!, androidPath)).toBe(2);
+
+    const source = path.join(androidPath, 'app/src/main/java');
+    expect(
+      fs.existsSync(
+        path.join(source, 'com/myapp/livenotifications/Rideshare.kt')
+      )
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(source, 'com/myapp/helpers/Helpers.kt'))
+    ).toBe(true);
+  });
+});

--- a/__tests__/utils/liveNotificationCustomWidget.test.ts
+++ b/__tests__/utils/liveNotificationCustomWidget.test.ts
@@ -1,0 +1,303 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  installCustomLiveActivityWidget,
+  resolveCustomLiveActivityWidget,
+} from '../../plugin/src/helpers/utils/liveNotificationCustomWidget';
+import type { LiveNotificationCustomWidget } from '../../plugin/src/types/cio-types';
+
+// These tests run against a real project tree: the resolver's whole job is deciding what is safe to
+// copy into the generated widget target, and that depends on what is actually on disk.
+
+const RESERVED = [
+  'CIOLiveActivityWidgetBundle.swift',
+  'CIOLiveActivityWidget-Info.plist',
+  'Assets.xcassets',
+];
+
+const WIDGET_SOURCE = `import CioLiveActivities_Attributes
+import SwiftUI
+import WidgetKit
+
+struct RideshareLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: CIOCustomAttributes.self) { context in
+            Text(context.state.data["status"] ?? "")
+        } dynamicIsland: { _ in DynamicIsland {} }
+    }
+}
+`;
+
+let projectRoot: string;
+let warn: jest.SpyInstance;
+
+/**
+ * Splits the test's combined shape into the two config surfaces the resolver now reads:
+ * `customType` is SDK config, `customWidget` is a build-time option.
+ */
+const resolve = (
+  input:
+    | { customType?: string; customWidget?: LiveNotificationCustomWidget }
+    | undefined,
+  autoInitializes = true
+) =>
+  resolveCustomLiveActivityWidget({
+    liveNotifications: input?.customType ? { customType: input.customType } : undefined,
+    buildOptions: input?.customWidget ? { customWidget: input.customWidget } : undefined,
+    autoInitializes,
+    projectRoot,
+    reservedFilenames: RESERVED,
+  });
+
+const writeProjectFile = (relativePath: string, contents = WIDGET_SOURCE): string => {
+  const absolute = path.join(projectRoot, relativePath);
+  fs.mkdirSync(path.dirname(absolute), { recursive: true });
+  fs.writeFileSync(absolute, contents);
+  return absolute;
+};
+
+beforeEach(() => {
+  projectRoot = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'cio-custom-widget-'))
+  );
+  warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warn.mockRestore();
+  fs.rmSync(projectRoot, { recursive: true, force: true });
+});
+
+describe('resolveCustomLiveActivityWidget()', () => {
+  test('resolves a relative path against the project root', () => {
+    const absolute = writeProjectFile('ios-widgets/RideshareLiveActivity.swift');
+
+    expect(
+      resolve({
+        customType: 'com.myapp.rideshare',
+        customWidget: {
+          sourceFile: './ios-widgets/RideshareLiveActivity.swift',
+          structName: 'RideshareLiveActivity',
+        },
+      })
+    ).toEqual({
+      sourceFiles: [absolute],
+      filenames: ['RideshareLiveActivity.swift'],
+      structName: 'RideshareLiveActivity',
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('accepts an absolute path and several files', () => {
+    const widget = writeProjectFile('widgets/RideshareLiveActivity.swift');
+    const views = writeProjectFile('widgets/RideshareViews.swift', 'struct RideshareViews {}');
+
+    expect(
+      resolve({
+        customType: 'com.myapp.rideshare',
+        customWidget: {
+          sourceFile: [widget, './widgets/RideshareViews.swift'],
+          structName: 'RideshareLiveActivity',
+        },
+      })
+    ).toEqual({
+      sourceFiles: [widget, views],
+      filenames: ['RideshareLiveActivity.swift', 'RideshareViews.swift'],
+      structName: 'RideshareLiveActivity',
+    });
+  });
+
+  test('returns nothing when no custom widget is configured', () => {
+    expect(resolve({})).toBeNull();
+    expect(resolve(undefined)).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('warns when a custom type has no widget to render it', () => {
+    expect(resolve({ customType: 'com.myapp.rideshare' })).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('customType "com.myapp.rideshare" is set without')
+    );
+  });
+
+  // Legitimate when the app registers the identifier from JavaScript at initialize, a mistake
+  // otherwise — the widget still compiles either way, so this only warns.
+  test('warns but still resolves when the custom type is missing', () => {
+    writeProjectFile('ios-widgets/RideshareLiveActivity.swift');
+
+    expect(
+      resolve({
+        customWidget: {
+          sourceFile: './ios-widgets/RideshareLiveActivity.swift',
+          structName: 'RideshareLiveActivity',
+        },
+      })
+    ).not.toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('config.liveNotifications.customType is not set')
+    );
+  });
+
+  test('skips a missing file rather than failing prebuild', () => {
+    expect(
+      resolve({
+        customType: 'com.myapp.rideshare',
+        customWidget: {
+          sourceFile: './ios-widgets/Missing.swift',
+          structName: 'RideshareLiveActivity',
+        },
+      })
+    ).toBeNull();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('was not found at'));
+  });
+
+  test('skips a path that is not a .swift file', () => {
+    writeProjectFile('ios-widgets/RideshareLiveActivity.m');
+
+    expect(
+      resolve({
+        customType: 'com.myapp.rideshare',
+        customWidget: {
+          sourceFile: './ios-widgets/RideshareLiveActivity.m',
+          structName: 'RideshareLiveActivity',
+        },
+      })
+    ).toBeNull();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('is not a .swift file'));
+  });
+
+  test('skips when structName is missing, since the bundle entry cannot be inferred', () => {
+    writeProjectFile('ios-widgets/RideshareLiveActivity.swift');
+
+    expect(
+      resolve({
+        customType: 'com.myapp.rideshare',
+        customWidget: {
+          sourceFile: './ios-widgets/RideshareLiveActivity.swift',
+          structName: '  ',
+        },
+      })
+    ).toBeNull();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('structName is required'));
+  });
+
+  // Everything is flattened into the widget directory, so two files can't share a name — and none of
+  // them may shadow a file the plugin itself writes there.
+  test('refuses two sources with the same file name', () => {
+    writeProjectFile('a/RideshareViews.swift');
+    writeProjectFile('b/RideshareViews.swift');
+
+    expect(
+      resolve({
+        customType: 'com.myapp.rideshare',
+        customWidget: {
+          sourceFile: ['./a/RideshareViews.swift', './b/RideshareViews.swift'],
+          structName: 'RideshareViews',
+        },
+      })
+    ).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('already copied from another sourceFile entry')
+    );
+  });
+
+  test.each(RESERVED.filter((filename) => filename.endsWith('.swift')))(
+    'refuses a source that would shadow %s',
+    (reserved) => {
+      writeProjectFile(`ios-widgets/${reserved}`);
+
+      expect(
+        resolve({
+          customType: 'com.myapp.rideshare',
+          customWidget: {
+            sourceFile: `./ios-widgets/${reserved}`,
+            structName: 'RideshareLiveActivity',
+          },
+        })
+      ).toBeNull();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('generated by the plugin'));
+    }
+  );
+
+  test('refuses a name that only differs in case, which is the same file on APFS', () => {
+    writeProjectFile('ios-widgets/cioliveactivitywidgetbundle.swift');
+
+    expect(
+      resolve({
+        customType: 'com.myapp.rideshare',
+        customWidget: {
+          sourceFile: './ios-widgets/cioliveactivitywidgetbundle.swift',
+          structName: 'RideshareLiveActivity',
+        },
+      })
+    ).toBeNull();
+  });
+
+  // A struct name that matches nothing fails at the Xcode build ("cannot find … in scope"), so it is
+  // worth surfacing at prebuild — but only as a warning, since the check is textual.
+  test('warns when structName is not declared in the sources, and still resolves', () => {
+    writeProjectFile('ios-widgets/RideshareLiveActivity.swift');
+
+    expect(
+      resolve({
+        customType: 'com.myapp.rideshare',
+        customWidget: {
+          sourceFile: './ios-widgets/RideshareLiveActivity.swift',
+          structName: 'TypoedName',
+        },
+      })
+    ).not.toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('structName "TypoedName" was not found')
+    );
+  });
+
+  test('accepts a struct declared with modifiers', () => {
+    writeProjectFile(
+      'ios-widgets/RideshareLiveActivity.swift',
+      '@available(iOS 16.2, *)\npublic struct RideshareLiveActivity: Widget {}\n'
+    );
+
+    expect(
+      resolve({
+        customType: 'com.myapp.rideshare',
+        customWidget: {
+          sourceFile: './ios-widgets/RideshareLiveActivity.swift',
+          structName: 'RideshareLiveActivity',
+        },
+      })
+    ).not.toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('installCustomLiveActivityWidget()', () => {
+  test('copies every source into the widget directory and reports the names to register', () => {
+    writeProjectFile('ios-widgets/RideshareLiveActivity.swift');
+    writeProjectFile('ios-widgets/RideshareViews.swift', 'struct RideshareViews {}');
+    const resolved = resolve({
+      customType: 'com.myapp.rideshare',
+      customWidget: {
+        sourceFile: [
+          './ios-widgets/RideshareLiveActivity.swift',
+          './ios-widgets/RideshareViews.swift',
+        ],
+        structName: 'RideshareLiveActivity',
+      },
+    });
+
+    const widgetPath = path.join(projectRoot, 'ios', 'CIOLiveActivityWidget');
+    fs.mkdirSync(widgetPath, { recursive: true });
+
+    expect(installCustomLiveActivityWidget(resolved!, widgetPath)).toEqual([
+      'RideshareLiveActivity.swift',
+      'RideshareViews.swift',
+    ]);
+    expect(fs.readFileSync(path.join(widgetPath, 'RideshareLiveActivity.swift'), 'utf8')).toEqual(
+      WIDGET_SOURCE
+    );
+    expect(fs.existsSync(path.join(widgetPath, 'RideshareViews.swift'))).toBe(true);
+  });
+});

--- a/__tests__/utils/patchLiveNotificationCode.test.ts
+++ b/__tests__/utils/patchLiveNotificationCode.test.ts
@@ -1,0 +1,528 @@
+import { PLATFORM } from '../../plugin/src/helpers/constants/common';
+import {
+  ALL_LIVE_NOTIFICATION_TYPES,
+  generateWidgetBundleSwift,
+  isRemoteLogo,
+  patchLiveNotificationPlaceholders,
+  resolveCustomLiveNotificationType,
+  resolveLiveNotificationTypes,
+  validateLiveNotificationBranding,
+} from '../../plugin/src/helpers/utils/patchLiveNotificationCode';
+import { isLiveNotificationsEnabled } from '../../plugin/src/helpers/utils/liveNotificationsEnabled';
+import { LIVE_NOTIFICATION_TYPES } from '../../plugin/src/types/cio-types';
+
+const SEGMENTS = LIVE_NOTIFICATION_TYPES.segments;
+const COUNTDOWN = LIVE_NOTIFICATION_TYPES.countdownTimer;
+
+const IOS_TEMPLATE = `import CioDataPipelines
+{{LIVE_NOTIFICATION_MODULE_IMPORT}}
+
+class CustomerIOSDKInitializer {
+    static func initialize() {
+        let builder = SDKConfigBuilder(cdpApiKey: "key")
+
+        {{LIVE_NOTIFICATION_MODULE_INIT}}
+        CustomerIO.initialize(withConfig: builder.build())
+    }
+}
+`;
+
+const ANDROID_TEMPLATE = `package io.customer.sdk.expo
+
+import io.customer.messagingpush.ModuleMessagingPushFCM
+{{LIVE_NOTIFICATION_MODULE_IMPORT}}
+
+object CustomerIOSDKInitializer {
+    fun initialize(application: Application) {
+        addCustomerIOModule(
+            ModuleMessagingPushFCM(
+                MessagingPushModuleConfig.Builder()
+                    {{LIVE_NOTIFICATION_MODULE_INIT}}
+                    .build()
+            )
+        )
+    }
+}
+`;
+
+describe('Live Notifications config', () => {
+  describe('resolveLiveNotificationTypes()', () => {
+    test('returns every built-in type when none are listed', () => {
+      expect(resolveLiveNotificationTypes(undefined)).toEqual(
+        ALL_LIVE_NOTIFICATION_TYPES
+      );
+    });
+
+    test('keeps only the recognized identifiers, in order', () => {
+      expect(resolveLiveNotificationTypes([COUNTDOWN, SEGMENTS])).toEqual([
+        COUNTDOWN,
+        SEGMENTS,
+      ]);
+    });
+
+    test('de-duplicates repeated identifiers', () => {
+      expect(resolveLiveNotificationTypes([SEGMENTS, SEGMENTS])).toEqual([
+        SEGMENTS,
+      ]);
+    });
+
+    // A template shipped by a newer native SDK must not turn into a Swift/Kotlin symbol that
+    // doesn't exist in this plugin build — that would be a compile error, not a soft failure.
+    test('ignores an unknown identifier with a warning and keeps the known ones', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      expect(resolveLiveNotificationTypes(['io.example.unknown', SEGMENTS])).toEqual([
+        SEGMENTS,
+      ]);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('io.example.unknown')
+      );
+
+      warn.mockRestore();
+    });
+
+    test('an entirely unknown list resolves to nothing', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      expect(resolveLiveNotificationTypes(['io.example.unknown'])).toEqual([]);
+      warn.mockRestore();
+    });
+
+    test('an explicitly empty list resolves to nothing', () => {
+      expect(resolveLiveNotificationTypes([])).toEqual([]);
+    });
+  });
+
+  describe('resolveCustomLiveNotificationType()', () => {
+    test('keeps the app identifier, trimmed', () => {
+      expect(resolveCustomLiveNotificationType('  com.myapp.rideshare ')).toBe(
+        'com.myapp.rideshare'
+      );
+    });
+
+    test.each([undefined, '', '   '])('treats %p as unconfigured', (value) => {
+      expect(resolveCustomLiveNotificationType(value)).toBeUndefined();
+    });
+
+    // Registering CIOCustomAttributes under a built-in identifier would make every event for that
+    // template resolve to whichever attributes type was registered first.
+    test('refuses a built-in identifier with a warning', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      expect(resolveCustomLiveNotificationType(SEGMENTS)).toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(SEGMENTS));
+
+      warn.mockRestore();
+    });
+  });
+
+  describe('isLiveNotificationsEnabled()', () => {
+    const cdpApiKey = 'key';
+
+    test('auto initialization: config presence is enough, no enabled flag', () => {
+      expect(
+        isLiveNotificationsEnabled(undefined, {
+          cdpApiKey,
+          liveNotifications: { types: [SEGMENTS] },
+        })
+      ).toBe(true);
+    });
+
+    test('auto initialization: a config without types still enables every built-in', () => {
+      expect(
+        isLiveNotificationsEnabled(undefined, {
+          cdpApiKey,
+          liveNotifications: {},
+        })
+      ).toBe(true);
+    });
+
+    test('JavaScript initialization: enabled flag with no SDK config', () => {
+      expect(isLiveNotificationsEnabled({ enabled: true }, undefined)).toBe(true);
+    });
+
+    test('off when neither is set', () => {
+      expect(isLiveNotificationsEnabled(undefined, { cdpApiKey })).toBe(false);
+      expect(isLiveNotificationsEnabled({}, { cdpApiKey })).toBe(false);
+    });
+
+    test('off when every configured type is unrecognized', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      expect(
+        isLiveNotificationsEnabled(undefined, {
+          cdpApiKey,
+          liveNotifications: { types: ['io.example.unknown'] },
+        })
+      ).toBe(false);
+      warn.mockRestore();
+    });
+
+    // A custom template needs the same native artifacts as a built-in one, so either half of the
+    // custom config turns the setup on — the missing half is then reported while generating.
+    test('a custom type alone is enough, with no built-in types', () => {
+      expect(
+        isLiveNotificationsEnabled(undefined, {
+          cdpApiKey,
+          liveNotifications: { types: [], customType: 'com.myapp.rideshare' },
+        })
+      ).toBe(true);
+    });
+
+    test('a custom type alone is enough, with no built-in types', () => {
+      expect(
+        isLiveNotificationsEnabled(undefined, {
+          cdpApiKey,
+          liveNotifications: { types: [], customType: 'com.myapp.rideshare' },
+        })
+      ).toBe(true);
+    });
+
+    test('a custom widget alone does not enable it — it is a build-time option', () => {
+      // `customWidget` says how to render, never whether the feature is on. A
+      // JavaScript-initialized app pairs it with `enabled`; an auto-initialized one with
+      // `config.liveNotifications.customType`.
+      expect(
+        isLiveNotificationsEnabled(
+          {
+            customWidget: {
+              sourceFile: './ios-widgets/RideshareLiveActivity.swift',
+              structName: 'RideshareLiveActivity',
+            },
+          },
+          undefined
+        )
+      ).toBe(false);
+    });
+
+    test('off when the custom type is blank and no built-in type is listed', () => {
+      expect(
+        isLiveNotificationsEnabled(undefined, {
+          cdpApiKey,
+          liveNotifications: { types: [], customType: '   ' },
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('isRemoteLogo()', () => {
+    test.each([
+      ['https://cdn.example.com/logo.png', true],
+      ['http://example.com/logo.png', true],
+      ['./assets/brand-logo.png', false],
+      ['assets/brand-logo.png', false],
+    ])('%s -> %s', (logo, expected) => {
+      expect(isRemoteLogo(logo)).toBe(expected);
+    });
+  });
+
+  describe('validateLiveNotificationBranding()', () => {
+    test('accepts valid hex colors', () => {
+      expect(() =>
+        validateLiveNotificationBranding({
+          backgroundColorHex: '#101010',
+          textColorHex: '#FFFFFF',
+          accentColorHex: '#00a0df',
+        })
+      ).not.toThrow();
+    });
+
+    // Caught at prebuild so it can't become a Color.parseColor that throws on device.
+    test.each(['00A0DF', '#FFF', '#GGGGGG', 'blue'])(
+      'rejects %s at prebuild',
+      (color) => {
+        expect(() =>
+          validateLiveNotificationBranding({ accentColorHex: color })
+        ).toThrow(/accentColorHex/);
+      }
+    );
+  });
+
+  describe('patchLiveNotificationPlaceholders() - iOS', () => {
+    test('registers each enabled type behind the 16.2 availability guard', () => {
+      const result = patchLiveNotificationPlaceholders(
+        IOS_TEMPLATE,
+        PLATFORM.IOS,
+        { types: [SEGMENTS, COUNTDOWN] }
+      );
+
+      expect(result).toContain('import CioLiveActivities');
+      expect(result).toContain('if #available(iOS 16.2, *)');
+      expect(result).toContain('builder.addModule(LiveActivitiesModule(config:');
+      expect(result).toContain('.register(CIOSegmentsAttributes.self)');
+      expect(result).toContain('.register(CIOCountdownTimerAttributes.self)');
+      // Registration must precede initialize, or push-to-start never registers a token.
+      expect(result.indexOf('addModule')).toBeLessThan(
+        result.indexOf('CustomerIO.initialize')
+      );
+    });
+
+    test('registers only the listed type', () => {
+      const result = patchLiveNotificationPlaceholders(
+        IOS_TEMPLATE,
+        PLATFORM.IOS,
+        { types: [COUNTDOWN] }
+      );
+
+      expect(result).toContain('.register(CIOCountdownTimerAttributes.self)');
+      expect(result).not.toContain('CIOSegmentsAttributes');
+    });
+
+    test('leaves no placeholders behind when unconfigured', () => {
+      const result = patchLiveNotificationPlaceholders(
+        IOS_TEMPLATE,
+        PLATFORM.IOS,
+        undefined
+      );
+
+      expect(result).not.toContain('{{LIVE_NOTIFICATION');
+      expect(result).not.toContain('LiveActivitiesModule');
+    });
+
+    // On the auto-initialization path this generated code *is* the runtime registration, so without
+    // it a custom activity would never get a push-to-start token.
+    test('registers the SDK attributes type under the app custom identifier', () => {
+      const result = patchLiveNotificationPlaceholders(IOS_TEMPLATE, PLATFORM.IOS, {
+        types: [SEGMENTS],
+        customType: 'com.myapp.rideshare',
+      });
+
+      expect(result).toContain('.register(CIOSegmentsAttributes.self)');
+      expect(result).toContain(
+        '.register(CIOCustomAttributes.self, identifier: "com.myapp.rideshare")'
+      );
+      expect(result.indexOf('addModule')).toBeLessThan(
+        result.indexOf('CustomerIO.initialize')
+      );
+    });
+
+    test('registers a custom type on its own, with no built-in types enabled', () => {
+      const result = patchLiveNotificationPlaceholders(IOS_TEMPLATE, PLATFORM.IOS, {
+        types: [],
+        customType: 'com.myapp.rideshare',
+      });
+
+      expect(result).toContain('if #available(iOS 16.2, *)');
+      expect(result).toContain(
+        '.register(CIOCustomAttributes.self, identifier: "com.myapp.rideshare")'
+      );
+      expect(result).not.toContain('CIOSegmentsAttributes');
+      expect(result).not.toContain('{{LIVE_NOTIFICATION');
+    });
+  });
+
+  describe('patchLiveNotificationPlaceholders() - Android', () => {
+    test('enables each type on the push module config builder', () => {
+      const result = patchLiveNotificationPlaceholders(
+        ANDROID_TEMPLATE,
+        PLATFORM.ANDROID,
+        { types: [SEGMENTS, COUNTDOWN] }
+      );
+
+      expect(result).toContain(
+        'import io.customer.messagingpush.livenotification.LiveNotificationType'
+      );
+      expect(result).toContain('.enableLiveNotificationTypes(');
+      expect(result).toContain('LiveNotificationType.SEGMENTS,');
+      expect(result).toContain('LiveNotificationType.COUNTDOWN_TIMER,');
+      expect(result).toContain('.build()');
+    });
+
+    test('applies branding with a bundled drawable resolved at runtime', () => {
+      const result = patchLiveNotificationPlaceholders(
+        ANDROID_TEMPLATE,
+        PLATFORM.ANDROID,
+        { types: [SEGMENTS] },
+        {
+          companyName: 'Acme',
+          logo: './assets/brand-logo.png',
+          accentColorHex: '#00A0DF',
+        }
+      );
+
+      expect(result).toContain('.setLiveNotificationBranding(');
+      expect(result).toContain('companyName = "Acme"');
+      expect(result).toContain('Color.parseColor("#00A0DF")');
+      expect(result).toContain('getIdentifier("cio_live_notification_logo"');
+      expect(result).toContain('LiveNotificationAsset::Drawable');
+    });
+
+    test('a remote logo becomes a RemoteUrl asset', () => {
+      const result = patchLiveNotificationPlaceholders(
+        ANDROID_TEMPLATE,
+        PLATFORM.ANDROID,
+        { types: [SEGMENTS] },
+        { logo: 'https://cdn.example.com/logo.png' }
+      );
+
+      expect(result).toContain(
+        'LiveNotificationAsset.RemoteUrl("https://cdn.example.com/logo.png")'
+      );
+      expect(result).not.toContain('getIdentifier(');
+    });
+
+    test('omits branding entirely when none is configured', () => {
+      const result = patchLiveNotificationPlaceholders(
+        ANDROID_TEMPLATE,
+        PLATFORM.ANDROID,
+        { types: [SEGMENTS] }
+      );
+
+      expect(result).not.toContain('setLiveNotificationBranding');
+      expect(result).not.toContain('LiveNotificationBranding');
+    });
+
+    test('allowlists a custom type alongside the built-in ones', () => {
+      const result = patchLiveNotificationPlaceholders(
+        ANDROID_TEMPLATE,
+        PLATFORM.ANDROID,
+        { types: [SEGMENTS], customType: 'com.myapp.rideshare' }
+      );
+
+      expect(result).toContain('.enableLiveNotificationTypes(');
+      expect(result).toContain(
+        '.enableCustomLiveNotificationTypes("com.myapp.rideshare")'
+      );
+    });
+
+    // On this path the generated initializer builds the push config directly, bypassing the React
+    // Native wrapper — so the callback has to be set here or the custom type renders nothing.
+    test('registers the app render callback and imports it', () => {
+      const result = patchLiveNotificationPlaceholders(
+        ANDROID_TEMPLATE,
+        PLATFORM.ANDROID,
+        { types: [SEGMENTS], customType: 'com.myapp.rideshare' },
+        undefined,
+        {
+          className: 'RideshareLiveNotificationCallback',
+          classPackage: 'com.myapp.livenotifications',
+        }
+      );
+
+      expect(result).toContain(
+        '.setLiveNotificationCallback(RideshareLiveNotificationCallback())'
+      );
+      expect(result).toContain(
+        'import com.myapp.livenotifications.RideshareLiveNotificationCallback'
+      );
+    });
+
+    test('omits the callback when no renderer is configured', () => {
+      const result = patchLiveNotificationPlaceholders(
+        ANDROID_TEMPLATE,
+        PLATFORM.ANDROID,
+        { types: [SEGMENTS], customType: 'com.myapp.rideshare' }
+      );
+
+      expect(result).not.toContain('.setLiveNotificationCallback(');
+    });
+
+    // The enum overload is what needs the import; a custom type is passed as a plain string, so an
+    // unused import would be left behind.
+    test('a custom type alone omits the built-in enum call and its import', () => {
+      const result = patchLiveNotificationPlaceholders(
+        ANDROID_TEMPLATE,
+        PLATFORM.ANDROID,
+        { types: [], customType: 'com.myapp.rideshare' }
+      );
+
+      expect(result).toContain(
+        '.enableCustomLiveNotificationTypes("com.myapp.rideshare")'
+      );
+      expect(result).not.toContain('.enableLiveNotificationTypes(');
+      expect(result).not.toContain(
+        'import io.customer.messagingpush.livenotification.LiveNotificationType'
+      );
+      // No import to add means the placeholder's whole line goes, not just its contents.
+      expect(result).not.toContain('\n\n\n');
+      expect(result).not.toContain('{{LIVE_NOTIFICATION');
+    });
+
+    // Apps that don't use the feature must get exactly the output they got before it existed.
+    test('collapses the builder chain back to one line when unconfigured', () => {
+      const result = patchLiveNotificationPlaceholders(
+        ANDROID_TEMPLATE,
+        PLATFORM.ANDROID,
+        undefined
+      );
+
+      expect(result).not.toContain('{{LIVE_NOTIFICATION');
+      expect(result).toContain('MessagingPushModuleConfig.Builder().build()');
+    });
+  });
+
+  describe('generateWidgetBundleSwift()', () => {
+    test('renders one widget per enabled type', () => {
+      const swift = generateWidgetBundleSwift([SEGMENTS, COUNTDOWN], undefined);
+
+      expect(swift).toContain('struct CIOLiveActivityWidgetBundle: WidgetBundle');
+      expect(swift).toContain('CIOSegmentsLiveActivity()');
+      expect(swift).toContain('CIOCountdownTimerLiveActivity()');
+      // No branding configured, so no color helper is emitted.
+      expect(swift).not.toContain('init(hex:');
+    });
+
+    test('compiles branding into each widget', () => {
+      const swift = generateWidgetBundleSwift([SEGMENTS, COUNTDOWN], {
+        logo: './assets/brand-logo.png',
+        backgroundColorHex: '#101010',
+        textColorHex: '#FFFFFF',
+        accentColorHex: '#00A0DF',
+      });
+
+      expect(swift).toContain('logo: Image("cio_live_notification_logo")');
+      expect(swift).toContain('background: Color(hex: 0x101010)');
+      expect(swift).toContain('textColor: Color(hex: 0xFFFFFF)');
+      // Only Segments has a progress bar to tint.
+      expect(swift).toContain('progressCompleteStyle: Color(hex: 0x00A0DF)');
+      expect(
+        swift.match(/progressCompleteStyle/g)
+      ).toHaveLength(1);
+      expect(swift).toContain('init(hex: UInt32)');
+    });
+
+    test('omits the logo for a remote URL, which a compiled widget cannot resolve', () => {
+      const swift = generateWidgetBundleSwift([SEGMENTS], {
+        logo: 'https://cdn.example.com/logo.png',
+        accentColorHex: '#00A0DF',
+      });
+
+      expect(swift).not.toContain('Image(');
+      expect(swift).toContain('progressCompleteStyle: Color(hex: 0x00A0DF)');
+    });
+
+    // Branding is compiled into the SDK's templates; a view the app wrote styles itself, so its
+    // entry must stay a bare initializer or the widget won't compile.
+    test("adds the app's widget struct with no branding argument", () => {
+      const swift = generateWidgetBundleSwift(
+        [SEGMENTS],
+        { accentColorHex: '#00A0DF' },
+        'RideshareLiveActivity'
+      );
+
+      expect(swift).toContain('CIOSegmentsLiveActivity(branding: CIOSegmentsBranding(');
+      expect(swift).toContain('RideshareLiveActivity()');
+      expect(swift).not.toContain('RideshareLiveActivity(branding');
+    });
+
+    test('renders a custom widget on its own, with no built-in templates', () => {
+      const swift = generateWidgetBundleSwift([], undefined, 'RideshareLiveActivity');
+
+      expect(swift).toContain('RideshareLiveActivity()');
+      expect(swift).not.toContain('CIOSegmentsLiveActivity');
+      expect(swift).not.toContain('CIOCountdownTimerLiveActivity');
+    });
+
+    // A WidgetBundle body has to return at least one widget, so an unrenderable config can't be
+    // emitted as an empty bundle — it wouldn't compile.
+    test('falls back to the built-in templates when nothing resolved', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const swift = generateWidgetBundleSwift([], undefined, undefined);
+
+      expect(swift).toContain('CIOSegmentsLiveActivity()');
+      expect(swift).toContain('CIOCountdownTimerLiveActivity()');
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('falling back'));
+
+      warn.mockRestore();
+    });
+  });
+});

--- a/api-extractor-output/customerio-expo-plugin.api.md
+++ b/api-extractor-output/customerio-expo-plugin.api.md
@@ -5,6 +5,14 @@
 ```ts
 
 // @public
+export type CustomerIOPluginLiveNotificationsOptions = {
+    enabled?: boolean;
+    customWidget?: LiveNotificationCustomWidget;
+    customRenderer?: LiveNotificationCustomRenderer;
+    branding?: LiveNotificationBranding;
+};
+
+// @public
 export type CustomerIOPluginLocationOptions = {
     enabled?: boolean;
 };
@@ -15,6 +23,7 @@ export type CustomerIOPluginOptions = {
     android: CustomerIOPluginOptionsAndroid;
     ios: CustomerIOPluginOptionsIOS;
     location?: CustomerIOPluginLocationOptions;
+    liveNotifications?: CustomerIOPluginLiveNotificationsOptions;
 };
 
 // @public
@@ -73,6 +82,39 @@ export type CustomerIOPluginPushNotificationOptions = {
 };
 
 // @public
+export const LIVE_NOTIFICATION_TYPES: {
+    readonly segments: "io.customer.livenotifications.segments";
+    readonly countdownTimer: "io.customer.livenotifications.countdowntimer";
+};
+
+// @public
+export type LiveNotificationBranding = {
+    companyName?: string;
+    logo?: string;
+    backgroundColorHex?: string;
+    textColorHex?: string;
+    accentColorHex?: string;
+};
+
+// @public
+export type LiveNotificationCustomRenderer = {
+    sourceFile: string | string[];
+    className: string;
+};
+
+// @public
+export type LiveNotificationCustomWidget = {
+    sourceFile: string | string[];
+    structName: string;
+};
+
+// @public
+export type LiveNotificationsSDKConfig = {
+    types?: string[];
+    customType?: string;
+};
+
+// @public
 export type LocationTrackingMode = 'OFF' | 'MANUAL' | 'ON_APP_START';
 
 // @public
@@ -88,6 +130,7 @@ export type NativeSDKConfig = {
     location?: {
         trackingMode?: LocationTrackingMode;
     };
+    liveNotifications?: LiveNotificationsSDKConfig;
 };
 
 // @public

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@babel/cli": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.29.7.tgz",
-      "integrity": "sha512-/75HwRbAYPqXv/Ax1h7Fg3IZfXgdU98jnA8H93/m/QBaPV3Hp5ICoLqzGYye1yHBCgpmXvtqgSUN8oOKX5tojQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.28.6.tgz",
+      "integrity": "sha512-6EUNcuBbNkj08Oj4gAZ+BUU8yLCgKzgVX4gaTh09Ya2C8ICM4P+G30g4m3akRxSYAp3A/gnWchrNst7px4/nUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -76,9 +76,9 @@
       "license": "MIT"
     },
     "node_modules/@babel/cli/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -152,29 +152,29 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
-      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helpers": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -191,12 +191,12 @@
       }
     },
     "node_modules/@babel/core/node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -214,13 +214,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -230,26 +230,26 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
-      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.27.3"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
-      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -268,18 +268,18 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
-      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
+      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
-        "@babel/helper-member-expression-to-functions": "^7.29.7",
-        "@babel/helper-optimise-call-expression": "^7.29.7",
-        "@babel/helper-replace-supers": "^7.29.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/traverse": "^7.28.6",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -300,13 +300,13 @@
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.29.7.tgz",
-      "integrity": "sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
+      "integrity": "sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-annotate-as-pure": "^7.27.3",
         "regexpu-core": "^6.3.1",
         "semver": "^6.3.1"
       },
@@ -358,50 +358,50 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
-      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
-      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
-      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
-      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -411,22 +411,22 @@
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
-      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
-      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -434,15 +434,15 @@
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.29.7.tgz",
-      "integrity": "sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
+      "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
-        "@babel/helper-wrap-function": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-wrap-function": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -452,15 +452,15 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
-      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.29.7",
-        "@babel/helper-optimise-call-expression": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -470,69 +470,69 @@
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
-      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
-      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
-      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
-      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.29.7.tgz",
-      "integrity": "sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
+      "integrity": "sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
-      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -633,12 +633,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -648,14 +648,14 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.29.7.tgz",
-      "integrity": "sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.28.5.tgz",
+      "integrity": "sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -665,13 +665,13 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.29.7.tgz",
-      "integrity": "sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
+      "integrity": "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -681,30 +681,13 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.29.7.tgz",
-      "integrity": "sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
+      "integrity": "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.7.tgz",
-      "integrity": "sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -714,15 +697,15 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.29.7.tgz",
-      "integrity": "sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
+      "integrity": "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
-        "@babel/plugin-transform-optional-chaining": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-transform-optional-chaining": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -732,14 +715,14 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.29.7.tgz",
-      "integrity": "sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.6.tgz",
+      "integrity": "sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -787,15 +770,15 @@
       }
     },
     "node_modules/@babel/plugin-proposal-decorators": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.7.tgz",
-      "integrity": "sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.0.tgz",
+      "integrity": "sha512-CVBVv3VY/XRMxRYq5dwr2DS7/MvqPm23cOCjbwNnVrfOqcWlnefua1uUs0sjdKOGjvPUG633o07uWzJq4oI6dA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/plugin-syntax-decorators": "^7.29.7"
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-syntax-decorators": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -805,13 +788,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-export-default-from": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.29.7.tgz",
-      "integrity": "sha512-p+G5BNXDcy3bOXplhY4HybQ1GxH3i2Tppmdm/3epyRu2VgJJZuUlZ61MqRTg582Q7ZLBdP7fePYvsumSEkMxcQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.27.1.tgz",
+      "integrity": "sha512-hjlsMBl1aJc5lp8MoCDEZCiYzlgdRAShOjAfRw6X+GlpLpUPU7c3XNLsKFZbQk/1cRzBlJ7CXg3xJAJMrFa1Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1001,13 +984,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-decorators": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz",
-      "integrity": "sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.28.6.tgz",
+      "integrity": "sha512-71EYI0ONURHJBL4rSFXnITXqXrrY8q4P0q006DPfN+Rk+ASM+++IBXem/ruokgBZR8YNEWZ8R6B+rCb8VcUTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1030,13 +1013,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-export-default-from": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.29.7.tgz",
-      "integrity": "sha512-foag0BB37ROhdeIX9O8G0jX7hw0UekJc04cHMrYLOnrErsnBKqJGHJ8eDRpoCFZBvEPPygmmtw4qyU97qa4oOw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.28.6.tgz",
+      "integrity": "sha512-Svlx1fjJFnNz0LZeUaybRukSxZI3KkpApUmIRzEdXC5k8ErTOz0OD0kNrICi5Vc3GlpP5ZCeRyRO+mfWTSz+iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1046,13 +1029,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-flow": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.29.7.tgz",
-      "integrity": "sha512-ajMX6QPcyomotqwpzhkYGxcK2i/us0rs1Qo9QvUpa+Fca0FTmqrzKrctoIYLMxcOhGZldGT/BAVkRGTWBiR8gQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.28.6.tgz",
+      "integrity": "sha512-D+OrJumc9McXNEBI/JmFnc/0uCM2/Y3PEBG3gfV3QIYkKv5pvnpzFrl1kYCrcHJP8nOeFB/SHi1IHz29pNGuew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1062,13 +1045,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-assertions": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.29.7.tgz",
-      "integrity": "sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.28.6.tgz",
+      "integrity": "sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1078,13 +1061,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
-      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1120,13 +1103,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
-      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1246,13 +1229,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
-      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1279,13 +1262,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.29.7.tgz",
-      "integrity": "sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
+      "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1295,15 +1278,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.7.tgz",
-      "integrity": "sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
+      "integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-remap-async-to-generator": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-remap-async-to-generator": "^7.27.1",
+        "@babel/traverse": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1313,15 +1296,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-to-generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.29.7.tgz",
-      "integrity": "sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
+      "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-remap-async-to-generator": "^7.29.7"
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-remap-async-to-generator": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1331,13 +1314,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.29.7.tgz",
-      "integrity": "sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
+      "integrity": "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1347,13 +1330,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.29.7.tgz",
-      "integrity": "sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
+      "integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1363,14 +1346,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-properties": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz",
-      "integrity": "sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
+      "integrity": "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1380,14 +1363,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.29.7.tgz",
-      "integrity": "sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.6.tgz",
+      "integrity": "sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1397,18 +1380,18 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.29.7.tgz",
-      "integrity": "sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
+      "integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-globals": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-replace-supers": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-replace-supers": "^7.28.6",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1418,14 +1401,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.29.7.tgz",
-      "integrity": "sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
+      "integrity": "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/template": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/template": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1435,14 +1418,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.29.7.tgz",
-      "integrity": "sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
+      "integrity": "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1452,14 +1435,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.29.7.tgz",
-      "integrity": "sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.28.6.tgz",
+      "integrity": "sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1469,13 +1452,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.29.7.tgz",
-      "integrity": "sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
+      "integrity": "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1485,14 +1468,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.7.tgz",
-      "integrity": "sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.0.tgz",
+      "integrity": "sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1502,13 +1485,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-dynamic-import": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.29.7.tgz",
-      "integrity": "sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
+      "integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1518,14 +1501,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-explicit-resource-management": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.29.7.tgz",
-      "integrity": "sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.6.tgz",
+      "integrity": "sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/plugin-transform-destructuring": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-transform-destructuring": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1535,13 +1518,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.29.7.tgz",
-      "integrity": "sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.6.tgz",
+      "integrity": "sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1551,13 +1534,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-export-namespace-from": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.29.7.tgz",
-      "integrity": "sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
+      "integrity": "sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1567,14 +1550,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-flow-strip-types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.29.7.tgz",
-      "integrity": "sha512-wRHeUjUjCZnMHmiO5bRgjFLcoEh7JyTdByOW11ahhwNa4V0bmeGEaIvt51yq0zQp2yWIpqfxXXPyUP6GFJZHOQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.27.1.tgz",
+      "integrity": "sha512-G5eDKsu50udECw7DL2AcsysXiQyB7Nfg521t2OAJ4tbfTJ27doHLeF/vlI1NZGlLdbb/v+ibvtL1YBQqYOwJGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/plugin-syntax-flow": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/plugin-syntax-flow": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1584,14 +1567,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.29.7.tgz",
-      "integrity": "sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
+      "integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1601,15 +1584,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-function-name": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.29.7.tgz",
-      "integrity": "sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
+      "integrity": "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-compilation-targets": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1619,13 +1602,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-json-strings": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.29.7.tgz",
-      "integrity": "sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.28.6.tgz",
+      "integrity": "sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1635,13 +1618,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-literals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.29.7.tgz",
-      "integrity": "sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
+      "integrity": "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1651,13 +1634,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.29.7.tgz",
-      "integrity": "sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
+      "integrity": "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1667,13 +1650,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.29.7.tgz",
-      "integrity": "sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
+      "integrity": "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1683,14 +1666,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.29.7.tgz",
-      "integrity": "sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
+      "integrity": "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1700,14 +1683,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
-      "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+      "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1717,16 +1700,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
-      "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
+      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1736,14 +1719,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.29.7.tgz",
-      "integrity": "sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
+      "integrity": "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1753,14 +1736,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.7.tgz",
-      "integrity": "sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
+      "integrity": "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1770,13 +1753,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-new-target": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.29.7.tgz",
-      "integrity": "sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
+      "integrity": "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1786,13 +1769,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.29.7.tgz",
-      "integrity": "sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
+      "integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1802,13 +1785,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-numeric-separator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.29.7.tgz",
-      "integrity": "sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
+      "integrity": "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1818,17 +1801,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.29.7.tgz",
-      "integrity": "sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
+      "integrity": "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/plugin-transform-destructuring": "^7.29.7",
-        "@babel/plugin-transform-parameters": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-transform-destructuring": "^7.28.5",
+        "@babel/plugin-transform-parameters": "^7.27.7",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1838,14 +1821,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-super": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.29.7.tgz",
-      "integrity": "sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
+      "integrity": "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-replace-supers": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1855,13 +1838,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-catch-binding": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.29.7.tgz",
-      "integrity": "sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
+      "integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1871,14 +1854,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.29.7.tgz",
-      "integrity": "sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
+      "integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1888,13 +1871,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.29.7.tgz",
-      "integrity": "sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==",
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+      "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1904,14 +1887,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-methods": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.29.7.tgz",
-      "integrity": "sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
+      "integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1921,15 +1904,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-property-in-object": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.29.7.tgz",
-      "integrity": "sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
+      "integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
-        "@babel/helper-create-class-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1939,13 +1922,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-property-literals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.29.7.tgz",
-      "integrity": "sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
+      "integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1955,13 +1938,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-display-name": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.29.7.tgz",
-      "integrity": "sha512-+1wdDMGNb4UPeY3Q4L5yLiYe6TXPXubs4NjrgRFw13hPRLJfEMw2Q5OXkee6/IfdqePIeW4Jjwe3aBh7SdKz4Q==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.28.0.tgz",
+      "integrity": "sha512-D6Eujc2zMxKjfa4Zxl4GHMsmhKKZ9VpcqIchJLvwTxad9zWIYulwYItBovpDOoNLISpcZSXoDJ5gaGbQUDqViA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1971,17 +1954,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.29.7.tgz",
-      "integrity": "sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.28.6.tgz",
+      "integrity": "sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/plugin-syntax-jsx": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-syntax-jsx": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1991,13 +1974,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-development": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.29.7.tgz",
-      "integrity": "sha512-Xfy3UVMF04+ypnFbkhvfqtmvwfe92qwQdbGZVonhE+6v35GzlofmOnA1szaZqzb9xYWr0nl1e5EMmzi0DNON1g==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.27.1.tgz",
+      "integrity": "sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/plugin-transform-react-jsx": "^7.29.7"
+        "@babel/plugin-transform-react-jsx": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2007,13 +1990,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
-      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2023,13 +2006,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
-      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2039,14 +2022,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-pure-annotations": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.29.7.tgz",
-      "integrity": "sha512-H5E+HBgDpr6Q5t+Aj11tL7XkIui1jhbIoArVQnqjgXo5/3YxkN7ZEBcWF4RQlB0T4rrxJQbXS6kiFV6B7XTqUA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.27.1.tgz",
+      "integrity": "sha512-JfuinvDOsD9FVMTHpzA/pBLisxpv1aSf+OIV8lgH3MuWrks19R27e6a6DipIg4aX1Zm9Wpb04p8wljfKrVSnPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2056,13 +2039,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.7.tgz",
-      "integrity": "sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
+      "integrity": "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2072,14 +2055,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-regexp-modifiers": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.29.7.tgz",
-      "integrity": "sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.28.6.tgz",
+      "integrity": "sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2089,13 +2072,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.29.7.tgz",
-      "integrity": "sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
+      "integrity": "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2105,14 +2088,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.29.7.tgz",
-      "integrity": "sha512-xmAscdE/AsqRW7vutbPNoUmu/nF5SrLKPs7aoJgEjo35lLKA/Bc0i2rMv/hr1+Y0o1bQCiVtith3u2vdgRL39Q==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.29.0.tgz",
+      "integrity": "sha512-jlaRT5dJtMaMCV6fAuLbsQMSwz/QkvaHOHOSXRitGGwSpR1blCY4KUKoyP2tYO8vJcqYe8cEj96cqSztv3uF9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
         "babel-plugin-polyfill-corejs2": "^0.4.14",
         "babel-plugin-polyfill-corejs3": "^0.13.0",
         "babel-plugin-polyfill-regenerator": "^0.6.5",
@@ -2136,13 +2119,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.29.7.tgz",
-      "integrity": "sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
+      "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2152,14 +2135,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.7.tgz",
-      "integrity": "sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
+      "integrity": "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2169,13 +2152,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-sticky-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.29.7.tgz",
-      "integrity": "sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
+      "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2185,13 +2168,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.29.7.tgz",
-      "integrity": "sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
+      "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2201,13 +2184,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.29.7.tgz",
-      "integrity": "sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
+      "integrity": "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2217,17 +2200,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
-      "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
+      "integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
-        "@babel/helper-create-class-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
-        "@babel/plugin-syntax-typescript": "^7.29.7"
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2237,13 +2220,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.29.7.tgz",
-      "integrity": "sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
+      "integrity": "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2253,14 +2236,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-property-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.29.7.tgz",
-      "integrity": "sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.28.6.tgz",
+      "integrity": "sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2270,14 +2253,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.29.7.tgz",
-      "integrity": "sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
+      "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2287,14 +2270,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-sets-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.29.7.tgz",
-      "integrity": "sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.28.6.tgz",
+      "integrity": "sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2304,77 +2287,76 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.7.tgz",
-      "integrity": "sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
+      "integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.29.7",
-        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.29.7",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.29.7",
-        "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^7.29.7",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.29.7",
-        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.29.7",
+        "@babel/compat-data": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
+        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
         "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-        "@babel/plugin-syntax-import-assertions": "^7.29.7",
-        "@babel/plugin-syntax-import-attributes": "^7.29.7",
+        "@babel/plugin-syntax-import-assertions": "^7.28.6",
+        "@babel/plugin-syntax-import-attributes": "^7.28.6",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-        "@babel/plugin-transform-arrow-functions": "^7.29.7",
-        "@babel/plugin-transform-async-generator-functions": "^7.29.7",
-        "@babel/plugin-transform-async-to-generator": "^7.29.7",
-        "@babel/plugin-transform-block-scoped-functions": "^7.29.7",
-        "@babel/plugin-transform-block-scoping": "^7.29.7",
-        "@babel/plugin-transform-class-properties": "^7.29.7",
-        "@babel/plugin-transform-class-static-block": "^7.29.7",
-        "@babel/plugin-transform-classes": "^7.29.7",
-        "@babel/plugin-transform-computed-properties": "^7.29.7",
-        "@babel/plugin-transform-destructuring": "^7.29.7",
-        "@babel/plugin-transform-dotall-regex": "^7.29.7",
-        "@babel/plugin-transform-duplicate-keys": "^7.29.7",
-        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.7",
-        "@babel/plugin-transform-dynamic-import": "^7.29.7",
-        "@babel/plugin-transform-explicit-resource-management": "^7.29.7",
-        "@babel/plugin-transform-exponentiation-operator": "^7.29.7",
-        "@babel/plugin-transform-export-namespace-from": "^7.29.7",
-        "@babel/plugin-transform-for-of": "^7.29.7",
-        "@babel/plugin-transform-function-name": "^7.29.7",
-        "@babel/plugin-transform-json-strings": "^7.29.7",
-        "@babel/plugin-transform-literals": "^7.29.7",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.29.7",
-        "@babel/plugin-transform-member-expression-literals": "^7.29.7",
-        "@babel/plugin-transform-modules-amd": "^7.29.7",
-        "@babel/plugin-transform-modules-commonjs": "^7.29.7",
-        "@babel/plugin-transform-modules-systemjs": "^7.29.7",
-        "@babel/plugin-transform-modules-umd": "^7.29.7",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.7",
-        "@babel/plugin-transform-new-target": "^7.29.7",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.29.7",
-        "@babel/plugin-transform-numeric-separator": "^7.29.7",
-        "@babel/plugin-transform-object-rest-spread": "^7.29.7",
-        "@babel/plugin-transform-object-super": "^7.29.7",
-        "@babel/plugin-transform-optional-catch-binding": "^7.29.7",
-        "@babel/plugin-transform-optional-chaining": "^7.29.7",
-        "@babel/plugin-transform-parameters": "^7.29.7",
-        "@babel/plugin-transform-private-methods": "^7.29.7",
-        "@babel/plugin-transform-private-property-in-object": "^7.29.7",
-        "@babel/plugin-transform-property-literals": "^7.29.7",
-        "@babel/plugin-transform-regenerator": "^7.29.7",
-        "@babel/plugin-transform-regexp-modifiers": "^7.29.7",
-        "@babel/plugin-transform-reserved-words": "^7.29.7",
-        "@babel/plugin-transform-shorthand-properties": "^7.29.7",
-        "@babel/plugin-transform-spread": "^7.29.7",
-        "@babel/plugin-transform-sticky-regex": "^7.29.7",
-        "@babel/plugin-transform-template-literals": "^7.29.7",
-        "@babel/plugin-transform-typeof-symbol": "^7.29.7",
-        "@babel/plugin-transform-unicode-escapes": "^7.29.7",
-        "@babel/plugin-transform-unicode-property-regex": "^7.29.7",
-        "@babel/plugin-transform-unicode-regex": "^7.29.7",
-        "@babel/plugin-transform-unicode-sets-regex": "^7.29.7",
+        "@babel/plugin-transform-arrow-functions": "^7.27.1",
+        "@babel/plugin-transform-async-generator-functions": "^7.29.0",
+        "@babel/plugin-transform-async-to-generator": "^7.28.6",
+        "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
+        "@babel/plugin-transform-block-scoping": "^7.28.6",
+        "@babel/plugin-transform-class-properties": "^7.28.6",
+        "@babel/plugin-transform-class-static-block": "^7.28.6",
+        "@babel/plugin-transform-classes": "^7.28.6",
+        "@babel/plugin-transform-computed-properties": "^7.28.6",
+        "@babel/plugin-transform-destructuring": "^7.28.5",
+        "@babel/plugin-transform-dotall-regex": "^7.28.6",
+        "@babel/plugin-transform-duplicate-keys": "^7.27.1",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.0",
+        "@babel/plugin-transform-dynamic-import": "^7.27.1",
+        "@babel/plugin-transform-explicit-resource-management": "^7.28.6",
+        "@babel/plugin-transform-exponentiation-operator": "^7.28.6",
+        "@babel/plugin-transform-export-namespace-from": "^7.27.1",
+        "@babel/plugin-transform-for-of": "^7.27.1",
+        "@babel/plugin-transform-function-name": "^7.27.1",
+        "@babel/plugin-transform-json-strings": "^7.28.6",
+        "@babel/plugin-transform-literals": "^7.27.1",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.28.6",
+        "@babel/plugin-transform-member-expression-literals": "^7.27.1",
+        "@babel/plugin-transform-modules-amd": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.28.6",
+        "@babel/plugin-transform-modules-systemjs": "^7.29.0",
+        "@babel/plugin-transform-modules-umd": "^7.27.1",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.0",
+        "@babel/plugin-transform-new-target": "^7.27.1",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
+        "@babel/plugin-transform-numeric-separator": "^7.28.6",
+        "@babel/plugin-transform-object-rest-spread": "^7.28.6",
+        "@babel/plugin-transform-object-super": "^7.27.1",
+        "@babel/plugin-transform-optional-catch-binding": "^7.28.6",
+        "@babel/plugin-transform-optional-chaining": "^7.28.6",
+        "@babel/plugin-transform-parameters": "^7.27.7",
+        "@babel/plugin-transform-private-methods": "^7.28.6",
+        "@babel/plugin-transform-private-property-in-object": "^7.28.6",
+        "@babel/plugin-transform-property-literals": "^7.27.1",
+        "@babel/plugin-transform-regenerator": "^7.29.0",
+        "@babel/plugin-transform-regexp-modifiers": "^7.28.6",
+        "@babel/plugin-transform-reserved-words": "^7.27.1",
+        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
+        "@babel/plugin-transform-spread": "^7.28.6",
+        "@babel/plugin-transform-sticky-regex": "^7.27.1",
+        "@babel/plugin-transform-template-literals": "^7.27.1",
+        "@babel/plugin-transform-typeof-symbol": "^7.27.1",
+        "@babel/plugin-transform-unicode-escapes": "^7.27.1",
+        "@babel/plugin-transform-unicode-property-regex": "^7.28.6",
+        "@babel/plugin-transform-unicode-regex": "^7.27.1",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
         "@babel/preset-modules": "0.1.6-no-external-plugins",
         "babel-plugin-polyfill-corejs2": "^0.4.15",
         "babel-plugin-polyfill-corejs3": "^0.14.0",
@@ -2414,15 +2396,15 @@
       }
     },
     "node_modules/@babel/preset-flow": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.29.7.tgz",
-      "integrity": "sha512-KYIRV0BuaN68CDdsqFkAD7MU7yipUqQNuNElwATdxaIdpTjhvtY82QvkBJs7zV3Evxj2jFAAZ1iO8nyy0nhjqA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.27.1.tgz",
+      "integrity": "sha512-ez3a2it5Fn6P54W8QkbfIyyIbxlXvcxyWHHvno1Wg0Ej5eiJY5hBb8ExttoIOJJk7V2dZE6prP7iby5q2aQ0Lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "@babel/plugin-transform-flow-strip-types": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-transform-flow-strip-types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2447,18 +2429,18 @@
       }
     },
     "node_modules/@babel/preset-react": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.29.7.tgz",
-      "integrity": "sha512-C+PV1TFUPTmBQGoPBL8j2QmLpZ117YTCwxIZeJOM96GbYMFSc7/pOXU5lVykwnZxyTqQxRsvoRk6f2FktZgGHA==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.28.5.tgz",
+      "integrity": "sha512-Z3J8vhRq7CeLjdC58jLv4lnZ5RKFUJWqH5emvxmv9Hv3BD1T9R/Im713R4MTKwvFaV74ejZ3sM01LyEKk4ugNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "@babel/plugin-transform-react-display-name": "^7.29.7",
-        "@babel/plugin-transform-react-jsx": "^7.29.7",
-        "@babel/plugin-transform-react-jsx-development": "^7.29.7",
-        "@babel/plugin-transform-react-pure-annotations": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-transform-react-display-name": "^7.28.0",
+        "@babel/plugin-transform-react-jsx": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-development": "^7.27.1",
+        "@babel/plugin-transform-react-pure-annotations": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2468,17 +2450,17 @@
       }
     },
     "node_modules/@babel/preset-typescript": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz",
-      "integrity": "sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "@babel/plugin-syntax-jsx": "^7.29.7",
-        "@babel/plugin-transform-modules-commonjs": "^7.29.7",
-        "@babel/plugin-transform-typescript": "^7.29.7"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2488,9 +2470,9 @@
       }
     },
     "node_modules/@babel/register": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.29.7.tgz",
-      "integrity": "sha512-AMGJoWuES861riy6pcB0fphE1YXybtQnBYQMuIyPv6mKLiosfa79BKTnAOyx215c/3RJPJpdQwoHZ3earVH7AA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.28.6.tgz",
+      "integrity": "sha512-pgcbbEl/dWQYb6L6Yew6F94rdwygfuv+vJ/tXfwIOYAfPB6TNWpXUMEtEq3YuTeHRdvMIhvz13bkT9CNaS+wqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2507,47 +2489,36 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/register/node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
-      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template/node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -2556,17 +2527,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -2574,12 +2545,12 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -2588,13 +2559,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2608,9 +2579,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
-      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2672,9 +2643,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2722,9 +2693,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
-      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2734,7 +2705,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.3.0",
+        "js-yaml": "^4.1.1",
         "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
@@ -2770,9 +2741,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2801,9 +2772,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.5",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
-      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2838,39 +2809,37 @@
       }
     },
     "node_modules/@expo/cli": {
-      "version": "57.0.11",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-57.0.11.tgz",
-      "integrity": "sha512-ENXCwRyL8Q9qbabUmm0L6w9kXTmdGotW7eDEEWmUDXLPux+nEzNDqw0MzWQ5K3ZsXS51QmUJZg5yETB+6SnNRg==",
+      "version": "55.0.26",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-55.0.26.tgz",
+      "integrity": "sha512-Ud9gpeGMF5RIL42LXvCw3k3mWK8rf/P2wu+Yrzz9Do1kcFKZeT9Vy2D/xukjdr/Xw+ELba87ThOot17GsPiWjw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@expo/code-signing-certificates": "^0.0.6",
-        "@expo/config": "~57.0.6",
-        "@expo/config-plugins": "~57.0.6",
+        "@expo/config": "~55.0.15",
+        "@expo/config-plugins": "~55.0.8",
         "@expo/devcert": "^1.2.1",
-        "@expo/env": "~2.4.2",
-        "@expo/image-utils": "^0.11.4",
-        "@expo/inline-modules": "^0.1.4",
-        "@expo/json-file": "^11.0.1",
-        "@expo/log-box": "^57.0.2",
-        "@expo/metro": "~56.0.0",
-        "@expo/metro-config": "~57.0.7",
-        "@expo/metro-file-map": "^57.0.1",
-        "@expo/osascript": "^2.7.1",
-        "@expo/package-manager": "^1.13.1",
-        "@expo/plist": "^0.8.1",
-        "@expo/prebuild-config": "^57.0.10",
-        "@expo/require-utils": "^57.0.4",
-        "@expo/router-server": "^57.0.4",
-        "@expo/schema-utils": "^57.0.2",
-        "@expo/spawn-async": "^1.8.0",
-        "@expo/ws-tunnel": "^2.0.0",
-        "@expo/xcpretty": "^4.4.4",
-        "@react-native/dev-middleware": "0.86.2",
+        "@expo/env": "~2.1.1",
+        "@expo/image-utils": "^0.8.13",
+        "@expo/json-file": "^10.0.13",
+        "@expo/log-box": "55.0.11",
+        "@expo/metro": "~55.1.0",
+        "@expo/metro-config": "~55.0.17",
+        "@expo/osascript": "^2.4.2",
+        "@expo/package-manager": "^1.10.4",
+        "@expo/plist": "^0.5.2",
+        "@expo/prebuild-config": "^55.0.16",
+        "@expo/require-utils": "^55.0.4",
+        "@expo/router-server": "^55.0.15",
+        "@expo/schema-utils": "^55.0.3",
+        "@expo/spawn-async": "^1.7.2",
+        "@expo/ws-tunnel": "^1.0.1",
+        "@expo/xcpretty": "^4.4.0",
+        "@react-native/dev-middleware": "0.83.6",
         "accepts": "^1.3.8",
-        "agent-cli-detector": "^0.1.2",
         "arg": "^5.0.2",
+        "better-opn": "~3.0.2",
         "bplist-creator": "0.1.0",
         "bplist-parser": "^0.3.1",
         "chalk": "^4.0.0",
@@ -2879,7 +2848,7 @@
         "connect": "^3.7.0",
         "debug": "^4.3.4",
         "dnssd-advertise": "^1.1.4",
-        "expo-server": "^57.0.1",
+        "expo-server": "^55.0.8",
         "fetch-nodeshim": "^0.4.10",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
@@ -2888,7 +2857,7 @@
         "node-forge": "^1.3.3",
         "npm-package-arg": "^11.0.0",
         "ora": "^3.4.0",
-        "picomatch": "^4.0.4",
+        "picomatch": "^4.0.3",
         "pretty-format": "^29.7.0",
         "progress": "^2.0.3",
         "prompts": "^2.3.2",
@@ -2896,6 +2865,7 @@
         "semver": "^7.6.0",
         "send": "^0.19.0",
         "slugify": "^1.3.4",
+        "source-map-support": "~0.5.21",
         "stacktrace-parser": "^0.1.10",
         "structured-headers": "^0.4.1",
         "terminal-link": "^2.1.1",
@@ -2905,7 +2875,7 @@
         "zod": "^3.25.76"
       },
       "bin": {
-        "expo-internal": "main.js"
+        "expo-internal": "build/bin/cli"
       },
       "peerDependencies": {
         "expo": "*",
@@ -2922,14 +2892,14 @@
       }
     },
     "node_modules/@expo/cli/node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -2938,22 +2908,22 @@
       }
     },
     "node_modules/@expo/cli/node_modules/@expo/config-plugins": {
-      "version": "57.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-57.0.6.tgz",
-      "integrity": "sha512-7CmKrS5Rnu8aSZyNlxH2qzA7Ls1HEa4EQvEVOAkHDKPr1e4Cg/nz7I7dUl09QDTVjMvkKYDH4Th0DuAsgqASaw==",
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.8.tgz",
+      "integrity": "sha512-8WfWTRntTCcowfOS+tHdB0z98gKetTwktg4G5TWkCkXVa8Jt1NUnvzaaU4UHk2vbR2U4N84RyZJFizSwfF6C9g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@expo/config-types": "^57.0.2",
-        "@expo/json-file": "~11.0.1",
-        "@expo/plist": "^0.8.1",
-        "@expo/require-utils": "^57.0.4",
+        "@expo/config-types": "^55.0.5",
+        "@expo/json-file": "~10.0.13",
+        "@expo/plist": "^0.5.2",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.5",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
+        "resolve-from": "^5.0.0",
         "semver": "^7.5.4",
         "slugify": "^1.6.6",
         "xcode": "^3.0.1",
@@ -2961,17 +2931,17 @@
       }
     },
     "node_modules/@expo/cli/node_modules/@expo/config-types": {
-      "version": "57.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-57.0.2.tgz",
-      "integrity": "sha512-ewW08OonrcRIsRKIlFvvcmmafE5zemb1ocu3HkNwtVPyRtj2w42pZCAkMIROYpcVBaPnc3mDT9UZDzwXWC3i6g==",
+      "version": "55.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-55.0.5.tgz",
+      "integrity": "sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/@expo/cli/node_modules/@expo/json-file": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-11.0.1.tgz",
-      "integrity": "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ==",
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.13.tgz",
+      "integrity": "sha512-pX/XjQn7tgNw6zuuV2ikmegmwe/S7uiwhrs2wXrANMkq7ozrA+JcZwgW9Q/8WZgciBzfAhNp5hnackHcrmapQA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2981,9 +2951,9 @@
       }
     },
     "node_modules/@expo/cli/node_modules/@expo/plist": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.8.1.tgz",
-      "integrity": "sha512-3gTReGIUm0oRaMClsAJYxBnVPCl6fVpsl8HS+DTVxDhW4GyVyxg9E/Znm3BvcHtUJ51RJJI14pC1wvrNilCRHw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.5.2.tgz",
+      "integrity": "sha512-o4xdVdBpe4aTl3sPMZ2u3fJH4iG1I768EIRk1xRZP+GaFI93MaR3JvoFibYqxeTmLQ1p1kNEVqylfUjezxx45g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3013,9 +2983,9 @@
       }
     },
     "node_modules/@expo/cli/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "peer": true,
@@ -3053,17 +3023,17 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "57.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-57.0.6.tgz",
-      "integrity": "sha512-VpMJpB/De/fb9bBFVVBiK6Ntg9lt0kAleLH9hcZz85CYRUQ3jVFVA8rNC5f8y4cp2+FiiPNFp62+kEOFI6pDiw==",
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-55.0.15.tgz",
+      "integrity": "sha512-lHc0ELIQ8126jYOMZpLv3WIuvordW98jFg5aT/J1/12n2ycuXu01XLZkJsdw0avO34cusUYb1It+MvY8JiMduA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@expo/config-plugins": "~57.0.6",
-        "@expo/config-types": "^57.0.2",
-        "@expo/json-file": "^11.0.1",
-        "@expo/require-utils": "^57.0.4",
+        "@expo/config-plugins": "~55.0.8",
+        "@expo/config-types": "^55.0.5",
+        "@expo/json-file": "^10.0.13",
+        "@expo/require-utils": "^55.0.4",
         "deepmerge": "^4.3.1",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
@@ -3103,14 +3073,14 @@
       "license": "MIT"
     },
     "node_modules/@expo/config/node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -3119,22 +3089,22 @@
       }
     },
     "node_modules/@expo/config/node_modules/@expo/config-plugins": {
-      "version": "57.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-57.0.6.tgz",
-      "integrity": "sha512-7CmKrS5Rnu8aSZyNlxH2qzA7Ls1HEa4EQvEVOAkHDKPr1e4Cg/nz7I7dUl09QDTVjMvkKYDH4Th0DuAsgqASaw==",
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.8.tgz",
+      "integrity": "sha512-8WfWTRntTCcowfOS+tHdB0z98gKetTwktg4G5TWkCkXVa8Jt1NUnvzaaU4UHk2vbR2U4N84RyZJFizSwfF6C9g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@expo/config-types": "^57.0.2",
-        "@expo/json-file": "~11.0.1",
-        "@expo/plist": "^0.8.1",
-        "@expo/require-utils": "^57.0.4",
+        "@expo/config-types": "^55.0.5",
+        "@expo/json-file": "~10.0.13",
+        "@expo/plist": "^0.5.2",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.5",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
+        "resolve-from": "^5.0.0",
         "semver": "^7.5.4",
         "slugify": "^1.6.6",
         "xcode": "^3.0.1",
@@ -3142,17 +3112,17 @@
       }
     },
     "node_modules/@expo/config/node_modules/@expo/config-types": {
-      "version": "57.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-57.0.2.tgz",
-      "integrity": "sha512-ewW08OonrcRIsRKIlFvvcmmafE5zemb1ocu3HkNwtVPyRtj2w42pZCAkMIROYpcVBaPnc3mDT9UZDzwXWC3i6g==",
+      "version": "55.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-55.0.5.tgz",
+      "integrity": "sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/@expo/config/node_modules/@expo/json-file": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-11.0.1.tgz",
-      "integrity": "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ==",
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.13.tgz",
+      "integrity": "sha512-pX/XjQn7tgNw6zuuV2ikmegmwe/S7uiwhrs2wXrANMkq7ozrA+JcZwgW9Q/8WZgciBzfAhNp5hnackHcrmapQA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3162,9 +3132,9 @@
       }
     },
     "node_modules/@expo/config/node_modules/@expo/plist": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.8.1.tgz",
-      "integrity": "sha512-3gTReGIUm0oRaMClsAJYxBnVPCl6fVpsl8HS+DTVxDhW4GyVyxg9E/Znm3BvcHtUJ51RJJI14pC1wvrNilCRHw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.5.2.tgz",
+      "integrity": "sha512-o4xdVdBpe4aTl3sPMZ2u3fJH4iG1I768EIRk1xRZP+GaFI93MaR3JvoFibYqxeTmLQ1p1kNEVqylfUjezxx45g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3194,9 +3164,9 @@
       }
     },
     "node_modules/@expo/config/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "peer": true,
@@ -3246,9 +3216,9 @@
       }
     },
     "node_modules/@expo/devtools": {
-      "version": "57.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/devtools/-/devtools-57.0.1.tgz",
-      "integrity": "sha512-GyUf+wFNkbttaX0jR7MZa9bm77U0IrLg6d2AjpxdyoXw/w4abHoXG0oFufwLMgP9zLTd5+Ct4X/ffNUTnlzZgg==",
+      "version": "55.0.2",
+      "resolved": "https://registry.npmjs.org/@expo/devtools/-/devtools-55.0.2.tgz",
+      "integrity": "sha512-4VsFn9MUriocyuhyA+ycJP3TJhUsOFHDc270l9h3LhNpXMf6wvIdGcA0QzXkZtORXmlDybWXRP2KT1k36HcQkA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3269,9 +3239,9 @@
       }
     },
     "node_modules/@expo/dom-webview": {
-      "version": "57.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/dom-webview/-/dom-webview-57.0.1.tgz",
-      "integrity": "sha512-lAKsME4SAq+8sf56oN0DX5TBYyruupoRxbWbD2xf9RnKY8y6x8eb9LCE5pxSN0qyWdqnp+0wmyWzDkKboThKAw==",
+      "version": "55.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/dom-webview/-/dom-webview-55.0.5.tgz",
+      "integrity": "sha512-lt3uxYOCk3wmWvtOOvsC35CKGbDAOx5C2EaY8SH1JVSfBzqmF8Cs0Xp1MPxncDPMyxpMiWx5SvvV/iLF1rJU4A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3282,9 +3252,9 @@
       }
     },
     "node_modules/@expo/env": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.4.2.tgz",
-      "integrity": "sha512-28pqaEqwnmLduZ00Pq9HkSzE5wbj1MTwp5/n8nm8rD8MCjR9eUnVOwmNksPI3Be2ReAPO/DbPn1puy0mvoocsQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.1.1.tgz",
+      "integrity": "sha512-rVvHC4I6xlPcg+mAO09ydUi2Wjv1ZytpLmHOSzvXzBAz9mMrJggqCe4s4dubjJvi/Ino/xQCLhbaLCnTtLpikg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3297,24 +3267,16 @@
         "node": ">=20.12.0"
       }
     },
-    "node_modules/@expo/expo-modules-macros-plugin": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@expo/expo-modules-macros-plugin/-/expo-modules-macros-plugin-0.6.1.tgz",
-      "integrity": "sha512-cpsLZE4rqkc1Y3eZTkxB98jrqY1YXgetmtxFt8q89jBRmk3quRuk1BZo+VcnCSObZardjg99r1k5xijEMONFGA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@expo/fingerprint": {
-      "version": "0.20.6",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.20.6.tgz",
-      "integrity": "sha512-cmC/6BOPRbdKr77Mgjwszb8aM0hY2RKBpMRCmjSdn9zIcn2FGor/ic4fHVr46cQFa1G6RDGg1GyAjRw3US4CCQ==",
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.16.6.tgz",
+      "integrity": "sha512-nRITNbnu3RKSHPvKVehrSU4KG2VY9V8nvULOHBw98ukHCAU4bGrU5APvcblOkX3JAap+xEHsg/mZvqlvkLInmQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@expo/env": "^2.4.2",
-        "@expo/spawn-async": "^1.8.0",
+        "@expo/env": "^2.0.11",
+        "@expo/spawn-async": "^1.7.2",
         "arg": "^5.0.2",
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
@@ -3349,9 +3311,9 @@
       }
     },
     "node_modules/@expo/fingerprint/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "peer": true,
@@ -3378,151 +3340,20 @@
       }
     },
     "node_modules/@expo/image-utils": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.11.4.tgz",
-      "integrity": "sha512-pn/4770DIEOcYZr484uazuwg20FX/qaDkeMRF6J+oxejynDmEmO8wLsCudaNShFE0BhyKGQTYrs2rsRhqrqESw==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.13.tgz",
+      "integrity": "sha512-1I//yBQeTY6p0u1ihqGNDAr35EbSG8uFEupFrIF0jd++h9EWH33521yZJU1yE+mwGlzCb61g3ehu78siMhXBlA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@expo/require-utils": "^57.0.4",
-        "@expo/spawn-async": "^1.8.0",
+        "@expo/require-utils": "^55.0.4",
+        "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
         "getenv": "^2.0.0",
         "jimp-compact": "0.16.1",
         "parse-png": "^2.1.0",
         "semver": "^7.6.0"
-      }
-    },
-    "node_modules/@expo/inline-modules": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@expo/inline-modules/-/inline-modules-0.1.4.tgz",
-      "integrity": "sha512-8bPSCm//dv8raYfrQ4x79rCX52vMw0QzmnYYl4eSOAvEbGvDPPRGGdbrhZZ7oihU+hI1sZNS5kYEgqODgFwfsw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@expo/config-plugins": "~57.0.6"
-      }
-    },
-    "node_modules/@expo/inline-modules/node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@expo/inline-modules/node_modules/@expo/config-plugins": {
-      "version": "57.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-57.0.6.tgz",
-      "integrity": "sha512-7CmKrS5Rnu8aSZyNlxH2qzA7Ls1HEa4EQvEVOAkHDKPr1e4Cg/nz7I7dUl09QDTVjMvkKYDH4Th0DuAsgqASaw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@expo/config-types": "^57.0.2",
-        "@expo/json-file": "~11.0.1",
-        "@expo/plist": "^0.8.1",
-        "@expo/require-utils": "^57.0.4",
-        "@expo/sdk-runtime-versions": "^1.0.0",
-        "chalk": "^4.1.2",
-        "debug": "^4.3.5",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "semver": "^7.5.4",
-        "slugify": "^1.6.6",
-        "xcode": "^3.0.1",
-        "xml2js": "0.6.0"
-      }
-    },
-    "node_modules/@expo/inline-modules/node_modules/@expo/config-types": {
-      "version": "57.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-57.0.2.tgz",
-      "integrity": "sha512-ewW08OonrcRIsRKIlFvvcmmafE5zemb1ocu3HkNwtVPyRtj2w42pZCAkMIROYpcVBaPnc3mDT9UZDzwXWC3i6g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@expo/inline-modules/node_modules/@expo/json-file": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-11.0.1.tgz",
-      "integrity": "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "json5": "^2.2.3"
-      }
-    },
-    "node_modules/@expo/inline-modules/node_modules/@expo/plist": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.8.1.tgz",
-      "integrity": "sha512-3gTReGIUm0oRaMClsAJYxBnVPCl6fVpsl8HS+DTVxDhW4GyVyxg9E/Znm3BvcHtUJ51RJJI14pC1wvrNilCRHw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
-        "base64-js": "^1.5.1",
-        "xmlbuilder": "^15.1.1"
-      }
-    },
-    "node_modules/@expo/inline-modules/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@expo/inline-modules/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@expo/inline-modules/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@expo/json-file": {
@@ -3537,64 +3368,64 @@
       }
     },
     "node_modules/@expo/local-build-cache-provider": {
-      "version": "57.0.5",
-      "resolved": "https://registry.npmjs.org/@expo/local-build-cache-provider/-/local-build-cache-provider-57.0.5.tgz",
-      "integrity": "sha512-OwiNC0Uxu67TOH7TEQ94GLa4oNzNfbbItKGdy3QMfX+hCSZv2VvjcjRo5vttMHfXCnXa9KZIu3GBS9pvtDHWhA==",
+      "version": "55.0.11",
+      "resolved": "https://registry.npmjs.org/@expo/local-build-cache-provider/-/local-build-cache-provider-55.0.11.tgz",
+      "integrity": "sha512-rJ4RTCrkeKaXaido/bVyhl90ZRtVTOEbj59F1PWVjIEIVgjdlfc1J3VD9v7hEsbf/+8Tbr/PgvWhT6Visi5sLQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@expo/config": "~57.0.6",
+        "@expo/config": "~55.0.15",
         "chalk": "^4.1.2"
       }
     },
     "node_modules/@expo/log-box": {
-      "version": "57.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/log-box/-/log-box-57.0.2.tgz",
-      "integrity": "sha512-ZsFyfIR7YCbQAdVLzuTUmMHofZC7ZS9ywYCJNPlLc78x59cI8GwXFEIVbRjjC0uJERpNtXx/tsNNnkhexXlzMw==",
+      "version": "55.0.11",
+      "resolved": "https://registry.npmjs.org/@expo/log-box/-/log-box-55.0.11.tgz",
+      "integrity": "sha512-JQHFLWkskIbJi6cxYMjErx8lQqfFJilDQLKmdTO3m3YkdmN9GE/CrzjOfVlCG0DGEGZJ90br0pGKvGPdXNsHKw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@expo/dom-webview": "^57.0.1",
+        "@expo/dom-webview": "^55.0.5",
         "anser": "^1.4.9",
         "stacktrace-parser": "^0.1.10"
       },
       "peerDependencies": {
-        "@expo/dom-webview": "^57.0.1",
+        "@expo/dom-webview": "^55.0.5",
         "expo": "*",
         "react": "*",
         "react-native": "*"
       }
     },
     "node_modules/@expo/metro": {
-      "version": "56.0.0",
-      "resolved": "https://registry.npmjs.org/@expo/metro/-/metro-56.0.0.tgz",
-      "integrity": "sha512-5gIgQHtEpjjvsjKfVtIv23a98LLRV0/y07PDShEwYSytAMlE3FSF8RHXqtHc1sUJL6dn7hnuIBpIbrLXXuVi0A==",
+      "version": "55.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/metro/-/metro-55.1.1.tgz",
+      "integrity": "sha512-/wfXo5hTuAVpVLG/4hzlmD9NBGJkzkmBEMm/4VICajYRbj7y8OmqqPWbbymzHiBiHB6tI9BnsyXpQM6zVZEECg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "metro": "0.84.4",
-        "metro-babel-transformer": "0.84.4",
-        "metro-cache": "0.84.4",
-        "metro-cache-key": "0.84.4",
-        "metro-config": "0.84.4",
-        "metro-core": "0.84.4",
-        "metro-file-map": "0.84.4",
-        "metro-minify-terser": "0.84.4",
-        "metro-resolver": "0.84.4",
-        "metro-runtime": "0.84.4",
-        "metro-source-map": "0.84.4",
-        "metro-symbolicate": "0.84.4",
-        "metro-transform-plugins": "0.84.4",
-        "metro-transform-worker": "0.84.4"
+        "metro": "0.83.7",
+        "metro-babel-transformer": "0.83.7",
+        "metro-cache": "0.83.7",
+        "metro-cache-key": "0.83.7",
+        "metro-config": "0.83.7",
+        "metro-core": "0.83.7",
+        "metro-file-map": "0.83.7",
+        "metro-minify-terser": "0.83.7",
+        "metro-resolver": "0.83.7",
+        "metro-runtime": "0.83.7",
+        "metro-source-map": "0.83.7",
+        "metro-symbolicate": "0.83.7",
+        "metro-transform-plugins": "0.83.7",
+        "metro-transform-worker": "0.83.7"
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "57.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-57.0.7.tgz",
-      "integrity": "sha512-bVfEkg4zF1cA62OqAdYXmFOooJ6TB/I+REi7Se6Ct+PbSC+89TwSqWXnYx34L08eIs4z+1ilgbATakTZpgefmQ==",
+      "version": "55.0.17",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-55.0.17.tgz",
+      "integrity": "sha512-o11VyNoRDXv0T5320D9cH+nSsrR/OMHTjtysKLIfDlidsBswDk1DMApPv9Kw0/gluArCSnbx8JC1G0Yh2Y4P3g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3602,25 +3433,21 @@
         "@babel/code-frame": "^7.20.0",
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.5",
-        "@expo/config": "~57.0.6",
-        "@expo/env": "~2.4.2",
-        "@expo/json-file": "~11.0.1",
-        "@expo/metro": "~56.0.0",
-        "@expo/require-utils": "^57.0.4",
-        "@expo/spawn-async": "^1.8.0",
-        "@jridgewell/gen-mapping": "^0.3.13",
-        "@jridgewell/remapping": "^2.3.5",
-        "@jridgewell/sourcemap-codec": "^1.5.5",
+        "@expo/config": "~55.0.15",
+        "@expo/env": "~2.1.1",
+        "@expo/json-file": "~10.0.13",
+        "@expo/metro": "~55.1.0",
+        "@expo/spawn-async": "^1.7.2",
         "browserslist": "^4.25.0",
         "chalk": "^4.1.0",
         "debug": "^4.3.2",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
-        "hermes-parser": "^0.36.0",
+        "hermes-parser": "^0.32.0",
         "jsc-safe-url": "^0.2.4",
         "lightningcss": "^1.30.1",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.14",
+        "picomatch": "^4.0.3",
+        "postcss": "~8.4.32",
         "resolve-from": "^5.0.0"
       },
       "peerDependencies": {
@@ -3633,14 +3460,14 @@
       }
     },
     "node_modules/@expo/metro-config/node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -3649,9 +3476,9 @@
       }
     },
     "node_modules/@expo/metro-config/node_modules/@expo/json-file": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-11.0.1.tgz",
-      "integrity": "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ==",
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.13.tgz",
+      "integrity": "sha512-pX/XjQn7tgNw6zuuV2ikmegmwe/S7uiwhrs2wXrANMkq7ozrA+JcZwgW9Q/8WZgciBzfAhNp5hnackHcrmapQA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3680,9 +3507,9 @@
       }
     },
     "node_modules/@expo/metro-config/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "peer": true,
@@ -3706,22 +3533,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@expo/metro-file-map": {
-      "version": "57.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/metro-file-map/-/metro-file-map-57.0.1.tgz",
-      "integrity": "sha512-8JXfVstZN7QnP4NianZZnlTVboOWR0sG8trUDNajOjnbGlPln29vponXM84tY+3tAHapz5/TxE53L0ixUwqPtA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "debug": "^4.3.4",
-        "fb-watchman": "^2.0.2",
-        "invariant": "^2.2.4",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.8"
       }
     },
     "node_modules/@expo/npm-proofread": {
@@ -3748,29 +3559,29 @@
       }
     },
     "node_modules/@expo/osascript": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.7.1.tgz",
-      "integrity": "sha512-Zn03EX6In7ts2lPUW2ESUSkEhEWQN1qqsiXjadtZMJOuZRkMiAg1ZQHuvz9DjByDWNJ2pBwAGyrts9lj9k389g==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.4.2.tgz",
+      "integrity": "sha512-/XP7PSYF2hzOZzqfjgkoWtllyeTN8dW3aM4P6YgKcmmPikKL5FdoyQhti4eh6RK5a5VrUXJTOlTNIpIHsfB5Iw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@expo/spawn-async": "^1.8.0"
+        "@expo/spawn-async": "^1.7.2"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@expo/package-manager": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.13.1.tgz",
-      "integrity": "sha512-y/K+CaYYpZpNGZhSX4HyLT/vyIunFjNfyoxNysPBCefeLKI/VCx6f9LNPzrxayr3rCYO5bl9O8H+HRQK265Nkg==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.10.4.tgz",
+      "integrity": "sha512-y9Mr4Kmpk4abAVZrNNPCdzOZr8nLLyi18p1SXr0RCVA8IfzqZX/eY4H+50a0HTmXqIsPZrQdcdb4I3ekMS9GvQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@expo/json-file": "^11.0.1",
-        "@expo/spawn-async": "^1.8.0",
+        "@expo/json-file": "^10.0.13",
+        "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
         "npm-package-arg": "^11.0.0",
         "ora": "^3.4.0",
@@ -3778,14 +3589,14 @@
       }
     },
     "node_modules/@expo/package-manager/node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -3794,9 +3605,9 @@
       }
     },
     "node_modules/@expo/package-manager/node_modules/@expo/json-file": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-11.0.1.tgz",
-      "integrity": "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ==",
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.13.tgz",
+      "integrity": "sha512-pX/XjQn7tgNw6zuuV2ikmegmwe/S7uiwhrs2wXrANMkq7ozrA+JcZwgW9Q/8WZgciBzfAhNp5hnackHcrmapQA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3818,34 +3629,37 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "57.0.10",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-57.0.10.tgz",
-      "integrity": "sha512-myrS5NolFAQWD8g7QuqkettnkyJx3GRl603N6rlmqAMxmO5EU7sZu4EX2EsIKkva8QtpX84B0E17PsM9xXMsTQ==",
+      "version": "55.0.16",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-55.0.16.tgz",
+      "integrity": "sha512-o4EAVgDGk1lISirtMD8hciO2vyMp7cWlPdfTtjjd5AXSfODVYDIDhygXrfvVQHmJXAztVqPUTKJT+BYOsVkYGQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@expo/config": "~57.0.6",
-        "@expo/config-plugins": "~57.0.6",
-        "@expo/config-types": "^57.0.2",
-        "@expo/image-utils": "^0.11.4",
-        "@expo/json-file": "^11.0.1",
-        "@react-native/normalize-colors": "0.86.2",
+        "@expo/config": "~55.0.15",
+        "@expo/config-plugins": "~55.0.8",
+        "@expo/config-types": "^55.0.5",
+        "@expo/image-utils": "^0.8.13",
+        "@expo/json-file": "^10.0.13",
+        "@react-native/normalize-colors": "0.83.6",
         "debug": "^4.3.1",
-        "expo-modules-autolinking": "~57.0.9",
         "resolve-from": "^5.0.0",
-        "semver": "^7.6.0"
+        "semver": "^7.6.0",
+        "xml2js": "0.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/@expo/prebuild-config/node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -3854,22 +3668,22 @@
       }
     },
     "node_modules/@expo/prebuild-config/node_modules/@expo/config-plugins": {
-      "version": "57.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-57.0.6.tgz",
-      "integrity": "sha512-7CmKrS5Rnu8aSZyNlxH2qzA7Ls1HEa4EQvEVOAkHDKPr1e4Cg/nz7I7dUl09QDTVjMvkKYDH4Th0DuAsgqASaw==",
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.8.tgz",
+      "integrity": "sha512-8WfWTRntTCcowfOS+tHdB0z98gKetTwktg4G5TWkCkXVa8Jt1NUnvzaaU4UHk2vbR2U4N84RyZJFizSwfF6C9g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@expo/config-types": "^57.0.2",
-        "@expo/json-file": "~11.0.1",
-        "@expo/plist": "^0.8.1",
-        "@expo/require-utils": "^57.0.4",
+        "@expo/config-types": "^55.0.5",
+        "@expo/json-file": "~10.0.13",
+        "@expo/plist": "^0.5.2",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.5",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
+        "resolve-from": "^5.0.0",
         "semver": "^7.5.4",
         "slugify": "^1.6.6",
         "xcode": "^3.0.1",
@@ -3877,17 +3691,17 @@
       }
     },
     "node_modules/@expo/prebuild-config/node_modules/@expo/config-types": {
-      "version": "57.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-57.0.2.tgz",
-      "integrity": "sha512-ewW08OonrcRIsRKIlFvvcmmafE5zemb1ocu3HkNwtVPyRtj2w42pZCAkMIROYpcVBaPnc3mDT9UZDzwXWC3i6g==",
+      "version": "55.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-55.0.5.tgz",
+      "integrity": "sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/@expo/prebuild-config/node_modules/@expo/json-file": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-11.0.1.tgz",
-      "integrity": "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ==",
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.13.tgz",
+      "integrity": "sha512-pX/XjQn7tgNw6zuuV2ikmegmwe/S7uiwhrs2wXrANMkq7ozrA+JcZwgW9Q/8WZgciBzfAhNp5hnackHcrmapQA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3897,9 +3711,9 @@
       }
     },
     "node_modules/@expo/prebuild-config/node_modules/@expo/plist": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.8.1.tgz",
-      "integrity": "sha512-3gTReGIUm0oRaMClsAJYxBnVPCl6fVpsl8HS+DTVxDhW4GyVyxg9E/Znm3BvcHtUJ51RJJI14pC1wvrNilCRHw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.5.2.tgz",
+      "integrity": "sha512-o4xdVdBpe4aTl3sPMZ2u3fJH4iG1I768EIRk1xRZP+GaFI93MaR3JvoFibYqxeTmLQ1p1kNEVqylfUjezxx45g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3929,9 +3743,9 @@
       }
     },
     "node_modules/@expo/prebuild-config/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "peer": true,
@@ -3958,9 +3772,9 @@
       }
     },
     "node_modules/@expo/require-utils": {
-      "version": "57.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-57.0.4.tgz",
-      "integrity": "sha512-e7xbg/9BTQcsZE/oErafZXtI7kh5IgfasLJ97J5sFSzX2cA74pDvdlhW1KHVSaDkQyQv6h1LSLhsY7dEeOk7hw==",
+      "version": "55.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.4.tgz",
+      "integrity": "sha512-JAANvXqV7MOysWeVWgaiDzikoyDjJWOV/ulOW60Zb3kXJfrx2oZOtGtDXDFKD1mXuahQgoM5QOjuZhF7gFRNjA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3970,7 +3784,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.24.8"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0"
+        "typescript": "^5.0.0 || ^5.0.0-0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3979,14 +3793,14 @@
       }
     },
     "node_modules/@expo/require-utils/node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -3995,9 +3809,9 @@
       }
     },
     "node_modules/@expo/router-server": {
-      "version": "57.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/router-server/-/router-server-57.0.4.tgz",
-      "integrity": "sha512-ucqCP0hK8nZb9+S8QJYdQxNCkfRClzkKdg2RpWYDKDYgRIHyoRyxEDRgDgvbhH+q78yfY83abU8OTx8MMOrf1g==",
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/@expo/router-server/-/router-server-55.0.15.tgz",
+      "integrity": "sha512-6LksYO4Pg13qroL138KfUebt/x/EO07zVhdyT/nTgcxnpn6CS4ecTl3DciSKhxbaH+0BVLdANkxYeGdp43TMwQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4005,12 +3819,12 @@
         "debug": "^4.3.4"
       },
       "peerDependencies": {
-        "@expo/metro-runtime": "^57.0.7",
+        "@expo/metro-runtime": "^55.0.10",
         "expo": "*",
-        "expo-constants": "^57.0.7",
-        "expo-font": "^57.0.1",
+        "expo-constants": "^55.0.15",
+        "expo-font": "^55.0.6",
         "expo-router": "*",
-        "expo-server": "^57.0.1",
+        "expo-server": "^55.0.8",
         "react": "*",
         "react-dom": "*",
         "react-server-dom-webpack": "~19.0.1 || ~19.1.2 || ~19.2.1"
@@ -4031,9 +3845,9 @@
       }
     },
     "node_modules/@expo/schema-utils": {
-      "version": "57.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-57.0.2.tgz",
-      "integrity": "sha512-fMu/jyN0l1Wzv7XkeWR4IYCx1M8ryui3FdBNGrWwbRgJ7EhxXxK8E2jxP2W3pbgUwUY0V3hG8+GyfCZwny+Lxw==",
+      "version": "55.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-55.0.3.tgz",
+      "integrity": "sha512-l9KHVjTo6MvoeyvwNr6AjckGJm8NIcqZ3QSAh51cWozXW9v2AUjyCyqYtFtyntLWRZ0x/ByYJishpQo4ZQq45Q==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -4046,14 +3860,14 @@
       "license": "MIT"
     },
     "node_modules/@expo/spawn-async": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.8.0.tgz",
-      "integrity": "sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.7.2.tgz",
+      "integrity": "sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "cross-spawn": "^7.0.6"
+        "cross-spawn": "^7.0.3"
       },
       "engines": {
         "node": ">=12"
@@ -4067,21 +3881,31 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/@expo/ws-tunnel": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@expo/ws-tunnel/-/ws-tunnel-2.0.0.tgz",
-      "integrity": "sha512-j+JfTRdCk820J9dU0sA2SqshQIKFOMo7ED84w9MJFcebfbNQgsLztEY/SABDkGnjatrW4xGqnUhVRxSBVyCkXw==",
+    "node_modules/@expo/vector-icons": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
+      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "ws": "^8.0.0"
+        "expo-font": ">=14.0.4",
+        "react": "*",
+        "react-native": "*"
       }
     },
+    "node_modules/@expo/ws-tunnel": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/ws-tunnel/-/ws-tunnel-1.0.6.tgz",
+      "integrity": "sha512-nDRbLmSrJar7abvUjp3smDwH8HcbZcoOEa5jVPUv9/9CajgmWw20JNRwTuBRzWIWIkEJDkz20GoNA+tSwUqk0Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@expo/xcpretty": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.4.tgz",
-      "integrity": "sha512-4aQzz9vgxcNXFfo/iyNgDDYfsU5XGKKxWxZopw0cVotHiW+U8IJbIxMaxsINs6bHhtkG3StKNPcOrn3eBuxKPw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.3.tgz",
+      "integrity": "sha512-wC562eD3gS6vO2tWHToFhlFnmHKfKHgF1oyvojeSkLK/ZYop1bMU+7cOMiF9Sq70CzcsLy/EMRy/uRc76QmNRw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -4095,14 +3919,14 @@
       }
     },
     "node_modules/@expo/xcpretty/node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -4174,9 +3998,9 @@
       "peer": true
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4327,9 +4151,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4613,9 +4437,9 @@
       "license": "MIT"
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4831,19 +4655,19 @@
       }
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.58.12",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.58.12.tgz",
-      "integrity": "sha512-VNpgC/1LaroLbn+UKmwDYspq+9r3EHyj4vJ3qUy/g8vB0rKt+1Wgs7WFj/JGpgxhG8SNyXs1XwYwe7nqkk8IDg==",
+      "version": "7.58.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.58.7.tgz",
+      "integrity": "sha512-yK6OycD46gIzLRpj6ueVUWPk1ACSpkN1LBo05gY1qPTylbWyUCanXfH7+VgkI5LJrJoRSQR5F04XuCffCXLOBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.33.10",
+        "@microsoft/api-extractor-model": "7.33.8",
         "@microsoft/tsdoc": "~0.16.0",
         "@microsoft/tsdoc-config": "~0.18.1",
-        "@rushstack/node-core-library": "5.23.3",
+        "@rushstack/node-core-library": "5.23.1",
         "@rushstack/rig-package": "0.7.3",
-        "@rushstack/terminal": "0.24.2",
-        "@rushstack/ts-command-line": "5.3.12",
+        "@rushstack/terminal": "0.24.0",
+        "@rushstack/ts-command-line": "5.3.9",
         "diff": "~8.0.2",
         "minimatch": "10.2.3",
         "resolve": "~1.22.1",
@@ -4856,28 +4680,15 @@
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.33.10",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.10.tgz",
-      "integrity": "sha512-uPUK17xGxeQ3av6TN7awp+dTTSTvx8fZC0XFL1gyt7hFapYuxND3XLXH8vkmI7UjfW92oogzFAFqHSifmJROaw==",
+      "version": "7.33.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.8.tgz",
+      "integrity": "sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "~0.16.0",
         "@microsoft/tsdoc-config": "~0.18.1",
-        "@rushstack/node-core-library": "5.23.3"
-      }
-    },
-    "node_modules/@microsoft/api-extractor/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "@rushstack/node-core-library": "5.23.1"
       }
     },
     "node_modules/@microsoft/tsdoc": {
@@ -4958,22 +4769,22 @@
       }
     },
     "node_modules/@pkgr/core": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
-      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.86.2",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.86.2.tgz",
-      "integrity": "sha512-vcX/mBjWAVnWofu7KecotquI2unZ/tITwA7OGdq/mdY/zmGXIEvYhfEYyOQij/LRqi9WAL+iizInTBWnxDhK/Q==",
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.85.2.tgz",
+      "integrity": "sha512-kauC/oPaxklU4Y+u9gBfCBJm51qX6WBZq4xx0USCdimtp+G8+554kpygfSWIjoqCJa2o06bWxBEjesiuCv+LzA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -4981,138 +4792,162 @@
       }
     },
     "node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.86.2",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.86.2.tgz",
-      "integrity": "sha512-NNDZqOlNbH5SzgPks1jFDYH3234Rpa5e/nhZymxhIiBH3NcE3uD+rGj/HWXhH7nHF2ToGK6XbUpqy7nmJPeh+g==",
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.83.6.tgz",
+      "integrity": "sha512-qfRXsHGeucT5c6mK+8Q7v4Ly3zmygfVmFlEtkiq7q07W1OTreld6nib4rJ/DBEeNiKBoBTuHjWliYGNuDjLFQA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/traverse": "^7.29.0",
-        "@react-native/codegen": "0.86.2"
+        "@babel/traverse": "^7.25.3",
+        "@react-native/codegen": "0.83.6"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/babel-preset": {
-      "version": "0.74.87",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.74.87.tgz",
-      "integrity": "sha512-hyKpfqzN2nxZmYYJ0tQIHG99FQO0OWXp/gVggAfEUgiT+yNKas1C60LuofUsK7cd+2o9jrpqgqW4WzEDZoBlTg==",
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.83.6.tgz",
+      "integrity": "sha512-4/fXFDUvGOObETZq4+SUFkafld6OGgQWut5cQiqVghlhCB5z/p2lVhPgEUr/aTxTzeS3AmN+ztC+GpYPQ7tsTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@babel/core": "^7.20.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
-        "@babel/plugin-proposal-class-properties": "^7.18.0",
-        "@babel/plugin-proposal-export-default-from": "^7.0.0",
-        "@babel/plugin-proposal-logical-assignment-operators": "^7.18.0",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.0",
-        "@babel/plugin-proposal-numeric-separator": "^7.0.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.20.0",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-        "@babel/plugin-proposal-optional-chaining": "^7.20.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
-        "@babel/plugin-syntax-export-default-from": "^7.0.0",
-        "@babel/plugin-syntax-flow": "^7.18.0",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
-        "@babel/plugin-syntax-optional-chaining": "^7.0.0",
-        "@babel/plugin-transform-arrow-functions": "^7.0.0",
-        "@babel/plugin-transform-async-to-generator": "^7.20.0",
-        "@babel/plugin-transform-block-scoping": "^7.0.0",
-        "@babel/plugin-transform-classes": "^7.0.0",
-        "@babel/plugin-transform-computed-properties": "^7.0.0",
-        "@babel/plugin-transform-destructuring": "^7.20.0",
-        "@babel/plugin-transform-flow-strip-types": "^7.20.0",
-        "@babel/plugin-transform-function-name": "^7.0.0",
-        "@babel/plugin-transform-literals": "^7.0.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
-        "@babel/plugin-transform-parameters": "^7.0.0",
-        "@babel/plugin-transform-private-methods": "^7.22.5",
-        "@babel/plugin-transform-private-property-in-object": "^7.22.11",
-        "@babel/plugin-transform-react-display-name": "^7.0.0",
-        "@babel/plugin-transform-react-jsx": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-source": "^7.0.0",
-        "@babel/plugin-transform-runtime": "^7.0.0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
-        "@babel/plugin-transform-spread": "^7.0.0",
-        "@babel/plugin-transform-sticky-regex": "^7.0.0",
-        "@babel/plugin-transform-typescript": "^7.5.0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0",
-        "@babel/template": "^7.0.0",
-        "@react-native/babel-plugin-codegen": "0.74.87",
+        "@babel/core": "^7.25.2",
+        "@babel/plugin-proposal-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-transform-arrow-functions": "^7.24.7",
+        "@babel/plugin-transform-async-generator-functions": "^7.25.4",
+        "@babel/plugin-transform-async-to-generator": "^7.24.7",
+        "@babel/plugin-transform-block-scoping": "^7.25.0",
+        "@babel/plugin-transform-class-properties": "^7.25.4",
+        "@babel/plugin-transform-classes": "^7.25.4",
+        "@babel/plugin-transform-computed-properties": "^7.24.7",
+        "@babel/plugin-transform-destructuring": "^7.24.8",
+        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
+        "@babel/plugin-transform-for-of": "^7.24.7",
+        "@babel/plugin-transform-function-name": "^7.25.1",
+        "@babel/plugin-transform-literals": "^7.25.2",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+        "@babel/plugin-transform-numeric-separator": "^7.24.7",
+        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
+        "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
+        "@babel/plugin-transform-optional-chaining": "^7.24.8",
+        "@babel/plugin-transform-parameters": "^7.24.7",
+        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
+        "@babel/plugin-transform-react-display-name": "^7.24.7",
+        "@babel/plugin-transform-react-jsx": "^7.25.2",
+        "@babel/plugin-transform-react-jsx-self": "^7.24.7",
+        "@babel/plugin-transform-react-jsx-source": "^7.24.7",
+        "@babel/plugin-transform-regenerator": "^7.24.7",
+        "@babel/plugin-transform-runtime": "^7.24.7",
+        "@babel/plugin-transform-shorthand-properties": "^7.24.7",
+        "@babel/plugin-transform-spread": "^7.24.7",
+        "@babel/plugin-transform-sticky-regex": "^7.24.7",
+        "@babel/plugin-transform-typescript": "^7.25.2",
+        "@babel/plugin-transform-unicode-regex": "^7.24.7",
+        "@babel/template": "^7.25.0",
+        "@react-native/babel-plugin-codegen": "0.83.6",
+        "babel-plugin-syntax-hermes-parser": "0.32.0",
         "babel-plugin-transform-flow-enums": "^0.0.2",
         "react-refresh": "^0.14.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
         "@babel/core": "*"
       }
     },
-    "node_modules/@react-native/babel-preset/node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.74.87",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.74.87.tgz",
-      "integrity": "sha512-+vJYpMnENFrwtgvDfUj+CtVJRJuUnzAUYT0/Pb68Sq9RfcZ5xdcCuUgyf7JO+akW2VTBoJY427wkcxU30qrWWw==",
+    "node_modules/@react-native/babel-preset/node_modules/babel-plugin-syntax-hermes-parser": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.0.tgz",
+      "integrity": "sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@react-native/codegen": "0.74.87"
-      },
-      "engines": {
-        "node": ">=18"
+        "hermes-parser": "0.32.0"
       }
     },
-    "node_modules/@react-native/babel-preset/node_modules/@react-native/codegen": {
-      "version": "0.74.87",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.74.87.tgz",
-      "integrity": "sha512-GMSYDiD+86zLKgMMgz9z0k6FxmRn+z6cimYZKkucW4soGbxWsbjUAZoZ56sJwt2FJ3XVRgXCrnOCgXoH/Bkhcg==",
+    "node_modules/@react-native/babel-preset/node_modules/hermes-estree": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
+      "integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@react-native/babel-preset/node_modules/hermes-parser": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.0.tgz",
+      "integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@babel/parser": "^7.20.0",
+        "hermes-estree": "0.32.0"
+      }
+    },
+    "node_modules/@react-native/codegen": {
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.83.6.tgz",
+      "integrity": "sha512-doB/Pq6Cf6IjF3wlQXTIiZOnsX9X8mEEk+CdGfyuCwZjWrf7IB8KaZEXXckJmfUcIwvJ9u/a72ZoTTCIoxAc9A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/parser": "^7.25.3",
         "glob": "^7.1.1",
-        "hermes-parser": "0.19.1",
+        "hermes-parser": "0.32.0",
         "invariant": "^2.2.4",
-        "jscodeshift": "^0.14.0",
-        "mkdirp": "^0.5.1",
-        "nullthrows": "^1.1.1"
+        "nullthrows": "^1.1.1",
+        "yargs": "^17.6.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
-        "@babel/preset-env": "^7.1.6"
+        "@babel/core": "*"
       }
     },
-    "node_modules/@react-native/babel-preset/node_modules/balanced-match": {
+    "node_modules/@react-native/codegen/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
-    "node_modules/@react-native/babel-preset/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+    "node_modules/@react-native/codegen/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/@react-native/babel-preset/node_modules/glob": {
+    "node_modules/@react-native/codegen/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5128,29 +4963,32 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@react-native/babel-preset/node_modules/hermes-estree": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.19.1.tgz",
-      "integrity": "sha512-daLGV3Q2MKk8w4evNMKwS8zBE/rcpA800nu1Q5kM08IKijoSnPe9Uo1iIxzPKRkn95IxxsgBMPeYHt3VG4ej2g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@react-native/babel-preset/node_modules/hermes-parser": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.19.1.tgz",
-      "integrity": "sha512-Vp+bXzxYJWrpEuJ/vXxUsLnt0+y4q9zyi4zUlkLqD8FKv4LjIfOvP69R/9Lty3dCyKh0E2BU7Eypqr63/rKT/A==",
+    "node_modules/@react-native/codegen/node_modules/hermes-estree": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
+      "integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@react-native/codegen/node_modules/hermes-parser": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.0.tgz",
+      "integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "hermes-estree": "0.19.1"
+        "hermes-estree": "0.32.0"
       }
     },
-    "node_modules/@react-native/babel-preset/node_modules/minimatch": {
+    "node_modules/@react-native/codegen/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5158,71 +4996,19 @@
         "node": "*"
       }
     },
-    "node_modules/@react-native/babel-preset/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/@react-native/codegen": {
-      "version": "0.86.2",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.86.2.tgz",
-      "integrity": "sha512-xKkudsahUJ1n//55g4fXk5BStVqqmZlz8HQveL45ZxcfDnwvhuYe2GymksQANFsSN+slvrarjrfq8kIxJzbceA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@babel/parser": "^7.29.0",
-        "hermes-parser": "0.36.0",
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1",
-        "tinyglobby": "^0.2.15",
-        "yargs": "^17.6.2"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/@react-native/codegen/node_modules/hermes-estree": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.36.0.tgz",
-      "integrity": "sha512-A1+8zn5oss2CFP7pKsOaxorQG6FNIz1WU1VDqruLPPZl3LVgeE2C5xfFg8Ow6/Ow4mSslLLtYP1J3n38eKyW9w==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@react-native/codegen/node_modules/hermes-parser": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.36.0.tgz",
-      "integrity": "sha512-GdpwMmH5x6IpC1cijvcvYnlPB60Mh6kTSF/NFdYV/j56gYdi+0RIakYs+eqOV+bbO0SW7mgVVGSsTJxyPQfo3w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "hermes-estree": "0.36.0"
-      }
-    },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.86.2",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.86.2.tgz",
-      "integrity": "sha512-YHXNKoM6Y/HjREySZ5arET2xgiHgg67r1MdwJB//MPJAJ0Xc5g0u6UHxY9VzsHO3Y07dre6s0BinYwjt1SEWvQ==",
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.85.2.tgz",
+      "integrity": "sha512-3KLgSg1kHvBpr93zMaQhvfYTgnCw7yZRED+3J4dMcYjfSjtD0Wf8SofU6uBmAw9JaVYvP43lpdwUpI4p0+ABsg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@react-native/dev-middleware": "0.86.2",
+        "@react-native/dev-middleware": "0.85.2",
         "debug": "^4.4.0",
         "invariant": "^2.2.4",
-        "metro": "^0.84.3",
-        "metro-config": "^0.84.3",
-        "metro-core": "^0.84.3",
+        "metro": "^0.84.0",
+        "metro-config": "^0.84.0",
+        "metro-core": "^0.84.0",
         "semver": "^7.1.3"
       },
       "engines": {
@@ -5230,7 +5016,7 @@
       },
       "peerDependencies": {
         "@react-native-community/cli": "*",
-        "@react-native/metro-config": "0.86.2"
+        "@react-native/metro-config": "0.85.2"
       },
       "peerDependenciesMeta": {
         "@react-native-community/cli": {
@@ -5241,20 +5027,35 @@
         }
       }
     },
-    "node_modules/@react-native/debugger-frontend": {
-      "version": "0.86.2",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.86.2.tgz",
-      "integrity": "sha512-KGS1aV5F6cIqpnoIUhLBXyVzy1oAj8jBFGau6vX4Vy0HXRJN7p+68RU7x6NuyraHvQcR14ccMGT5TkFuNjQ4gA==",
+    "node_modules/@react-native/community-cli-plugin/node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/debugger-frontend": {
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.85.2.tgz",
+      "integrity": "sha512-j+0b9H5f5hGTLQxHIhJU/b/W6ijuxJF+ZTLHB0se2kzUBNxFKd7DkIc6753qk3CJdiv55vxG3XDgmlpbHxOpmA==",
       "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
         "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       }
     },
-    "node_modules/@react-native/debugger-shell": {
-      "version": "0.86.2",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.86.2.tgz",
-      "integrity": "sha512-/TaVJ2+gGajZPJGrFaObUQmHmlaxAlfmOPZicl6pNKDUjzSgFMpcLkdTOExvb+USYTVdGX1XwxXyvjQdUO2bvg==",
+    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/debugger-shell": {
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.85.2.tgz",
+      "integrity": "sha512-r5BkhqPMfg3LmaZS5zadHmBNVH5h4bhSpv4BEPGfK4gat9HABAMzUzybi+2wpgU3SoHxnyKGdExEJvoqVcjeRg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5266,16 +5067,16 @@
         "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       }
     },
-    "node_modules/@react-native/dev-middleware": {
-      "version": "0.86.2",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.86.2.tgz",
-      "integrity": "sha512-B7L0vKvg+IcEElT7Vpqh1xj5yJAqWUegjbP+bQRaorJMAYnv11GkliTnZV2AdTDfZQJWgOEx8i8LGkHkUg7bnA==",
+    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/dev-middleware": {
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.85.2.tgz",
+      "integrity": "sha512-3J+NaDUg+QEfDeLAUzgaWhpaxEg78g+KwbydlDCewh2G6WnHpsty8XooruxNHzyAsqVWywZMrzmbn78Ctc1O9Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.86.2",
-        "@react-native/debugger-shell": "0.86.2",
+        "@react-native/debugger-frontend": "0.85.2",
+        "@react-native/debugger-shell": "0.85.2",
         "chrome-launcher": "^0.15.2",
         "chromium-edge-launcher": "^0.3.0",
         "connect": "^3.6.5",
@@ -5290,10 +5091,492 @@
         "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       }
     },
+    "node_modules/@react-native/community-cli-plugin/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/chromium-edge-launcher": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.3.0.tgz",
+      "integrity": "sha512-p03azHlGjtyRvFEee3cyvtsRYdniSkwjkzmM/KmVnqT5d7QkkwpJBhis/zCLMYdQMVJ5tt140TBNqqrZPaWeFA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0",
+        "mkdirp": "^1.0.4"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/hermes-estree": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+      "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/hermes-parser": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+      "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hermes-estree": "0.35.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/metro": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.84.4.tgz",
+      "integrity": "sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "accepts": "^2.0.0",
+        "ci-info": "^2.0.0",
+        "connect": "^3.6.5",
+        "debug": "^4.4.0",
+        "error-stack-parser": "^2.0.6",
+        "flow-enums-runtime": "^0.0.6",
+        "graceful-fs": "^4.2.4",
+        "hermes-parser": "0.35.0",
+        "image-size": "^1.0.2",
+        "invariant": "^2.2.4",
+        "jest-worker": "^29.7.0",
+        "jsc-safe-url": "^0.2.2",
+        "lodash.throttle": "^4.1.1",
+        "metro-babel-transformer": "0.84.4",
+        "metro-cache": "0.84.4",
+        "metro-cache-key": "0.84.4",
+        "metro-config": "0.84.4",
+        "metro-core": "0.84.4",
+        "metro-file-map": "0.84.4",
+        "metro-resolver": "0.84.4",
+        "metro-runtime": "0.84.4",
+        "metro-source-map": "0.84.4",
+        "metro-symbolicate": "0.84.4",
+        "metro-transform-plugins": "0.84.4",
+        "metro-transform-worker": "0.84.4",
+        "mime-types": "^3.0.1",
+        "nullthrows": "^1.1.1",
+        "serialize-error": "^2.1.0",
+        "source-map": "^0.5.6",
+        "throat": "^5.0.0",
+        "ws": "^7.5.10",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "metro": "src/cli.js"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/metro-babel-transformer": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.84.4.tgz",
+      "integrity": "sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "flow-enums-runtime": "^0.0.6",
+        "hermes-parser": "0.35.0",
+        "metro-cache-key": "0.84.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/metro-cache": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.84.4.tgz",
+      "integrity": "sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "exponential-backoff": "^3.1.1",
+        "flow-enums-runtime": "^0.0.6",
+        "https-proxy-agent": "^7.0.5",
+        "metro-core": "0.84.4"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/metro-cache-key": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.84.4.tgz",
+      "integrity": "sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/metro-config": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.84.4.tgz",
+      "integrity": "sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "connect": "^3.6.5",
+        "flow-enums-runtime": "^0.0.6",
+        "jest-validate": "^29.7.0",
+        "metro": "0.84.4",
+        "metro-cache": "0.84.4",
+        "metro-core": "0.84.4",
+        "metro-runtime": "0.84.4",
+        "yaml": "^2.6.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/metro-core": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.84.4.tgz",
+      "integrity": "sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "lodash.throttle": "^4.1.1",
+        "metro-resolver": "0.84.4"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/metro-file-map": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.84.4.tgz",
+      "integrity": "sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "fb-watchman": "^2.0.0",
+        "flow-enums-runtime": "^0.0.6",
+        "graceful-fs": "^4.2.4",
+        "invariant": "^2.2.4",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "nullthrows": "^1.1.1",
+        "walker": "^1.0.7"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/metro-minify-terser": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.84.4.tgz",
+      "integrity": "sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "terser": "^5.15.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/metro-resolver": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.84.4.tgz",
+      "integrity": "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/metro-runtime": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz",
+      "integrity": "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/metro-source-map": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
+      "integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-symbolicate": "0.84.4",
+        "nullthrows": "^1.1.1",
+        "ob1": "0.84.4",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/metro-symbolicate": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.4.tgz",
+      "integrity": "sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-source-map": "0.84.4",
+        "nullthrows": "^1.1.1",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "bin": {
+        "metro-symbolicate": "src/index.js"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/metro-transform-plugins": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.84.4.tgz",
+      "integrity": "sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/metro-transform-worker": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.84.4.tgz",
+      "integrity": "sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "metro": "0.84.4",
+        "metro-babel-transformer": "0.84.4",
+        "metro-cache": "0.84.4",
+        "metro-cache-key": "0.84.4",
+        "metro-minify-terser": "0.84.4",
+        "metro-source-map": "0.84.4",
+        "metro-transform-plugins": "0.84.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/ob1": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.4.tgz",
+      "integrity": "sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-native/debugger-frontend": {
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.83.6.tgz",
+      "integrity": "sha512-TyWXEpAjVundrc87fPWg91piOUg75+X9iutcfDe7cO3NrAEYCsl7Z09rKHuiAGkxfG9/rFD13dPsYIixUFkSFA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.4"
+      }
+    },
+    "node_modules/@react-native/debugger-shell": {
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.83.6.tgz",
+      "integrity": "sha512-684TJMBCU0l0ZjJWzrnK0HH+ERaM9KLyxyArE1k7BrP+gVl4X9GO0Pi94RoInOxvW/nyV65sOU6Ip1F3ygS0cg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "fb-dotslash": "0.5.8"
+      },
+      "engines": {
+        "node": ">= 20.19.4"
+      }
+    },
+    "node_modules/@react-native/dev-middleware": {
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.83.6.tgz",
+      "integrity": "sha512-22xoddLTelpcVnF385SNH2hdP7X2av5pu7yRl/WnM5jBznbcl0+M9Ce94cj+WVeomsoUF/vlfuB0Ooy+RMlRiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@isaacs/ttlcache": "^1.4.1",
+        "@react-native/debugger-frontend": "0.83.6",
+        "@react-native/debugger-shell": "0.83.6",
+        "chrome-launcher": "^0.15.2",
+        "chromium-edge-launcher": "^0.2.0",
+        "connect": "^3.6.5",
+        "debug": "^4.4.0",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "open": "^7.0.3",
+        "serve-static": "^1.16.2",
+        "ws": "^7.5.10"
+      },
+      "engines": {
+        "node": ">= 20.19.4"
+      }
+    },
     "node_modules/@react-native/dev-middleware/node_modules/ws": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
-      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -5313,9 +5596,9 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.86.2",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.86.2.tgz",
-      "integrity": "sha512-2F6x14NcHMpVmfTTFKfMkpV5dZedZrLiv6PE+c3vgnesV2bjleUBydr4U+NI8VkI7OwW71L0A5qQ76I9LCrfoQ==",
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.85.2.tgz",
+      "integrity": "sha512-YXBOLeAqFrv7XwUeBPTKZeOV1FIxn4AW7UAEitScf3ibC8bu8+6NpJu4HWgbNQHg7vDbbTZVbcOl8EwGxsSq2w==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -5323,9 +5606,9 @@
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.86.2",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.86.2.tgz",
-      "integrity": "sha512-bIwNcGBaQ74shB5z1mRkxOpjikimuwsnOCEkZSzL67Z1FTyK1ObpENfyd2QvcvVW9Cjl+tHuw9ynpBnb2jPoJQ==",
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.85.2.tgz",
+      "integrity": "sha512-esGEAmKVM40DV/yVmNljCKZTIeUo7qXqc+Hwffkv3TG+b3E24xyFovHrbP98gGxZr2ZsEyx+2sKLdXF5asY5nw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -5333,16 +5616,17 @@
       }
     },
     "node_modules/@react-native/normalize-colors": {
-      "version": "0.86.2",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.86.2.tgz",
-      "integrity": "sha512-EzPFc9Y6lzYOWeso2almwXI7f8+qReHxWvT+algsOczb2UhWXIWXDoSvkdwoSfiwwmGt/ijJgKJoeHlzPkLwRg==",
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.83.6.tgz",
+      "integrity": "sha512-bTM24b5v4qN3h52oflnv+OujFORn/kVi06WaWhnQQw14/ycilPqIsqsa+DpIBqdBrXxvLa9fXtCRrQtGATZCEw==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/@react-native/virtualized-lists": {
-      "version": "0.86.2",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.86.2.tgz",
-      "integrity": "sha512-uO0J72gh3EvE+1/GHRk18QRyBDTRHRB0AraAfojsRjbT7VMuJwKrZYaKGshavoaEud6aw00ZB9/8mTMIKjjcAw==",
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.85.2.tgz",
+      "integrity": "sha512-wmVKpAlcr+UB0L5SpbrV865EdleUP7I5+X+48e1aRsQK8q+wsTRBXeUwWVip/1l+HZwlZFeO8iOILJ16VRu0Cw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5355,7 +5639,7 @@
       "peerDependencies": {
         "@types/react": "^19.2.0",
         "react": "*",
-        "react-native": "0.86.2"
+        "react-native": "0.85.2"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -5371,13 +5655,13 @@
       "license": "MIT"
     },
     "node_modules/@rushstack/node-core-library": {
-      "version": "5.23.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.23.3.tgz",
-      "integrity": "sha512-f6uuza7Um65bwsIJgf0MRs7IPA5IG+A+zs1AYGQvpZmLjtTGdfHowhQw4kwF0pPhJCrU4UHNhK8Qa6tLygYZCA==",
+      "version": "5.23.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.23.1.tgz",
+      "integrity": "sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "~8.20.0",
+        "ajv": "~8.18.0",
         "ajv-draft-04": "~1.0.0",
         "ajv-formats": "~3.0.1",
         "fs-extra": "~11.3.0",
@@ -5393,51 +5677,6 @@
         "@types/node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/fs-extra": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
-      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@rushstack/problem-matcher": {
@@ -5467,13 +5706,13 @@
       }
     },
     "node_modules/@rushstack/terminal": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.24.2.tgz",
-      "integrity": "sha512-KB7PpvzDyKMw/RGU3TxOwxTs3OwZ4gq6+WHlTJN/JfQH4ezliNtWIqver78jTaAJyz/ZAAlJGH7a/M1WyFLFSw==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.24.0.tgz",
+      "integrity": "sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rushstack/node-core-library": "5.23.3",
+        "@rushstack/node-core-library": "5.23.1",
         "@rushstack/problem-matcher": "0.2.1",
         "supports-color": "~8.1.1"
       },
@@ -5487,22 +5726,22 @@
       }
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.12.tgz",
-      "integrity": "sha512-Vg2n24arSf7JvUNga2DMHYTbxnVq9L5OtVCp4Gfr8YC/kmL/bmdR8FQhGcpMzMYNY9Vdw3+TaimG11Sf+z1Tpw==",
+      "version": "5.3.9",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.9.tgz",
+      "integrity": "sha512-GIHqU+sRGQ3LGWAZu1O+9Yh++qwtyNIIGuNbcWHJjBTm2qRez0cwINUHZ+pQLR8UuzZDcMajrDaNbUYoaL/XtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rushstack/terminal": "0.24.2",
+        "@rushstack/terminal": "0.24.0",
         "@types/argparse": "1.0.38",
         "argparse": "~1.0.9",
         "string-argv": "~0.3.1"
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.27.12",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
-      "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {
@@ -5556,9 +5795,9 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
-      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5625,9 +5864,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
-      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -5703,12 +5942,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
-      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -5719,9 +5958,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -5785,17 +6024,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
-      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
+      "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/type-utils": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/type-utils": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -5808,15 +6047,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.65.0",
+        "@typescript-eslint/parser": "^8.59.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5824,16 +6063,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
-      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
+      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -5849,14 +6088,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
-      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
+      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.65.0",
-        "@typescript-eslint/types": "^8.65.0",
+        "@typescript-eslint/tsconfig-utils": "^8.59.1",
+        "@typescript-eslint/types": "^8.59.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -5871,14 +6110,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
-      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
+      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0"
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5889,9 +6128,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
-      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
+      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5906,15 +6145,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
-      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
+      "integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -5931,9 +6170,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
-      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
+      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5945,16 +6184,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
-      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
+      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.65.0",
-        "@typescript-eslint/tsconfig-utils": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/project-service": "8.59.1",
+        "@typescript-eslint/tsconfig-utils": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -5973,16 +6212,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
-      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
+      "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0"
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5997,13 +6236,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
-      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
+      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/types": "8.59.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -6028,9 +6267,9 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
-      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC",
       "peer": true
@@ -6082,9 +6321,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
-      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -6138,20 +6377,6 @@
       },
       "engines": {
         "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/agent-cli-detector": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/agent-cli-detector/-/agent-cli-detector-0.1.4.tgz",
-      "integrity": "sha512-qPgevFvpaQoBaRJVKzr8R7h1WPvV3DtbgRIQlne4le66KBzXx5hNBwo/+NTw67LgkKBlhCzksrdautpUdlls0Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "agent-cli-detector": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=18.18"
       }
     },
     "node_modules/aggregate-error": {
@@ -6714,14 +6939,14 @@
       "peer": true
     },
     "node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.36.1.tgz",
-      "integrity": "sha512-ycduwJbvdvIMmVvlAZqGggS+pm5Eu4Bk9pcV9Sm2Z4PJNRVsKkv0g7vHj+LeuC1gHTeF67sJXFOq61IlqCa2hA==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.1.tgz",
+      "integrity": "sha512-HgErPZTghW76Rkq9uqn5ESeiD97FbqpZ1V170T1RG2RDp+7pJVQV2pQJs7y5YzN0/gcT6GM5ci9apRnIwuyPdQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "hermes-parser": "0.36.1"
+        "hermes-parser": "0.32.1"
       }
     },
     "node_modules/babel-plugin-transform-flow-enums": {
@@ -6762,9 +6987,9 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "57.0.5",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-57.0.5.tgz",
-      "integrity": "sha512-sz9ZBTiUAlu5P9VORVNKoeAaY2qKFQRC6eQV5Y8aMkqcorvXKEv97UeCkFMLmMBEPKA+QeWImREKkX9/H21WQA==",
+      "version": "55.0.18",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-55.0.18.tgz",
+      "integrity": "sha512-zmDwKxCFBTe4e/jQXuITRUZlbl8HTZOhsUlwcHGjwEUB0lKQfRdaSYXZckQ+jMOBC34MrOl3Cs7/6F6vNbj5Pw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -6773,49 +6998,30 @@
         "@babel/helper-module-imports": "^7.25.9",
         "@babel/plugin-proposal-decorators": "^7.12.9",
         "@babel/plugin-proposal-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-syntax-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-transform-async-generator-functions": "^7.25.4",
-        "@babel/plugin-transform-async-to-generator": "^7.24.7",
-        "@babel/plugin-transform-block-scoping": "^7.25.0",
-        "@babel/plugin-transform-class-properties": "^7.25.4",
         "@babel/plugin-transform-class-static-block": "^7.27.1",
-        "@babel/plugin-transform-classes": "^7.25.4",
-        "@babel/plugin-transform-destructuring": "^7.24.8",
         "@babel/plugin-transform-export-namespace-from": "^7.25.9",
         "@babel/plugin-transform-flow-strip-types": "^7.25.2",
-        "@babel/plugin-transform-for-of": "^7.24.7",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
         "@babel/plugin-transform-modules-commonjs": "^7.24.8",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
         "@babel/plugin-transform-object-rest-spread": "^7.24.7",
-        "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
-        "@babel/plugin-transform-optional-chaining": "^7.24.8",
         "@babel/plugin-transform-parameters": "^7.24.7",
         "@babel/plugin-transform-private-methods": "^7.24.7",
         "@babel/plugin-transform-private-property-in-object": "^7.24.7",
-        "@babel/plugin-transform-react-display-name": "^7.24.7",
-        "@babel/plugin-transform-react-jsx": "^7.28.6",
-        "@babel/plugin-transform-react-jsx-development": "^7.27.1",
-        "@babel/plugin-transform-react-pure-annotations": "^7.27.1",
         "@babel/plugin-transform-runtime": "^7.24.7",
-        "@babel/plugin-transform-typescript": "^7.25.2",
-        "@babel/plugin-transform-unicode-regex": "^7.24.7",
+        "@babel/preset-react": "^7.22.15",
         "@babel/preset-typescript": "^7.23.0",
-        "@react-native/babel-plugin-codegen": "0.86.2",
+        "@react-native/babel-preset": "0.83.6",
         "babel-plugin-react-compiler": "^1.0.0",
         "babel-plugin-react-native-web": "~0.21.0",
-        "babel-plugin-syntax-hermes-parser": "^0.36.0",
+        "babel-plugin-syntax-hermes-parser": "^0.32.0",
         "babel-plugin-transform-flow-enums": "^0.0.2",
-        "debug": "^4.3.4"
+        "debug": "^4.3.4",
+        "resolve-from": "^5.0.0"
       },
       "peerDependencies": {
         "@babel/runtime": "^7.20.0",
         "expo": "*",
-        "expo-widgets": "^57.0.7",
+        "expo-widgets": "^55.0.14",
         "react-refresh": ">=0.14.0 <1.0.0"
       },
       "peerDependenciesMeta": {
@@ -6878,15 +7084,48 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.8.tgz",
-      "integrity": "sha512-zAgkquC2WYF0PIc6XbNYkA2uuxxFavzgmX61R+dHDUa558V8Ejf8ozTZFR6QzM24RWu4kBcRkhJ5kpz77j9fnQ==",
+      "version": "2.10.24",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/better-opn": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/better-opn/-/better-opn-3.0.2.tgz",
+      "integrity": "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "open": "^8.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/better-opn/node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/big-integer": {
@@ -6938,16 +7177,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -6963,9 +7202,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
-      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6982,10 +7221,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.44",
-        "caniuse-lite": "^1.0.30001806",
-        "electron-to-chromium": "^1.5.393",
-        "node-releases": "^2.0.51",
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -7105,9 +7344,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001806",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
-      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7222,9 +7461,10 @@
       }
     },
     "node_modules/chromium-edge-launcher": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.3.0.tgz",
-      "integrity": "sha512-p03azHlGjtyRvFEee3cyvtsRYdniSkwjkzmM/KmVnqT5d7QkkwpJBhis/zCLMYdQMVJ5tt140TBNqqrZPaWeFA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.2.0.tgz",
+      "integrity": "sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -7232,7 +7472,8 @@
         "escape-string-regexp": "^4.0.0",
         "is-wsl": "^2.2.0",
         "lighthouse-logger": "^1.0.0",
-        "mkdirp": "^1.0.4"
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
       }
     },
     "node_modules/ci-info": {
@@ -7822,6 +8063,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
@@ -7949,9 +8201,9 @@
       }
     },
     "node_modules/dnssd-advertise": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/dnssd-advertise/-/dnssd-advertise-1.1.6.tgz",
-      "integrity": "sha512-Ndrrf6BMPalkQPd/zubL+4YghH2J9NspapQ09uDXwYbvOPkP0oaqf5CkcwJ0b50kS2O3ul6yVu+jz+RY62Cejg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/dnssd-advertise/-/dnssd-advertise-1.1.4.tgz",
+      "integrity": "sha512-AmGyK9WpNf06WeP5TjHZq/wNzP76OuEeaiTlKr9E/EEelYLczywUKoqRz+DPRq/ErssjT4lU+/W7wzJW+7K/ZA==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -8026,9 +8278,9 @@
       "peer": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.398",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.398.tgz",
-      "integrity": "sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ==",
+      "version": "1.5.345",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.345.tgz",
+      "integrity": "sha512-F9JXQGiMrz6yVNPI2qOVPvB9HzjH5cGzhs8oJ6A28V5L/YnzN/0KsuiibqF+F1Fd9qxFzD1BUnYSd8JfULxTwg==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -8172,25 +8424,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es-abstract-get": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
-      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.2",
-        "is-callable": "^1.2.7",
-        "object-inspect": "^1.13.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -8212,9 +8445,9 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.4.0.tgz",
-      "integrity": "sha512-c/A0P0oxkACDc+cKWw8evLXK83oBKgn0qPOqCYT4x9uolpCIJAcYvJC9QYKNDRPsTeGyCrQ326jrvgZWdCdK5Q==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
+      "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8240,9 +8473,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8282,18 +8515,15 @@
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
-      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "es-abstract-get": "^1.0.0",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
         "is-callable": "^1.2.7",
-        "is-date-object": "^1.1.0",
-        "is-symbol": "^1.1.1"
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8353,9 +8583,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.5",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
-      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8364,8 +8594,8 @@
         "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.6",
-        "@eslint/js": "9.39.5",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -8448,14 +8678,14 @@
       }
     },
     "node_modules/eslint-import-resolver-node/node_modules/resolve": {
-      "version": "2.0.0-next.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
-      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+      "version": "2.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.2",
+        "is-core-module": "^2.16.1",
         "node-exports-info": "^1.6.0",
         "object-keys": "^1.1.1",
         "path-parse": "^1.0.7",
@@ -8472,9 +8702,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
-      "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8561,9 +8791,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8633,9 +8863,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-node/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8707,9 +8937,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8731,14 +8961,14 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
-      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+      "version": "2.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.2",
+        "is-core-module": "^2.16.1",
         "node-exports-info": "^1.6.0",
         "object-keys": "^1.1.1",
         "path-parse": "^1.0.7",
@@ -8845,9 +9075,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9031,36 +9261,36 @@
       }
     },
     "node_modules/expo": {
-      "version": "57.0.9",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-57.0.9.tgz",
-      "integrity": "sha512-NDEvnU+vjRdMbtOyDC25OSok9/E97al97pyx+bMphQgNRGAED0D7oF8ha7oGYsLE+7jFzpPADVM9S60dGbpHIA==",
+      "version": "55.0.18",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-55.0.18.tgz",
+      "integrity": "sha512-J3LVgN8ygERC0pmSjXfW2W/jlT18+VBek6vB9DBJiCNyrGKpSE4Kv9BH7VooiIMEizwwzsgDgXbDRWBS14IaKA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "^57.0.11",
-        "@expo/config": "~57.0.6",
-        "@expo/config-plugins": "~57.0.6",
-        "@expo/devtools": "~57.0.1",
-        "@expo/dom-webview": "~57.0.1",
-        "@expo/fingerprint": "^0.20.6",
-        "@expo/local-build-cache-provider": "^57.0.5",
-        "@expo/log-box": "^57.0.2",
-        "@expo/metro": "~56.0.0",
-        "@expo/metro-config": "~57.0.7",
+        "@expo/cli": "55.0.26",
+        "@expo/config": "~55.0.15",
+        "@expo/config-plugins": "~55.0.8",
+        "@expo/devtools": "55.0.2",
+        "@expo/fingerprint": "0.16.6",
+        "@expo/local-build-cache-provider": "55.0.11",
+        "@expo/log-box": "55.0.11",
+        "@expo/metro": "~55.1.0",
+        "@expo/metro-config": "55.0.17",
+        "@expo/vector-icons": "^15.0.2",
         "@ungap/structured-clone": "^1.3.0",
-        "babel-preset-expo": "~57.0.5",
-        "expo-asset": "~57.0.8",
-        "expo-constants": "~57.0.8",
-        "expo-file-system": "~57.0.1",
-        "expo-font": "~57.0.1",
-        "expo-keep-awake": "~57.0.1",
-        "expo-modules-autolinking": "~57.0.9",
-        "expo-modules-core": "~57.0.8",
+        "babel-preset-expo": "~55.0.18",
+        "expo-asset": "~55.0.16",
+        "expo-constants": "~55.0.15",
+        "expo-file-system": "~55.0.17",
+        "expo-font": "~55.0.6",
+        "expo-keep-awake": "~55.0.6",
+        "expo-modules-autolinking": "55.0.19",
+        "expo-modules-core": "55.0.23",
         "pretty-format": "^29.7.0",
         "react-refresh": "^0.14.2",
-        "whatwg-url-minimum": "^0.1.2"
+        "whatwg-url-minimum": "^0.1.1"
       },
       "bin": {
         "expo": "bin/cli",
@@ -9071,9 +9301,7 @@
         "@expo/dom-webview": "*",
         "@expo/metro-runtime": "*",
         "react": "*",
-        "react-dom": "*",
         "react-native": "*",
-        "react-native-web": "*",
         "react-native-webview": "*"
       },
       "peerDependenciesMeta": {
@@ -9083,27 +9311,21 @@
         "@expo/metro-runtime": {
           "optional": true
         },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native-web": {
-          "optional": true
-        },
         "react-native-webview": {
           "optional": true
         }
       }
     },
     "node_modules/expo-asset": {
-      "version": "57.0.8",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-57.0.8.tgz",
-      "integrity": "sha512-sGocG+Wd2WcZ1KjKyB2LfUZXzrBM0VHEATGcpJKF9T3HM56M/sMbH73vv+n85u5Zr0FkJjEbV1DWhGPimCR1QQ==",
+      "version": "55.0.16",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-55.0.16.tgz",
+      "integrity": "sha512-5IJyfJtYqvKGg04NKGQWiCIoK/fULDL9m15mXPPyfabD1jsToVj2hnWmo1r2SWNNmMwtQxi6jTpcGwVo2nLDxg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@expo/image-utils": "^0.11.4",
-        "expo-constants": "~57.0.8"
+        "@expo/image-utils": "^0.8.13",
+        "expo-constants": "~55.0.15"
       },
       "peerDependencies": {
         "expo": "*",
@@ -9126,14 +9348,14 @@
       }
     },
     "node_modules/expo-constants": {
-      "version": "57.0.8",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-57.0.8.tgz",
-      "integrity": "sha512-ts+B7E5076BtkblrKGy7+Sm/R2obHfTwqhmYQVYbWRtilv3+C/xNwHZhyNEnAvzM/JjKqx7UdaITUBYaeFreZw==",
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.15.tgz",
+      "integrity": "sha512-w394fcZLJjeKN+9ZnJzL/HiarE1nwZFDa+3S9frevh6Ur+MAAs9QDrcXhDrV8T3xqRzzYaqsP6Z8TFZ4efWN1A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@expo/env": "~2.4.2"
+        "@expo/env": "~2.1.1"
       },
       "peerDependencies": {
         "expo": "*",
@@ -9141,9 +9363,9 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "57.0.1",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-57.0.1.tgz",
-      "integrity": "sha512-w7/ERvQFrGP2apTO9lDtZ+O6JQIhfakL7+Xqzh+rfMO9B4LB4qwrz+YvLgir8KFRVX64JHBnRuYBVLY1oQZcqw==",
+      "version": "55.0.17",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-55.0.17.tgz",
+      "integrity": "sha512-d27K1cagUOt2BwxwPka9KW8Znu5kN1tnairozCzzCRZviZFtWnBxwFuJ3KU6MAbav/9UhSMkp5Ve/oZ+SR0UgQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -9153,9 +9375,9 @@
       }
     },
     "node_modules/expo-font": {
-      "version": "57.0.1",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-57.0.1.tgz",
-      "integrity": "sha512-QyS9L1Kh9sKJg4gfU6rdbpxpmH+DyzBX8z6jVvXMUDoqLr1GqmkO/Wu379KCXjL///kWbhpNlbi7AgBuj4VdIQ==",
+      "version": "55.0.6",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-55.0.6.tgz",
+      "integrity": "sha512-x9czUA3UQWjIwa0ZUEs/eWJNqB4mAue/m4ltESlNPLZhHL0nWWqIfsyHmklTLFH7mVfcHSJvew6k+pR2FE1zVw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -9169,9 +9391,9 @@
       }
     },
     "node_modules/expo-keep-awake": {
-      "version": "57.0.1",
-      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-57.0.1.tgz",
-      "integrity": "sha512-28lkFImeXTS+bhAjuCFV7w7tW5bXg27BJVrxv+nC/nyYa86qEa0oFeHwqol6ha5k4pdVDQgBF09GM4A1k76Ssg==",
+      "version": "55.0.6",
+      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-55.0.6.tgz",
+      "integrity": "sha512-acJjeHqkNxMVckEcJhGQeIksqqsarscSHJtT559bNgyiM4r14dViQ66su7bb6qDVeBt0K7z3glXI1dHVck1Zgg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -9251,9 +9473,9 @@
       }
     },
     "node_modules/expo-module-scripts/node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -9285,6 +9507,99 @@
       "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/expo-module-scripts/node_modules/@react-native/babel-plugin-codegen": {
+      "version": "0.74.87",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.74.87.tgz",
+      "integrity": "sha512-+vJYpMnENFrwtgvDfUj+CtVJRJuUnzAUYT0/Pb68Sq9RfcZ5xdcCuUgyf7JO+akW2VTBoJY427wkcxU30qrWWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@react-native/codegen": "0.74.87"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/expo-module-scripts/node_modules/@react-native/babel-preset": {
+      "version": "0.74.87",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.74.87.tgz",
+      "integrity": "sha512-hyKpfqzN2nxZmYYJ0tQIHG99FQO0OWXp/gVggAfEUgiT+yNKas1C60LuofUsK7cd+2o9jrpqgqW4WzEDZoBlTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.20.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+        "@babel/plugin-proposal-class-properties": "^7.18.0",
+        "@babel/plugin-proposal-export-default-from": "^7.0.0",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.18.0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.0",
+        "@babel/plugin-proposal-numeric-separator": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.0",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.20.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+        "@babel/plugin-syntax-export-default-from": "^7.0.0",
+        "@babel/plugin-syntax-flow": "^7.18.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.0.0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-async-to-generator": "^7.20.0",
+        "@babel/plugin-transform-block-scoping": "^7.0.0",
+        "@babel/plugin-transform-classes": "^7.0.0",
+        "@babel/plugin-transform-computed-properties": "^7.0.0",
+        "@babel/plugin-transform-destructuring": "^7.20.0",
+        "@babel/plugin-transform-flow-strip-types": "^7.20.0",
+        "@babel/plugin-transform-function-name": "^7.0.0",
+        "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
+        "@babel/plugin-transform-parameters": "^7.0.0",
+        "@babel/plugin-transform-private-methods": "^7.22.5",
+        "@babel/plugin-transform-private-property-in-object": "^7.22.11",
+        "@babel/plugin-transform-react-display-name": "^7.0.0",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-source": "^7.0.0",
+        "@babel/plugin-transform-runtime": "^7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+        "@babel/plugin-transform-spread": "^7.0.0",
+        "@babel/plugin-transform-sticky-regex": "^7.0.0",
+        "@babel/plugin-transform-typescript": "^7.5.0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0",
+        "@babel/template": "^7.0.0",
+        "@react-native/babel-plugin-codegen": "0.74.87",
+        "babel-plugin-transform-flow-enums": "^0.0.2",
+        "react-refresh": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/expo-module-scripts/node_modules/@react-native/codegen": {
+      "version": "0.74.87",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.74.87.tgz",
+      "integrity": "sha512-GMSYDiD+86zLKgMMgz9z0k6FxmRn+z6cimYZKkucW4soGbxWsbjUAZoZ56sJwt2FJ3XVRgXCrnOCgXoH/Bkhcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.0",
+        "glob": "^7.1.1",
+        "hermes-parser": "0.19.1",
+        "invariant": "^2.2.4",
+        "jscodeshift": "^0.14.0",
+        "mkdirp": "^0.5.1",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@babel/preset-env": "^7.1.6"
       }
     },
     "node_modules/expo-module-scripts/node_modules/@types/istanbul-reports": {
@@ -9626,9 +9941,9 @@
       "license": "MIT"
     },
     "node_modules/expo-module-scripts/node_modules/brace-expansion": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
-      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9751,14 +10066,14 @@
       }
     },
     "node_modules/expo-module-scripts/node_modules/eslint-plugin-prettier": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
-      "integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
+      "integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "prettier-linter-helpers": "^1.0.1",
-        "synckit": "^0.11.13"
+        "synckit": "^0.11.12"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -9826,9 +10141,9 @@
       }
     },
     "node_modules/expo-module-scripts/node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -9923,9 +10238,9 @@
       }
     },
     "node_modules/expo-module-scripts/node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9961,6 +10276,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expo-module-scripts/node_modules/hermes-estree": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.19.1.tgz",
+      "integrity": "sha512-daLGV3Q2MKk8w4evNMKwS8zBE/rcpA800nu1Q5kM08IKijoSnPe9Uo1iIxzPKRkn95IxxsgBMPeYHt3VG4ej2g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/expo-module-scripts/node_modules/hermes-parser": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.19.1.tgz",
+      "integrity": "sha512-Vp+bXzxYJWrpEuJ/vXxUsLnt0+y4q9zyi4zUlkLqD8FKv4LjIfOvP69R/9Lty3dCyKh0E2BU7Eypqr63/rKT/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.19.1"
       }
     },
     "node_modules/expo-module-scripts/node_modules/jsesc": {
@@ -10000,10 +10332,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/expo-module-scripts/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/expo-module-scripts/node_modules/prettier": {
-      "version": "3.9.6",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
-      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -10148,15 +10493,15 @@
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "57.0.9",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-57.0.9.tgz",
-      "integrity": "sha512-lj2nsAKMMRLXSFnGgaaQrWJ2fdSpLPc/bca6Rkiw4g8zYPn7qX4MRUJgavvzm/hBrzvMnlhXVgJtidOGuwBh+w==",
+      "version": "55.0.19",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-55.0.19.tgz",
+      "integrity": "sha512-rHO1NZC/bxcKTLzkn6WYm9ErzS6qp7Kgb1NM2YxXJAYRWHwW/M7NZXyj6swWiKxyhRpcdoppRpjrz1sBuYGAjg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@expo/require-utils": "^57.0.4",
-        "@expo/spawn-async": "^1.8.0",
+        "@expo/require-utils": "^55.0.4",
+        "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.1.0",
         "commander": "^7.2.0"
       },
@@ -10176,21 +10521,19 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "57.0.8",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-57.0.8.tgz",
-      "integrity": "sha512-ZUU943Oso3B8jFggC+2+LOk8oa+im66IQlleYay6WP5iexbdF2fqpgC4BcYsN4xhCkDKh7KDINSt1FlcxyRRjQ==",
+      "version": "55.0.23",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-55.0.23.tgz",
+      "integrity": "sha512-IGWT5N9MoV4zgWyrv686bElnKhzhE7E6pSazhaBNh3vgViAah5nnAz2o5h5YoUMR2B+ZTdHumRbGHN6gHLgwPA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@expo/expo-modules-macros-plugin": "0.6.1",
-        "expo-modules-jsi": "~57.0.4",
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
         "react": "*",
         "react-native": "*",
-        "react-native-worklets": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0"
+        "react-native-worklets": "^0.7.4 || ^0.8.0"
       },
       "peerDependenciesMeta": {
         "react-native-worklets": {
@@ -10198,21 +10541,10 @@
         }
       }
     },
-    "node_modules/expo-modules-jsi": {
-      "version": "57.0.4",
-      "resolved": "https://registry.npmjs.org/expo-modules-jsi/-/expo-modules-jsi-57.0.4.tgz",
-      "integrity": "sha512-vt7FyqUqqFXiRVnBqYD7y+GSPTgeua5Ocoy0+SYt+RSHkZEA2Fyop7If3g1TYDzQObYybPRo7TG2Rle1XLaWFw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "react-native": "*"
-      }
-    },
     "node_modules/expo-server": {
-      "version": "57.0.1",
-      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-57.0.1.tgz",
-      "integrity": "sha512-sBfVDH6dmKVHZxqUxbfkzS00PZELMZt1IpnHKxcOTMZtR/t7CtRAFrbXcisG+EyzeqHSVDacZT+1tbYfZt5D8w==",
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-55.0.8.tgz",
+      "integrity": "sha512-AoV5TKuO4biSzrhe/OVLyInfTT0pV9/OOc/g/oVq5vmCjL8SaSYTkES8PLt+67Tm7VqX+Dn0+kSx1nQcjEKaPw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -10221,14 +10553,14 @@
       }
     },
     "node_modules/expo/node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -10237,22 +10569,22 @@
       }
     },
     "node_modules/expo/node_modules/@expo/config-plugins": {
-      "version": "57.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-57.0.6.tgz",
-      "integrity": "sha512-7CmKrS5Rnu8aSZyNlxH2qzA7Ls1HEa4EQvEVOAkHDKPr1e4Cg/nz7I7dUl09QDTVjMvkKYDH4Th0DuAsgqASaw==",
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.8.tgz",
+      "integrity": "sha512-8WfWTRntTCcowfOS+tHdB0z98gKetTwktg4G5TWkCkXVa8Jt1NUnvzaaU4UHk2vbR2U4N84RyZJFizSwfF6C9g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@expo/config-types": "^57.0.2",
-        "@expo/json-file": "~11.0.1",
-        "@expo/plist": "^0.8.1",
-        "@expo/require-utils": "^57.0.4",
+        "@expo/config-types": "^55.0.5",
+        "@expo/json-file": "~10.0.13",
+        "@expo/plist": "^0.5.2",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.5",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
+        "resolve-from": "^5.0.0",
         "semver": "^7.5.4",
         "slugify": "^1.6.6",
         "xcode": "^3.0.1",
@@ -10260,17 +10592,17 @@
       }
     },
     "node_modules/expo/node_modules/@expo/config-types": {
-      "version": "57.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-57.0.2.tgz",
-      "integrity": "sha512-ewW08OonrcRIsRKIlFvvcmmafE5zemb1ocu3HkNwtVPyRtj2w42pZCAkMIROYpcVBaPnc3mDT9UZDzwXWC3i6g==",
+      "version": "55.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-55.0.5.tgz",
+      "integrity": "sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/expo/node_modules/@expo/json-file": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-11.0.1.tgz",
-      "integrity": "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ==",
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.13.tgz",
+      "integrity": "sha512-pX/XjQn7tgNw6zuuV2ikmegmwe/S7uiwhrs2wXrANMkq7ozrA+JcZwgW9Q/8WZgciBzfAhNp5hnackHcrmapQA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -10280,9 +10612,9 @@
       }
     },
     "node_modules/expo/node_modules/@expo/plist": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.8.1.tgz",
-      "integrity": "sha512-3gTReGIUm0oRaMClsAJYxBnVPCl6fVpsl8HS+DTVxDhW4GyVyxg9E/Znm3BvcHtUJ51RJJI14pC1wvrNilCRHw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.5.2.tgz",
+      "integrity": "sha512-o4xdVdBpe4aTl3sPMZ2u3fJH4iG1I768EIRk1xRZP+GaFI93MaR3JvoFibYqxeTmLQ1p1kNEVqylfUjezxx45g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -10312,9 +10644,9 @@
       }
     },
     "node_modules/expo/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "peer": true,
@@ -10406,9 +10738,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "dev": true,
       "funding": [
         {
@@ -10682,9 +11014,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
-      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -10695,25 +11027,12 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/flow-estree": {
-      "version": "0.325.0",
-      "resolved": "https://registry.npmjs.org/flow-estree/-/flow-estree-0.325.0.tgz",
-      "integrity": "sha512-HnYTpF6Al3YZpiPwket4x33V7iXSUgyqmtOz9FvgGBRKfBzZre/A3sRpXN1Jsq1VeRson1ToHJn+EosHemaPpQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/flow-parser": {
-      "version": "0.325.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.325.0.tgz",
-      "integrity": "sha512-3uJxDHNXuiNM5twT+tk0iIn8zdSkF67cmE/6SoWFbmxcX7BnI82qYeJSEhrfNnDx7TwhAVPnLqV7MCt+biVwZw==",
+      "version": "0.312.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.312.0.tgz",
+      "integrity": "sha512-y1iG1bU7i22Mc3sSlchhmV992o8vxzwFLy6K1ZZqbmfXf0qpljN1/AZRuhOA+8uMz8a5iQUdoUyT7pvmdN1flA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "flow-estree": "0.325.0"
-      },
       "engines": {
         "node": ">=0.4.0"
       }
@@ -10760,17 +11079,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
       },
       "engines": {
         "node": ">= 6"
@@ -10787,9 +11106,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
-      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -10840,21 +11159,18 @@
       }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
-      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.9",
-        "call-bound": "^1.0.4",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
         "functions-have-names": "^1.2.3",
-        "has-property-descriptors": "^1.0.2",
-        "hasown": "^2.0.4",
-        "is-callable": "^1.2.7",
-        "is-document.all": "^1.0.0"
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11034,9 +11350,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
-      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11252,9 +11568,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11265,29 +11581,29 @@
       }
     },
     "node_modules/hermes-compiler": {
-      "version": "250829098.0.16",
-      "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.16.tgz",
-      "integrity": "sha512-xsgzk+mUyvt9t1nUbF8USBlYxajTUtPJhVZ86q85s/SEoMKCF+52YZcudb0ENSnV3T3lV9mgB3s6R7+pH90zgw==",
+      "version": "250829098.0.10",
+      "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.10.tgz",
+      "integrity": "sha512-TcRlZ0/TlyfJqquRFAWoyElVNnkdYRi/sEp4/Qy8/GYxjg8j2cS9D4MjuaQ+qimkmLN7AmO+44IznRf06mAr0w==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/hermes-estree": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.36.1.tgz",
-      "integrity": "sha512-guv1nQ6IJ7S83NRFPWc3SA7IBZrdNC9kapwOq6uXvF4wP+sDCgjzQbKPCoyYmoyZRzztF/n/c36l/rccCZSiCw==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.1.tgz",
+      "integrity": "sha512-ne5hkuDxheNBAikDjqvCZCwihnz0vVu9YsBzAEO1puiyFR4F1+PAz/SiPHSsNTuOveCYGRMX8Xbx4LOubeC0Qg==",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/hermes-parser": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.36.1.tgz",
-      "integrity": "sha512-GApNk4zLHi2UWoWZZkx7LNCOSzLSc5lB55pZ/PhK7ycFeg7u5LcF88p/WbpIi1XUDtE0MpHE3uRR3u3KB7TjSQ==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.1.tgz",
+      "integrity": "sha512-175dz634X/W5AiwrpLdoMl/MOb17poLHyIqgyExlE8D9zQ1OPnoORnGMB5ltRKnpvQzBjMYvT2rN/sHeIfZW5Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "hermes-estree": "0.36.1"
+        "hermes-estree": "0.32.1"
       }
     },
     "node_modules/hosted-git-info": {
@@ -11680,13 +11996,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
-      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.3"
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11744,22 +12060,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-document.all": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
-      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -12597,9 +12897,9 @@
       "license": "MIT"
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12852,9 +13152,9 @@
       "license": "MIT"
     },
     "node_modules/jest-expo/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13076,13 +13376,13 @@
       }
     },
     "node_modules/jest-message-util/node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -13201,6 +13501,17 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/jest-runtime": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
@@ -13243,9 +13554,9 @@
       "license": "MIT"
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13579,20 +13890,10 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -13887,9 +14188,9 @@
       "peer": true
     },
     "node_modules/lightningcss": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
-      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
       "peer": true,
@@ -13904,23 +14205,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.33.0",
-        "lightningcss-darwin-arm64": "1.33.0",
-        "lightningcss-darwin-x64": "1.33.0",
-        "lightningcss-freebsd-x64": "1.33.0",
-        "lightningcss-linux-arm-gnueabihf": "1.33.0",
-        "lightningcss-linux-arm64-gnu": "1.33.0",
-        "lightningcss-linux-arm64-musl": "1.33.0",
-        "lightningcss-linux-x64-gnu": "1.33.0",
-        "lightningcss-linux-x64-musl": "1.33.0",
-        "lightningcss-win32-arm64-msvc": "1.33.0",
-        "lightningcss-win32-x64-msvc": "1.33.0"
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
-      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
       ],
@@ -13940,9 +14241,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
-      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
       ],
@@ -13962,9 +14263,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
-      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
       ],
@@ -13984,9 +14285,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
-      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
       ],
@@ -14006,9 +14307,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
-      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
       ],
@@ -14028,9 +14329,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
-      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
       ],
@@ -14050,9 +14351,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
-      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
       ],
@@ -14072,9 +14373,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
-      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
       ],
@@ -14094,9 +14395,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
-      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
       ],
@@ -14116,9 +14417,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
-      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
       ],
@@ -14138,9 +14439,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
-      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
       ],
@@ -14418,9 +14719,10 @@
       }
     },
     "node_modules/metro": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.84.4.tgz",
-      "integrity": "sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.7.tgz",
+      "integrity": "sha512-SPaPEyvTsTmd0LpT7RaZciQyDw2i/JB7+iY9L5VfBo72+psescFxBqpI1TL9dnL+pmnfkU+l/J1mEEGLeF65EQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14444,18 +14746,18 @@
         "jest-worker": "^29.7.0",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.84.4",
-        "metro-cache": "0.84.4",
-        "metro-cache-key": "0.84.4",
-        "metro-config": "0.84.4",
-        "metro-core": "0.84.4",
-        "metro-file-map": "0.84.4",
-        "metro-resolver": "0.84.4",
-        "metro-runtime": "0.84.4",
-        "metro-source-map": "0.84.4",
-        "metro-symbolicate": "0.84.4",
-        "metro-transform-plugins": "0.84.4",
-        "metro-transform-worker": "0.84.4",
+        "metro-babel-transformer": "0.83.7",
+        "metro-cache": "0.83.7",
+        "metro-cache-key": "0.83.7",
+        "metro-config": "0.83.7",
+        "metro-core": "0.83.7",
+        "metro-file-map": "0.83.7",
+        "metro-resolver": "0.83.7",
+        "metro-runtime": "0.83.7",
+        "metro-source-map": "0.83.7",
+        "metro-symbolicate": "0.83.7",
+        "metro-transform-plugins": "0.83.7",
+        "metro-transform-worker": "0.83.7",
         "mime-types": "^3.0.1",
         "nullthrows": "^1.1.1",
         "serialize-error": "^2.1.0",
@@ -14468,30 +14770,32 @@
         "metro": "src/cli.js"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.84.4.tgz",
-      "integrity": "sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.7.tgz",
+      "integrity": "sha512-sBqBkt6kNut/88bv+Ucvm4yqdPetbvAEsHzi3MAgJEifOSYYzX5Z5Kgw3TFOrwf/mHJTOBG2ONlaMHoyfP15TA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
         "hermes-parser": "0.35.0",
-        "metro-cache-key": "0.84.4",
+        "metro-cache-key": "0.83.7",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-babel-transformer/node_modules/hermes-estree": {
       "version": "0.35.0",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
       "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -14499,6 +14803,7 @@
       "version": "0.35.0",
       "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
       "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14506,38 +14811,41 @@
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.84.4.tgz",
-      "integrity": "sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.7.tgz",
+      "integrity": "sha512-E9SRePXQ1Zvlj79VcOk57q7VC7rMHMFQ+jhmPHBiq+dJ0bJB5BL87lWZF6oh5X76Cci5tpDuQNaDwwuSCToEeg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "exponential-backoff": "^3.1.1",
         "flow-enums-runtime": "^0.0.6",
         "https-proxy-agent": "^7.0.5",
-        "metro-core": "0.84.4"
+        "metro-core": "0.83.7"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.84.4.tgz",
-      "integrity": "sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.7.tgz",
+      "integrity": "sha512-W1c2Nmx8MiJTJt+eWhMO08z9VKi3kZOaz99IYGdqeqDgY9j+yZjXl62rUav4Di0heZfh4/n2s722PqRL1OODeg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-cache/node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -14548,6 +14856,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14559,44 +14868,47 @@
       }
     },
     "node_modules/metro-config": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.84.4.tgz",
-      "integrity": "sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.7.tgz",
+      "integrity": "sha512-83mjWFbFOt2GeJ6pFIum5mSnc1uTsZJAtD8o4ej0s4NVsYsA7fB+pHvTfHhFrpeMONaobu2riKavkPei05Er/Q==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "connect": "^3.6.5",
         "flow-enums-runtime": "^0.0.6",
         "jest-validate": "^29.7.0",
-        "metro": "0.84.4",
-        "metro-cache": "0.84.4",
-        "metro-core": "0.84.4",
-        "metro-runtime": "0.84.4",
+        "metro": "0.83.7",
+        "metro-cache": "0.83.7",
+        "metro-core": "0.83.7",
+        "metro-runtime": "0.83.7",
         "yaml": "^2.6.1"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-core": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.84.4.tgz",
-      "integrity": "sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.7.tgz",
+      "integrity": "sha512-6yn3w1wnltT6RQl7p7YES2l95ArC+mWrOssEiH8p5/DDrJS65/szf9LsC9JrBv8c5DdvSY3V3f0GRYg0Ox7hCg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.84.4"
+        "metro-resolver": "0.83.7"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.84.4.tgz",
-      "integrity": "sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.7.tgz",
+      "integrity": "sha512-+j0F1m+FQYVAQ6syf+mwhIPV5GoFQrkInX8bppuc50IzNsZbMrp8R5H/Sx/K2daQ3YEa9F/XwkeZT8gzJfgeCw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14611,13 +14923,14 @@
         "walker": "^1.0.7"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.84.4.tgz",
-      "integrity": "sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.7.tgz",
+      "integrity": "sha512-MfJar2IS4tBRuLb9svwb0Gu5l9BsH+pcRm8eGcEi/wy8MzZinfinh5dFLt2nWkocnulIgtGB5NkFDdbXqMXKhQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14625,26 +14938,28 @@
         "terser": "^5.15.0"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.84.4.tgz",
-      "integrity": "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.7.tgz",
+      "integrity": "sha512-WSJIENlMcoSsuz66IfBHOkgfp3KJt2UW2TnEHPf1b8pIG2eEXNOVmo2+03A0H17WY2XGXWgxL0CG7FAopqgB1A==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz",
-      "integrity": "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.7.tgz",
+      "integrity": "sha512-9GKkJURaB2iyYoEExKnedzAHzxmKtSi+k0tsZUvMoU27tBZJElchYt7JH/Ai/XzYAI9lCAaV7u5HZSI8J5Z+wQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14652,13 +14967,14 @@
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
-      "integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.7.tgz",
+      "integrity": "sha512-JgA1h7oc1a1jydBe1GhVFsUoMYo3wLPk7oRA32rjlDsq+sP2JLt9x2p2lWbNSxTm/u8NV4VRid3hvEJgcX8tKw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14666,20 +14982,21 @@
         "@babel/types": "^7.29.0",
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.84.4",
+        "metro-symbolicate": "0.83.7",
         "nullthrows": "^1.1.1",
-        "ob1": "0.84.4",
+        "ob1": "0.83.7",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-source-map/node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
@@ -14687,15 +15004,16 @@
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.4.tgz",
-      "integrity": "sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.7.tgz",
+      "integrity": "sha512-g4suyxw20WOHWI680c+Kq4wC/NF+Hx5pRH9afrMp+sMTxqLeKcPR1Xf4wMhsjlbvx7LbIREdke6q928jEjvJWw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.84.4",
+        "metro-source-map": "0.83.7",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
@@ -14704,13 +15022,14 @@
         "metro-symbolicate": "src/index.js"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-symbolicate/node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
@@ -14718,9 +15037,10 @@
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.84.4.tgz",
-      "integrity": "sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.7.tgz",
+      "integrity": "sha512-Ss0FpBiZDjX2kwhukMDl5sNdYK8T/06IPqxNE4H6PTlRlfs9q11cef13c/xESY/Pm4VCkp1yJUZO3kXzvMxQFA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14732,13 +15052,14 @@
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.84.4.tgz",
-      "integrity": "sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.7.tgz",
+      "integrity": "sha512-UegCo7ygB2fT64mRK2nbAjQVJ1zSwIIHy8d96jJv2nKZFDaViYBiughEdu5HM/Ceq0WN3LZrZk3zhl9aoiLYFw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14747,27 +15068,28 @@
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
         "flow-enums-runtime": "^0.0.6",
-        "metro": "0.84.4",
-        "metro-babel-transformer": "0.84.4",
-        "metro-cache": "0.84.4",
-        "metro-cache-key": "0.84.4",
-        "metro-minify-terser": "0.84.4",
-        "metro-source-map": "0.84.4",
-        "metro-transform-plugins": "0.84.4",
+        "metro": "0.83.7",
+        "metro-babel-transformer": "0.83.7",
+        "metro-cache": "0.83.7",
+        "metro-cache-key": "0.83.7",
+        "metro-minify-terser": "0.83.7",
+        "metro-source-map": "0.83.7",
+        "metro-transform-plugins": "0.83.7",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro/node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -14779,6 +15101,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14793,6 +15116,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -14800,6 +15124,7 @@
       "version": "0.35.0",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
       "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -14807,6 +15132,7 @@
       "version": "0.35.0",
       "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
       "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14817,6 +15143,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14834,6 +15161,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -14844,6 +15172,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
@@ -14851,9 +15180,10 @@
       }
     },
     "node_modules/metro/node_modules/ws": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
-      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -15029,9 +15359,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -15094,9 +15424,9 @@
       "license": "MIT"
     },
     "node_modules/node-dir/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15118,9 +15448,9 @@
       }
     },
     "node_modules/node-exports-info": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
-      "integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15164,13 +15494,10 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
-      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -15219,23 +15546,24 @@
       "license": "MIT"
     },
     "node_modules/nwsapi": {
-      "version": "2.2.24",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
-      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ob1": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.4.tgz",
-      "integrity": "sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.7.tgz",
+      "integrity": "sha512-9M5kpuOLyTPogMtZiQUIxdAZxl7Dxs6tVBbJErSumsqGMuhVSoUbkfeZ3XNPpLpwBBtqY5QDUzGwggLHX3slQg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/object-assign": {
@@ -15576,14 +15904,13 @@
       }
     },
     "node_modules/own-keys": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
-      "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.4",
-        "get-intrinsic": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "object-keys": "^1.1.1",
         "safe-push-apply": "^1.0.0"
       },
@@ -15805,9 +16132,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -15952,9 +16279,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.25",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
-      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
       "dev": true,
       "funding": [
         {
@@ -15973,7 +16300,7 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -16211,9 +16538,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
-      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -16232,9 +16559,9 @@
       }
     },
     "node_modules/react-devtools-core/node_modules/ws": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
-      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -16277,31 +16604,31 @@
       "license": "MIT"
     },
     "node_modules/react-native": {
-      "version": "0.86.2",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.86.2.tgz",
-      "integrity": "sha512-zbJXGZpwfZGA79Z9ob6Atvfx4nAQL8yJBa35s58E4Oo+khPykfQP2sTeumkKbjwajFYfVayg8pj7Il9nIfTk7A==",
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.85.2.tgz",
+      "integrity": "sha512-GFWEPwLYirfj5X8gMtXOWtqX0cqUEURRHETZfFk37VCa4++izrKvGvv24anvuyulXV87NAhVkfNw93rLg3HByw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@react-native/assets-registry": "0.86.2",
-        "@react-native/codegen": "0.86.2",
-        "@react-native/community-cli-plugin": "0.86.2",
-        "@react-native/gradle-plugin": "0.86.2",
-        "@react-native/js-polyfills": "0.86.2",
-        "@react-native/normalize-colors": "0.86.2",
-        "@react-native/virtualized-lists": "0.86.2",
+        "@react-native/assets-registry": "0.85.2",
+        "@react-native/codegen": "0.85.2",
+        "@react-native/community-cli-plugin": "0.85.2",
+        "@react-native/gradle-plugin": "0.85.2",
+        "@react-native/js-polyfills": "0.85.2",
+        "@react-native/normalize-colors": "0.85.2",
+        "@react-native/virtualized-lists": "0.85.2",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
-        "babel-plugin-syntax-hermes-parser": "0.36.0",
+        "babel-plugin-syntax-hermes-parser": "0.33.3",
         "base64-js": "^1.5.1",
         "commander": "^12.0.0",
         "flow-enums-runtime": "^0.0.6",
-        "hermes-compiler": "250829098.0.16",
+        "hermes-compiler": "250829098.0.10",
         "invariant": "^2.2.4",
         "memoize-one": "^5.0.0",
-        "metro-runtime": "^0.84.3",
-        "metro-source-map": "^0.84.3",
+        "metro-runtime": "^0.84.0",
+        "metro-source-map": "^0.84.0",
         "nullthrows": "^1.1.1",
         "pretty-format": "^29.7.0",
         "promise": "^8.3.0",
@@ -16323,7 +16650,7 @@
         "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       },
       "peerDependencies": {
-        "@react-native/jest-preset": "0.86.2",
+        "@react-native/jest-preset": "0.85.2",
         "@types/react": "^19.1.1",
         "react": "^19.2.3"
       },
@@ -16381,9 +16708,9 @@
       "license": "MIT"
     },
     "node_modules/react-native-builder-bob/node_modules/brace-expansion": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
-      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16456,14 +16783,43 @@
         "node": ">=10"
       }
     },
-    "node_modules/react-native/node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.36.0.tgz",
-      "integrity": "sha512-LhD0xdoedDw7ansQgXbB2DADLZIK/LRXuWNBPuVzMc5S2WK5GyT89tCM+cQzxFGO0mGyLK6D5TrVOJJzAoDy8Q==",
+    "node_modules/react-native/node_modules/@react-native/codegen": {
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.85.2.tgz",
+      "integrity": "sha512-XCginmxh0//++EXVOEJHBVZxHla294FzLCFF6jXwAUjvXVhqyIKyxhABfz+r4OOmaiuWk4Rtd4arqdAzeHeprg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "hermes-parser": "0.36.0"
+        "@babel/core": "^7.25.2",
+        "@babel/parser": "^7.29.0",
+        "hermes-parser": "0.33.3",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "tinyglobby": "^0.2.15",
+        "yargs": "^17.6.2"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/react-native/node_modules/@react-native/normalize-colors": {
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.85.2.tgz",
+      "integrity": "sha512-svuOLtjbFGXDdHsriHXuND5FgHg7XlkOXCbH/8+X4t76YLH6qSTffSIQQrKLDL5mn4EFU+Oh/PNO0/FfpnTOTg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-native/node_modules/babel-plugin-syntax-hermes-parser": {
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.33.3.tgz",
+      "integrity": "sha512-/Z9xYdaJ1lC0pT9do6TqCqhOSLfZ5Ot8D5za1p+feEfWYupCOfGbhhEXN9r2ZgJtDNUNRw/Z+T2CvAGKBqtqWA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hermes-parser": "0.33.3"
       }
     },
     "node_modules/react-native/node_modules/commander": {
@@ -16477,26 +16833,105 @@
       }
     },
     "node_modules/react-native/node_modules/hermes-estree": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.36.0.tgz",
-      "integrity": "sha512-A1+8zn5oss2CFP7pKsOaxorQG6FNIz1WU1VDqruLPPZl3LVgeE2C5xfFg8Ow6/Ow4mSslLLtYP1J3n38eKyW9w==",
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.33.3.tgz",
+      "integrity": "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/react-native/node_modules/hermes-parser": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.36.0.tgz",
-      "integrity": "sha512-GdpwMmH5x6IpC1cijvcvYnlPB60Mh6kTSF/NFdYV/j56gYdi+0RIakYs+eqOV+bbO0SW7mgVVGSsTJxyPQfo3w==",
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.33.3.tgz",
+      "integrity": "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "hermes-estree": "0.36.0"
+        "hermes-estree": "0.33.3"
+      }
+    },
+    "node_modules/react-native/node_modules/metro-runtime": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz",
+      "integrity": "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro-source-map": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
+      "integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-symbolicate": "0.84.4",
+        "nullthrows": "^1.1.1",
+        "ob1": "0.84.4",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro-symbolicate": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.4.tgz",
+      "integrity": "sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-source-map": "0.84.4",
+        "nullthrows": "^1.1.1",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "bin": {
+        "metro-symbolicate": "src/index.js"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/ob1": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.4.tgz",
+      "integrity": "sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react-native/node_modules/ws": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
-      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -16678,9 +17113,9 @@
       "license": "MIT"
     },
     "node_modules/regjsparser": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.2.tgz",
-      "integrity": "sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+      "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -16863,9 +17298,9 @@
       "license": "MIT"
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17017,9 +17452,9 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
-      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -17047,9 +17482,9 @@
       "peer": true
     },
     "node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -17260,9 +17695,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
-      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -17273,15 +17708,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
-      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4",
-        "side-channel-list": "^1.0.1",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -17434,10 +17869,9 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -17711,20 +18145,19 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
-      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.9",
-        "call-bound": "^1.0.4",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
         "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.24.2",
-        "es-object-atoms": "^1.1.2",
-        "has-property-descriptors": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -17734,16 +18167,16 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
-      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.9",
-        "call-bound": "^1.0.4",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
         "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.1.2"
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -17885,9 +18318,9 @@
       "license": "MIT"
     },
     "node_modules/sucrase/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18005,13 +18438,13 @@
       "license": "MIT"
     },
     "node_modules/synckit": {
-      "version": "0.11.13",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
-      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
+      "version": "0.11.12",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.3.6"
+        "@pkgr/core": "^0.2.9"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -18041,9 +18474,9 @@
       "license": "MIT"
     },
     "node_modules/temp/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18119,9 +18552,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
-      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
+      "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
@@ -18135,17 +18568,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/test-exclude": {
@@ -18171,9 +18593,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18255,9 +18677,9 @@
       "peer": true
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -18376,9 +18798,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/ts-jest": {
-      "version": "29.4.12",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
-      "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18388,7 +18810,7 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.8.5",
+        "semver": "^7.7.4",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -18578,18 +19000,18 @@
       }
     },
     "node_modules/typed-array-length": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
-      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.9",
-        "for-each": "^0.3.5",
-        "gopd": "^1.2.0",
-        "is-typed-array": "^1.1.15",
-        "possible-typed-array-names": "^1.1.0",
-        "reflect.getprototypeof": "^1.0.10"
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -18613,16 +19035,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
-      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.1.tgz",
+      "integrity": "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.65.0",
-        "@typescript-eslint/parser": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0"
+        "@typescript-eslint/eslint-plugin": "8.59.1",
+        "@typescript-eslint/parser": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -18680,9 +19102,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -18953,9 +19375,9 @@
       }
     },
     "node_modules/whatwg-url-minimum": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/whatwg-url-minimum/-/whatwg-url-minimum-0.1.2.tgz",
-      "integrity": "sha512-XPEm0XFQWNVG292lII1PrRRJl3sItrs7CettZ4ncYxuDVpLyy+NwlGyut2hXI0JswcJUxeCH+CyOJK0ZzAXD6A==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url-minimum/-/whatwg-url-minimum-0.1.1.tgz",
+      "integrity": "sha512-u2FNVjFVFZhdjb502KzXy1gKn1mEisQRJssmSJT8CPhZdZa0AP6VCbWlXERKyGu0l09t0k50FiDiralpGhBxgA==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -19043,14 +19465,14 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.22",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
-      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.9",
+        "call-bind": "^1.0.8",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",
@@ -19213,9 +19635,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -19315,9 +19737,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "peer": true,
       "bin": {
@@ -19331,9 +19753,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.3",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
-      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",

--- a/plugin/src/android/withCIOAndroid.ts
+++ b/plugin/src/android/withCIOAndroid.ts
@@ -2,12 +2,16 @@ import type { ExpoConfig } from '@expo/config-types';
 
 import type {
   CustomerIOPluginOptionsAndroid,
+  CustomerIOPluginLiveNotificationsOptions,
   CustomerIOPluginLocationOptions,
   NativeSDKConfig,
 } from '../types/cio-types';
 import { withAndroidManifestUpdates } from './withAndroidManifestUpdates';
 import { withAppGoogleServices } from './withAppGoogleServices';
 import { withGoogleServicesJSON } from './withGoogleServicesJSON';
+import { withLiveNotificationCallbackRegistration } from './withLiveNotificationCallbackRegistration';
+import { withLiveNotificationCustomRenderer } from './withLiveNotificationCustomRenderer';
+import { withLiveNotificationLogo } from './withLiveNotificationLogo';
 import { withLocationGradleProperties } from './withLocationGradleProperties';
 import { withMainApplicationModifications } from './withMainApplicationModifications';
 import { withNotificationChannelMetadata } from './withNotificationChannelMetadata';
@@ -20,6 +24,7 @@ export function withCIOAndroid(
   sdkConfig?: NativeSDKConfig,
   props?: CustomerIOPluginOptionsAndroid,
   location?: CustomerIOPluginLocationOptions,
+  liveNotifications?: CustomerIOPluginLiveNotificationsOptions,
 ): ExpoConfig {
   // Only run notification setup if props are provided
   if (props) {
@@ -36,7 +41,35 @@ export function withCIOAndroid(
 
   // Add auto initialization if sdkConfig is provided
   if (sdkConfig) {
-    config = withMainApplicationModifications(config, { sdkConfig, location });
+    config = withMainApplicationModifications(config, {
+      sdkConfig,
+      location,
+      liveNotifications,
+    });
+  } else {
+    // Only for JavaScript-initialized apps. With automatic initialization the generated initializer
+    // sets the render callback on the push config itself, so registering the wrapper's static too
+    // would be dead code — that path never reads it.
+    config = withLiveNotificationCallbackRegistration(config, liveNotifications);
+  }
+
+  // Outside the `sdkConfig` split on purpose, exactly like the branding logo: both paths above name
+  // the app's renderer class in generated Kotlin, and neither compiles unless the file is copied in.
+  config = withLiveNotificationCustomRenderer(config, {
+    liveNotifications,
+    sdkLiveNotifications: sdkConfig?.liveNotifications,
+  });
+
+  // Outside the `sdkConfig` block on purpose: a local branding logo has to become a drawable even
+  // when the app initializes from JavaScript, because the branding it passes to `CustomerIO.initialize`
+  // names that drawable and nothing else would put it in the project.
+  //
+  // Deliberately not gated on `isLiveNotificationsEnabled` either: that flag decides whether to
+  // generate the *iOS* build-time artifacts, and Android needs none of them. An Android app can use
+  // Live Notifications entirely from JavaScript without ever setting it, so requiring it here would
+  // reintroduce the missing-drawable gap on exactly the path this is meant to cover.
+  if (liveNotifications?.branding) {
+    config = withLiveNotificationLogo(config, liveNotifications.branding);
   }
 
   // Update project strings for user agent metadata

--- a/plugin/src/android/withLiveNotificationCallbackRegistration.ts
+++ b/plugin/src/android/withLiveNotificationCallbackRegistration.ts
@@ -1,0 +1,56 @@
+import type { ConfigPlugin } from '@expo/config-plugins';
+import { withMainApplication } from '@expo/config-plugins';
+
+import { CIO_MAINAPPLICATION_ONCREATE_REGEX } from '../helpers/constants/android';
+import { resolveCustomLiveNotificationRenderer } from '../helpers/utils/liveNotificationCustomRenderer';
+import type { CustomerIOPluginLiveNotificationsOptions } from '../types/cio-types';
+import { addCodeToMethod, addImportToFile } from '../utils/android';
+
+const WRAPPER_CLASS = 'NativeLiveActivitiesModule';
+const WRAPPER_IMPORT = `import io.customer.reactnative.sdk.liveactivities.${WRAPPER_CLASS}`;
+
+/**
+ * Registers the app's custom render callback from `MainApplication.onCreate`, for apps that
+ * initialize the SDK from JavaScript.
+ *
+ * The automatic-initialization path does not need this: its generated initializer sets the callback
+ * on the push module config directly (see `patchLiveNotificationCode`). A JavaScript-initialized app
+ * has no such initializer — the SDK is built later, from JavaScript, through the React Native
+ * wrapper — and the wrapper applies whatever static callback was registered before that happens.
+ * `onCreate` is the only place guaranteed to run first, and it runs in every process, including one
+ * Android starts solely to deliver a push.
+ */
+export const withLiveNotificationCallbackRegistration: ConfigPlugin<
+  CustomerIOPluginLiveNotificationsOptions | undefined
+> = (configOuter, liveNotifications) => {
+  return withMainApplication(configOuter, async (config) => {
+    // Silent: withLiveNotificationCustomRenderer runs the same resolution and owns the warnings.
+    // `customType` is not visible on this path — it reaches the SDK from JavaScript — so pass none
+    // and let a configured renderer stand on its own.
+    const renderer = resolveCustomLiveNotificationRenderer({
+      liveNotifications: undefined,
+      buildOptions: liveNotifications,
+      projectRoot: config.modRequest.projectRoot,
+      silent: true,
+    });
+    if (!renderer) return config;
+
+    const registration = `${WRAPPER_CLASS}.setLiveNotificationCallback(${renderer.className}())`;
+    let contents = config.modResults.contents;
+    if (!contents.includes(registration)) {
+      contents = addCodeToMethod(
+        contents,
+        CIO_MAINAPPLICATION_ONCREATE_REGEX,
+        registration
+      );
+    }
+    contents = addImportToFile(contents, WRAPPER_IMPORT);
+    contents = addImportToFile(
+      contents,
+      `import ${renderer.classPackage}.${renderer.className}`
+    );
+
+    config.modResults.contents = contents;
+    return config;
+  });
+};

--- a/plugin/src/android/withLiveNotificationCustomRenderer.ts
+++ b/plugin/src/android/withLiveNotificationCustomRenderer.ts
@@ -1,0 +1,47 @@
+import type { ConfigPlugin } from '@expo/config-plugins';
+import { withProjectBuildGradle } from '@expo/config-plugins';
+
+import {
+  installAndroidCustomLiveNotificationRenderer,
+  resolveCustomLiveNotificationRenderer,
+} from '../helpers/utils/liveNotificationCustomRenderer';
+import type {
+  CustomerIOPluginLiveNotificationsOptions,
+  LiveNotificationsSDKConfig,
+} from '../types/cio-types';
+
+type CustomRendererModParams = {
+  /** Build-time options carrying `customRenderer`. */
+  liveNotifications: CustomerIOPluginLiveNotificationsOptions | undefined;
+  /** SDK config, read only for `customType` — present only on the auto-initialization path. */
+  sdkLiveNotifications: LiveNotificationsSDKConfig | undefined;
+};
+
+/**
+ * Copies the configured custom live notification renderer into the Android source tree.
+ *
+ * Runs on both initialization paths, like the branding logo and for the same reason: the class is
+ * referenced by generated Kotlin on the automatic path and by the `MainApplication` registration on
+ * the JavaScript path, and neither compiles unless the file is in the project.
+ *
+ * Piggybacks on the project build.gradle mod purely for its access to the Android project root,
+ * matching how the google-services file and the branding logo are copied.
+ */
+export const withLiveNotificationCustomRenderer: ConfigPlugin<
+  CustomRendererModParams
+> = (configOuter, { liveNotifications, sdkLiveNotifications }) => {
+  return withProjectBuildGradle(configOuter, (props) => {
+    const renderer = resolveCustomLiveNotificationRenderer({
+      liveNotifications: sdkLiveNotifications,
+      buildOptions: liveNotifications,
+      projectRoot: props.modRequest.projectRoot,
+    });
+    if (renderer) {
+      installAndroidCustomLiveNotificationRenderer(
+        renderer,
+        props.modRequest.platformProjectRoot
+      );
+    }
+    return props;
+  });
+};

--- a/plugin/src/android/withLiveNotificationLogo.ts
+++ b/plugin/src/android/withLiveNotificationLogo.ts
@@ -1,0 +1,29 @@
+import type { ConfigPlugin } from '@expo/config-plugins';
+import { withProjectBuildGradle } from '@expo/config-plugins';
+
+import { installAndroidLiveNotificationLogo } from '../helpers/utils/liveNotificationLogo';
+import type { LiveNotificationBranding } from '../types/cio-types';
+
+/**
+ * Copies the configured Live Notifications branding logo into the Android drawables.
+ *
+ * The drawable is resolved by name at runtime, so it has to exist for the logo to render — whether
+ * the name comes from the generated initializer or from the branding an app passes to
+ * `CustomerIO.initialize` in JavaScript. That is why this runs off the build-time branding options
+ * rather than the SDK config, which exists only on the automatic-initialization path.
+ *
+ * Piggybacks on the project build.gradle mod purely for its access to the Android project root,
+ * matching how the google-services file is copied.
+ */
+export const withLiveNotificationLogo: ConfigPlugin<
+  LiveNotificationBranding | undefined
+> = (configOuter, branding) => {
+  return withProjectBuildGradle(configOuter, (props) => {
+    installAndroidLiveNotificationLogo(
+      branding,
+      props.modRequest.platformProjectRoot,
+      props.modRequest.projectRoot
+    );
+    return props;
+  });
+};

--- a/plugin/src/android/withMainApplicationModifications.ts
+++ b/plugin/src/android/withMainApplicationModifications.ts
@@ -3,8 +3,10 @@ import { withMainApplication } from '@expo/config-plugins';
 import type { ApplicationProjectFile } from '@expo/config-plugins/build/android/Paths';
 import { CIO_MAINAPPLICATION_ONCREATE_REGEX, CIO_NATIVE_SDK_INITIALIZE_CALL, CIO_NATIVE_SDK_INITIALIZE_SNIPPET } from '../helpers/constants/android';
 import { PLATFORM } from '../helpers/constants/common';
+import { resolveCustomLiveNotificationRenderer } from '../helpers/utils/liveNotificationCustomRenderer';
 import { patchNativeSDKInitializer } from '../helpers/utils/patchPluginNativeCode';
 import type {
+  CustomerIOPluginLiveNotificationsOptions,
   CustomerIOPluginLocationOptions,
   NativeSDKConfig,
 } from '../types/cio-types';
@@ -14,11 +16,16 @@ import { logger } from '../utils/logger';
 type MainApplicationModParams = {
   sdkConfig: NativeSDKConfig;
   location?: CustomerIOPluginLocationOptions;
+  /**
+   * Live Notification build-time options rather than `sdkConfig`: branding also has to reach the
+   * generated iOS widget, and `customRenderer` names Kotlin that only exists at build time.
+   */
+  liveNotifications?: CustomerIOPluginLiveNotificationsOptions;
 };
 
-export const withMainApplicationModifications: ConfigPlugin<MainApplicationModParams> = (configOuter, { sdkConfig, location }) => {
+export const withMainApplicationModifications: ConfigPlugin<MainApplicationModParams> = (configOuter, { sdkConfig, location, liveNotifications }) => {
   return withMainApplication(configOuter, async (config) => {
-    const content = setupCustomerIOSDKInitializer(config, sdkConfig, location);
+    const content = setupCustomerIOSDKInitializer(config, sdkConfig, location, liveNotifications);
     config.modResults.contents = content;
     return config;
   });
@@ -67,13 +74,29 @@ const setupCustomerIOSDKInitializer = (
   config: ExportedConfigWithProps<ApplicationProjectFile>,
   sdkConfig: NativeSDKConfig,
   location?: CustomerIOPluginLocationOptions,
+  liveNotifications?: CustomerIOPluginLiveNotificationsOptions,
 ): string => {
   const locationOptions = getLocationInitOptions(location, sdkConfig);
+  // Resolved silently: withLiveNotificationCustomRenderer runs the same resolution and owns the
+  // warnings, so a misconfigured renderer is reported once rather than per mod.
+  const customRenderer = resolveCustomLiveNotificationRenderer({
+    liveNotifications: sdkConfig.liveNotifications,
+    buildOptions: liveNotifications,
+    projectRoot: config.modRequest.projectRoot,
+    silent: true,
+  }) ?? undefined;
 
   try {
     // Always regenerate the CustomerIOSDKInitializer file to reflect config changes
     copyTemplateFile(config, SDK_INITIALIZER_FILE, SDK_INITIALIZER_PACKAGE, (content) =>
-      patchNativeSDKInitializer(content, PLATFORM.ANDROID, sdkConfig, locationOptions)
+      patchNativeSDKInitializer(
+        content,
+        PLATFORM.ANDROID,
+        sdkConfig,
+        locationOptions,
+        liveNotifications?.branding,
+        customRenderer
+      )
     );
     return injectCustomerIOInitializerIntoMainApplication(config.modResults.contents);
   } catch (error) {

--- a/plugin/src/helpers/constants/ios.ts
+++ b/plugin/src/helpers/constants/ios.ts
@@ -122,6 +122,9 @@ export const DEFAULT_BUNDLE_VERSION = '1';
 export const DEFAULT_BUNDLE_SHORT_VERSION = '1.0';
 export const CIO_TARGET_NAME = 'CustomerIOSDK';
 export const CIO_NOTIFICATION_TARGET_NAME = 'NotificationService';
+export const CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME = 'CIOLiveActivityWidget';
+// Live Activities require iOS 16.2+; used as the injected widget extension's deployment target.
+export const DEFAULT_LIVE_ACTIVITY_DEPLOYMENT_TARGET = '16.2';
 
 export const CIO_APPDELEGATEHEADER_IMPORT_SNIPPET = `#import <UserNotifications/UserNotifications.h>`;
 export const CIO_APPDELEGATEHEADER_USER_NOTIFICATION_CENTER_SNIPPET =

--- a/plugin/src/helpers/native-files/android/CustomerIOSDKInitializer.kt
+++ b/plugin/src/helpers/native-files/android/CustomerIOSDKInitializer.kt
@@ -8,6 +8,7 @@ import io.customer.messagingpush.MessagingPushModuleConfig
 import io.customer.messagingpush.ModuleMessagingPushFCM
 import io.customer.reactnative.sdk.messaginginapp.ReactInAppEventListener
 {{LOCATION_MODULE_IMPORT}}
+{{LIVE_NOTIFICATION_MODULE_IMPORT}}
 import io.customer.sdk.CustomerIOBuilder
 import io.customer.sdk.core.util.CioLogLevel
 import io.customer.sdk.data.model.Region
@@ -39,7 +40,9 @@ object CustomerIOSDKInitializer {
         }
         addCustomerIOModule(
             ModuleMessagingPushFCM(
-                MessagingPushModuleConfig.Builder().build()
+                MessagingPushModuleConfig.Builder()
+                    {{LIVE_NOTIFICATION_MODULE_INIT}}
+                    .build()
             )
         )
         {{LOCATION_MODULE_INIT}}

--- a/plugin/src/helpers/native-files/ios/CustomerIOSDKInitializer.swift
+++ b/plugin/src/helpers/native-files/ios/CustomerIOSDKInitializer.swift
@@ -2,6 +2,7 @@ import CioDataPipelines
 import CioInternalCommon
 import CioMessagingInApp
 {{LOCATION_MODULE_IMPORT}}
+{{LIVE_NOTIFICATION_MODULE_IMPORT}}
 
 class CustomerIOSDKInitializer {
     static func initialize() {
@@ -25,6 +26,7 @@ class CustomerIOSDKInitializer {
         setIfDefined(value: {{MIGRATION_SITE_ID}}, thenPassItTo: builder.migrationSiteId)
 
         {{LOCATION_MODULE_INIT}}
+        {{LIVE_NOTIFICATION_MODULE_INIT}}
         CustomerIO.initialize(withConfig: builder.build())
 
         if let siteId = siteId {

--- a/plugin/src/helpers/native-files/ios/apn/CioSdkAppDelegateHandler.swift
+++ b/plugin/src/helpers/native-files/ios/apn/CioSdkAppDelegateHandler.swift
@@ -2,6 +2,11 @@ import Foundation
 import UIKit
 import UserNotifications
 import CioMessagingPushAPN
+// Live Activities pods are only present when the feature is enabled in the plugin config.
+#if canImport(CioLiveActivities)
+import CioDataPipelines
+import CioLiveActivities
+#endif
 #if canImport(EXNotifications)
 import EXNotifications
 import ExpoModulesCore
@@ -54,5 +59,19 @@ public class CioSdkAppDelegateHandler: NSObject {
     
   public func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
     cioAppDelegate.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+  }
+
+  /// Reports an `opened` metric when the app is launched from a tapped Live Activity, and returns
+  /// the URL that should actually be routed.
+  ///
+  /// For a Customer.io widget URL this is the customer's deep link (`nil` when the activity carried
+  /// none, so there is nothing to open). Any other URL is returned unchanged, leaving the app's
+  /// existing deep-link handling untouched.
+  public func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> URL? {
+    #if canImport(CioLiveActivities)
+    return CustomerIO.liveActivities.handleWidgetUrl(url)
+    #else
+    return url
+    #endif
   }
 }

--- a/plugin/src/helpers/native-files/ios/fcm/CioSdkAppDelegateHandler.swift
+++ b/plugin/src/helpers/native-files/ios/fcm/CioSdkAppDelegateHandler.swift
@@ -1,5 +1,10 @@
 import Foundation
 import CioMessagingPushFCM
+// Live Activities pods are only present when the feature is enabled in the plugin config.
+#if canImport(CioLiveActivities)
+import CioDataPipelines
+import CioLiveActivities
+#endif
 import CioFirebaseWrapper
 @_spi(Internal) import CioMessagingPush
 import FirebaseCore
@@ -67,5 +72,19 @@ public class CioSdkAppDelegateHandler: NSObject {
     
   public func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
     
+  }
+
+  /// Reports an `opened` metric when the app is launched from a tapped Live Activity, and returns
+  /// the URL that should actually be routed.
+  ///
+  /// For a Customer.io widget URL this is the customer's deep link (`nil` when the activity carried
+  /// none, so there is nothing to open). Any other URL is returned unchanged, leaving the app's
+  /// existing deep-link handling untouched.
+  public func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> URL? {
+    #if canImport(CioLiveActivities)
+    return CustomerIO.liveActivities.handleWidgetUrl(url)
+    #else
+    return url
+    #endif
   }
 }

--- a/plugin/src/helpers/native-files/ios/widget/CIOLiveActivityWidget-Info.plist
+++ b/plugin/src/helpers/native-files/ios/widget/CIOLiveActivityWidget-Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleShortVersionString</key>
+	<string>{{BUNDLE_SHORT_VERSION}}</string>
+	<key>CFBundleVersion</key>
+	<string>{{BUNDLE_VERSION}}</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>CIOLiveActivityWidget</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/plugin/src/helpers/native-files/ios/widget/CIOLiveActivityWidgetBundle.swift
+++ b/plugin/src/helpers/native-files/ios/widget/CIOLiveActivityWidgetBundle.swift
@@ -1,0 +1,18 @@
+import CioLiveActivities_Attributes
+import CioLiveActivities_Templates
+import SwiftUI
+import WidgetKit
+
+// Reference copy of the widget bundle. The plugin generates this file instead of copying it, so that
+// it renders exactly the templates the app enabled, with its branding compiled in and its own
+// `liveNotifications.customWidget` SwiftUI added — see `generateWidgetBundleSwift`.
+//
+// The SwiftUI for each built-in template lives in the Customer.io iOS SDK, so this widget bundle is
+// all the host app needs.
+@main
+struct CIOLiveActivityWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        CIOSegmentsLiveActivity()
+        CIOCountdownTimerLiveActivity()
+    }
+}

--- a/plugin/src/helpers/utils/injectCIOPodfileCode.ts
+++ b/plugin/src/helpers/utils/injectCIOPodfileCode.ts
@@ -1,6 +1,6 @@
 import type { CustomerIOPluginOptionsIOS } from '../../types/cio-types';
 import { logger } from '../../utils/logger';
-import { getRelativePathToRNSDK } from '../constants/ios';
+import { CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME, getRelativePathToRNSDK } from '../constants/ios';
 import { injectCodeByRegex } from './codeInjection';
 import { FileManagement } from './fileManagement';
 
@@ -9,6 +9,8 @@ export type InjectCIOPodfileOptions = {
   locationEnabled?: boolean;
   /** When false and locationEnabled, inject only :subspecs => ['location']. When true, use push + location. */
   hasPush?: boolean;
+  /** When true, add the `liveactivities` subspec (enables -DCIO_LIVEACTIVITIES_ENABLED). */
+  liveNotificationsEnabled?: boolean;
 };
 
 /** Builds the host-app pod snippet for the Podfile.
@@ -29,23 +31,95 @@ export function buildHostAppPodSnippet(
 ): string {
   const resolvedPath = getRelativePathToRNSDK(iosPath);
   const locationEnabled = options?.locationEnabled === true;
+  const liveNotificationsEnabled = options?.liveNotificationsEnabled === true;
   const hasPush = options?.hasPush !== false;
-
-  if (!locationEnabled) {
-    const subspec = isFcmPushProvider ? 'fcm' : 'apn';
-    return `pod 'customerio-reactnative/${subspec}', :path => '${resolvedPath}'`;
-  }
-  if (!hasPush) {
-    return `pod 'customerio-reactnative', :subspecs => ['location'], :path => '${resolvedPath}'`;
-  }
   const pushSubspec = isFcmPushProvider ? 'fcm' : 'apn';
-  return `pod 'customerio-reactnative', :subspecs => ['${pushSubspec}', 'location'], :path => '${resolvedPath}'`;
+
+  // Simple single-subspec form only when no optional modules are enabled.
+  if (!locationEnabled && !liveNotificationsEnabled) {
+    return `pod 'customerio-reactnative/${pushSubspec}', :path => '${resolvedPath}'`;
+  }
+
+  // Otherwise use the explicit :subspecs array form, including whichever modules are enabled.
+  const subspecs: string[] = [];
+  if (hasPush) {
+    subspecs.push(pushSubspec);
+  }
+  if (locationEnabled) {
+    subspecs.push('location');
+  }
+  if (liveNotificationsEnabled) {
+    subspecs.push('liveactivities');
+  }
+  const subspecList = subspecs.map((subspec) => `'${subspec}'`).join(', ');
+  return `pod 'customerio-reactnative', :subspecs => [${subspecList}], :path => '${resolvedPath}'`;
+}
+
+// TEMPORARY (REL-1): Live Activities are not on the CocoaPods trunk yet. The `liveactivities`
+// subspec depends on `CustomerIO/LiveActivities`, and the widget links the templates and attributes
+// pods directly — none of which exist in a released `CustomerIO` podspec. Resolve the whole
+// Customer.io iOS SDK from the branch that carries them instead.
+//
+// Every pod the host app pulls has to be listed: CocoaPods refuses to mix a git-sourced pod with
+// trunk-sourced pods that share its dependency graph. Delete this and the two call sites once Live
+// Activities ship in a released native SDK.
+const UNRELEASED_IOS_SDK_GIT = 'https://github.com/customerio/customerio-ios.git';
+const UNRELEASED_IOS_SDK_BRANCH = 'feat/live-activities';
+
+/**
+ * The pods the host app actually resolves, which is what may be listed: a `pod` line *adds* a
+ * dependency, so naming one the app doesn't use changes its build. That matters most for the push
+ * provider — listing the FCM pod in an APN app would pull Firebase in, the very thing the
+ * `customerio-reactnative` podspec splits its subspecs to avoid.
+ */
+function hostUnreleasedPods(
+  hasPush: boolean,
+  isFcmPushProvider: boolean,
+  locationEnabled: boolean
+): string[] {
+  return [
+    // `CustomerIO` and its transitive modules are in the graph on every configuration.
+    'CustomerIO',
+    'CustomerIOCommon',
+    'CustomerIODataPipelines',
+    'CustomerIOTrackingMigration',
+    'CustomerIOMessagingInApp',
+    // Push pods only when push is configured. The subspec list already omits the push subspec
+    // without it, so naming these anyway would link push SDKs the app never asked for.
+    ...(hasPush
+      ? [
+          'CustomerIOMessagingPush',
+          isFcmPushProvider ? 'CustomerIOMessagingPushFCM' : 'CustomerIOMessagingPushAPN',
+        ]
+      : []),
+    ...(locationEnabled ? ['CustomerIOLocation'] : []),
+    'CustomerIOLiveActivities',
+    'CustomerIOLiveActivitiesAttributes',
+    'CustomerIOLiveActivitiesTemplates',
+  ];
+}
+
+const WIDGET_UNRELEASED_PODS = [
+  'CustomerIOLiveActivitiesTemplates',
+  'CustomerIOLiveActivitiesAttributes',
+];
+
+/** `pod` lines resolving `pods` from the unreleased Live Activities branch, one per line. */
+function unreleasedPodLines(pods: string[], indent: string): string {
+  return pods
+    .map(
+      (pod) =>
+        `${indent}pod '${pod}', :git => '${UNRELEASED_IOS_SDK_GIT}', :branch => '${UNRELEASED_IOS_SDK_BRANCH}'`
+    )
+    .join('\n');
 }
 
 const HOST_APP_BLOCK_START = '# --- CustomerIO Host App START ---';
 const HOST_APP_BLOCK_END = '# --- CustomerIO Host App END ---';
 const NOTIFICATION_BLOCK_START = '# --- CustomerIO Notification START ---';
 const NOTIFICATION_BLOCK_END = '# --- CustomerIO Notification END ---';
+const LIVE_ACTIVITY_BLOCK_START = '# --- CustomerIO Live Activity START ---';
+const LIVE_ACTIVITY_BLOCK_END = '# --- CustomerIO Live Activity END ---';
 
 /**
  * Pure string transform: given the existing Podfile contents, returns the
@@ -69,9 +143,22 @@ export function injectHostAppPodfileCode(
   const lineInPodfileToInjectSnippetBefore = /post_install do \|installer\|/;
   const podLine = buildHostAppPodSnippet(iosPath, isFcmPushProvider, options);
 
+  // TEMPORARY (REL-1): only Live Activities need the unreleased branch, so apps without them keep
+  // resolving from the CocoaPods trunk and their Podfile is byte-identical to before.
+  const unreleasedPods = options?.liveNotificationsEnabled
+    ? `\n${unreleasedPodLines(
+        hostUnreleasedPods(
+          options.hasPush === true,
+          isFcmPushProvider,
+          options.locationEnabled === true
+        ),
+        '  '
+      )}`
+    : '';
+
   const snippetToInjectInPodfile = `
 ${HOST_APP_BLOCK_START}
-  ${podLine}
+  ${podLine}${unreleasedPods}
 ${HOST_APP_BLOCK_END}
 `.trim();
 
@@ -148,6 +235,47 @@ export async function injectCIONotificationPodfileCode(
   if (next !== podfile) {
     // FileManagement.append matches what the previous direct-append did.
     // Slice off the leading content (already on disk) and append only the new tail.
+    await FileManagement.append(filename, next.slice(podfile.length));
+  }
+}
+
+/**
+ * Pure string transform: given the existing Podfile contents, returns the Podfile with the Live
+ * Activity widget target block appended at the end. The widget links the Customer.io iOS SDK's Live
+ * Activity template + attributes pods (published to CocoaPods on release). Idempotent — returns
+ * input unchanged if the block is already present. Exported for tests.
+ */
+export function appendLiveActivityWidgetTargetToPodfile(
+  podfileContent: string,
+  useFrameworks: CustomerIOPluginOptionsIOS['useFrameworks'],
+): string {
+  if (podfileContent.match(new RegExp(LIVE_ACTIVITY_BLOCK_START))) {
+    return podfileContent;
+  }
+
+  const snippetToAppend = `
+${LIVE_ACTIVITY_BLOCK_START}
+target '${CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME}' do
+  ${useFrameworks === 'static' ? 'use_frameworks! :linkage => :static' : ''}
+${unreleasedPodLines(WIDGET_UNRELEASED_PODS, '  ')}
+end
+${LIVE_ACTIVITY_BLOCK_END}
+`.trim();
+
+  // Separate from any preceding CIO block (the notification block is appended trimmed, without a
+  // trailing newline) and leave a trailing newline so a following block starts on its own line.
+  const separator = podfileContent.endsWith('\n') ? '' : '\n';
+  return `${podfileContent}${separator}${snippetToAppend}\n`;
+}
+
+export async function injectCIOLiveActivityWidgetPodfileCode(
+  iosPath: string,
+  useFrameworks: CustomerIOPluginOptionsIOS['useFrameworks'],
+) {
+  const filename = `${iosPath}/Podfile`;
+  const podfile = await FileManagement.read(filename);
+  const next = appendLiveActivityWidgetTargetToPodfile(podfile, useFrameworks);
+  if (next !== podfile) {
     await FileManagement.append(filename, next.slice(podfile.length));
   }
 }

--- a/plugin/src/helpers/utils/liveNotificationCustomRenderer.ts
+++ b/plugin/src/helpers/utils/liveNotificationCustomRenderer.ts
@@ -1,0 +1,197 @@
+import path from 'path';
+
+import type {
+  CustomerIOPluginLiveNotificationsOptions,
+  LiveNotificationsSDKConfig,
+} from '../../types/cio-types';
+import { logger } from '../../utils/logger';
+import { FileManagement } from './fileManagement';
+
+/**
+ * The Android counterpart to `liveNotificationCustomWidget`: a custom live notification is Kotlin the
+ * app writes and Customer.io registers. The plugin copies the configured file(s) into the app's
+ * source tree and instantiates the named `CustomerIOLiveNotificationsCallback` where the renderer is
+ * registered.
+ *
+ * Android has no built-in template for a custom type, so without this the type is allowlisted — it
+ * starts, reports, and the backend can push updates to it — but the SDK draws nothing and logs
+ * "no built-in template and createLiveNotification returned null".
+ *
+ * Best-effort in the same way the widget and the branding logo are: anything misconfigured warns and
+ * is skipped rather than failing prebuild, because a half-wired renderer fails deep in the Gradle
+ * build where it is far harder to diagnose.
+ */
+
+/** A custom renderer resolved against the project on disk, ready to copy into the app. */
+export type ResolvedCustomRenderer = {
+  /** Absolute paths of the Kotlin files to copy, in configured order. */
+  sourceFiles: string[];
+  /** Kotlin package each file declares, parallel to [sourceFiles] — it decides where each lands. */
+  packages: string[];
+  /** The `CustomerIOLiveNotificationsCallback` class to instantiate. */
+  className: string;
+  /** Package [className] lives in, so callers can import it. */
+  classPackage: string;
+};
+
+export type ResolveCustomRendererOptions = {
+  /** SDK config, read only for `customType` — present only on the auto-initialization path. */
+  liveNotifications: LiveNotificationsSDKConfig | undefined;
+  /** Build-time options carrying `customRenderer`, available on either initialization path. */
+  buildOptions: CustomerIOPluginLiveNotificationsOptions | undefined;
+  /** Project root the configured relative paths resolve against. */
+  projectRoot: string;
+  /**
+   * Suppress the warnings. Resolution runs from two mods — the one that copies the files and the one
+   * that generates the code referencing them — and both must reach the same verdict, so they call
+   * the same function rather than a looser variant. Only the copying mod reports, so a misconfigured
+   * renderer is diagnosed once.
+   */
+  silent?: boolean;
+};
+
+const TAG = '[customerio-expo-plugin]';
+const SKIPPED = 'No custom live notification will be rendered on Android.';
+
+/** `package com.example.app` — Kotlin allows no semicolon, and the file may open with comments. */
+const PACKAGE_REGEX = /^\s*package\s+([A-Za-z_][A-Za-z0-9_.]*)\s*;?\s*$/m;
+
+/**
+ * Resolve `liveNotifications.customRenderer` to the files to copy and the class to instantiate, or
+ * null when there is nothing usable to render with.
+ */
+export function resolveCustomLiveNotificationRenderer(
+  options: ResolveCustomRendererOptions
+): ResolvedCustomRenderer | null {
+  const { liveNotifications, buildOptions, projectRoot, silent = false } = options;
+  const warn = (message: string) => {
+    if (!silent) logger.warn(message);
+  };
+  const customType = liveNotifications?.customType?.trim();
+  const customRenderer = buildOptions?.customRenderer;
+
+  if (!customRenderer) {
+    if (customType) {
+      warn(
+        `${TAG} config.liveNotifications.customType "${customType}" is set without the top-level ` +
+          `liveNotifications.customRenderer, so Android has nothing to draw it with. The activity will ` +
+          `start and report, and the backend can push updates to it, but no notification appears. ` +
+          `Point customRenderer.sourceFile at your Kotlin file and set customRenderer.className.`
+      );
+    }
+    return null;
+  }
+
+  const className = customRenderer.className?.trim();
+  if (!className) {
+    warn(
+      `${TAG} liveNotifications.customRenderer.className is required — the plugin never parses Kotlin, ` +
+        `so it cannot infer which class to register. ${SKIPPED}`
+    );
+    return null;
+  }
+
+  const configured = (
+    Array.isArray(customRenderer.sourceFile)
+      ? customRenderer.sourceFile
+      : [customRenderer.sourceFile]
+  ).filter((entry): entry is string => typeof entry === 'string' && entry.trim() !== '');
+
+  if (configured.length === 0) {
+    warn(
+      `${TAG} liveNotifications.customRenderer.sourceFile is required and must be a path to a .kt file. ${SKIPPED}`
+    );
+    return null;
+  }
+
+  const sourceFiles: string[] = [];
+  const packages: string[] = [];
+  let classPackage: string | undefined;
+
+  for (const entry of configured) {
+    const configuredPath = entry.trim();
+
+    if (path.extname(configuredPath).toLowerCase() !== '.kt') {
+      warn(
+        `${TAG} liveNotifications.customRenderer.sourceFile "${configuredPath}" is not a .kt file. ${SKIPPED}`
+      );
+      return null;
+    }
+
+    const absolute = path.isAbsolute(configuredPath)
+      ? configuredPath
+      : path.resolve(projectRoot, configuredPath);
+    if (!FileManagement.exists(absolute)) {
+      warn(
+        `${TAG} liveNotifications.customRenderer.sourceFile "${configuredPath}" was not found at ${absolute}. ${SKIPPED}`
+      );
+      return null;
+    }
+
+    const contents = FileManagement.readFile(absolute);
+    const declaredPackage = contents.match(PACKAGE_REGEX)?.[1];
+    if (!declaredPackage) {
+      // Unlike the iOS widget, these are not flattened into one plugin-owned directory: Kotlin
+      // resolves a class by its package, so the file has to declare one to be placed at all.
+      warn(
+        `${TAG} liveNotifications.customRenderer.sourceFile "${configuredPath}" declares no Kotlin package. ` +
+          `Add one (e.g. \`package com.myapp.livenotifications\`) so the plugin knows where to copy it and ` +
+          `how to import ${className}. ${SKIPPED}`
+      );
+      return null;
+    }
+
+    // The declaring file decides the import, so a multi-file renderer can keep helpers elsewhere.
+    if (new RegExp(`\\bclass\\s+${className}\\b`).test(contents)) {
+      classPackage = declaredPackage;
+    }
+
+    sourceFiles.push(absolute);
+    packages.push(declaredPackage);
+  }
+
+  if (!classPackage) {
+    // Warn rather than skip, matching the widget's treatment of a missing struct: the class may be
+    // declared in a way this crude check misses, and being wrong here costs a compile error the
+    // developer can read, not a silently broken activity.
+    warn(
+      `${TAG} liveNotifications.customRenderer.className "${className}" was not found in any configured ` +
+        `sourceFile. Assuming it lives in "${packages[0]}"; if the generated code fails to compile, that ` +
+        `is why.`
+    );
+    classPackage = packages[0];
+  }
+
+  return { sourceFiles, packages, className, classPackage };
+}
+
+/**
+ * Copy the resolved files into the Android source tree, each under the package it declares.
+ *
+ * Returns the number of files installed. Failures are logged and skipped per file rather than
+ * thrown: prebuild has already generated the rest of the project by this point.
+ */
+export function installAndroidCustomLiveNotificationRenderer(
+  renderer: ResolvedCustomRenderer,
+  androidPath: string
+): number {
+  let installed = 0;
+
+  renderer.sourceFiles.forEach((source, index) => {
+    const packagePath = renderer.packages[index].replace(/\./g, '/');
+    const destinationDir = path.join(androidPath, 'app/src/main/java', packagePath);
+    const destination = path.join(destinationDir, path.basename(source));
+
+    try {
+      FileManagement.mkdir(destinationDir, { recursive: true });
+      FileManagement.copyFile(source, destination);
+      installed += 1;
+    } catch (error: unknown) {
+      logger.error(
+        `${TAG} Failed to copy the custom live notification renderer to ${destination}: ${String(error)}`
+      );
+    }
+  });
+
+  return installed;
+}

--- a/plugin/src/helpers/utils/liveNotificationCustomWidget.ts
+++ b/plugin/src/helpers/utils/liveNotificationCustomWidget.ts
@@ -1,0 +1,205 @@
+import path from 'path';
+
+import type {
+  CustomerIOPluginLiveNotificationsOptions,
+  LiveNotificationsSDKConfig,
+} from '../../types/cio-types';
+import { logger } from '../../utils/logger';
+import { FileManagement } from './fileManagement';
+
+/**
+ * A custom Live Activity is SwiftUI the app writes and Customer.io compiles: the plugin copies the
+ * configured file(s) into the widget extension it generates and instantiates the named struct in
+ * the generated `WidgetBundle`. The app therefore needs no widget target of its own, and no
+ * attributes type — the native SDK ships `CIOCustomAttributes` for exactly this.
+ *
+ * Everything here is best-effort in the same way the branding logo install is: a misconfigured
+ * widget warns and is skipped rather than failing prebuild, because the alternative (a
+ * half-registered target) is worse than a project without the custom template.
+ */
+
+/** A custom widget resolved against the project on disk, ready to copy into the widget target. */
+export type ResolvedCustomWidget = {
+  /** Absolute paths of the Swift files to compile, in configured order. */
+  sourceFiles: string[];
+  /** File names those get inside the widget directory — also their Xcode group/build entries. */
+  filenames: string[];
+  /** Swift `Widget` struct the generated bundle instantiates. */
+  structName: string;
+};
+
+export type ResolveCustomWidgetOptions = {
+  /** SDK config, read only for `customType` — present only on the auto-initialization path. */
+  liveNotifications: LiveNotificationsSDKConfig | undefined;
+  /** Build-time options carrying `customWidget`, available on either initialization path. */
+  buildOptions: CustomerIOPluginLiveNotificationsOptions | undefined;
+  /**
+   * Whether the app initializes the SDK automatically. Only then does the plugin generate the code
+   * that registers `customType`, so only then can a missing `customType` be diagnosed here — a
+   * JavaScript-initialized app supplies it at runtime, where the plugin cannot see it.
+   */
+  autoInitializes: boolean;
+  /** Project root the configured relative paths resolve against. */
+  projectRoot: string;
+  /**
+   * File names the plugin writes into the widget directory itself. A copied file must not shadow
+   * one of them: the copies land in the same flat directory, so it would overwrite the generated
+   * bundle, the target's Info.plist, or the branding asset catalog.
+   */
+  reservedFilenames: string[];
+};
+
+const TAG = '[customerio-expo-plugin]';
+const SKIPPED = 'No custom Live Activity template will be rendered.';
+
+/**
+ * Resolve `liveNotifications.customWidget` to the files to compile and the struct to instantiate,
+ * or null when there is nothing usable to render.
+ *
+ * Anything structurally wrong (no struct name, a non-Swift path, a file that isn't there, names
+ * that would collide once flattened into the widget directory) drops the whole custom template
+ * rather than part of it: a widget missing one of its files fails deep in the Xcode build, which is
+ * far harder to diagnose than a prebuild warning.
+ */
+export function resolveCustomLiveActivityWidget(
+  options: ResolveCustomWidgetOptions
+): ResolvedCustomWidget | null {
+  const { liveNotifications, buildOptions, autoInitializes, projectRoot, reservedFilenames } =
+    options;
+  const customType = liveNotifications?.customType?.trim();
+  const customWidget = buildOptions?.customWidget;
+
+  if (!customWidget) {
+    if (customType) {
+      logger.warn(
+        `${TAG} config.liveNotifications.customType "${customType}" is set without the top-level ` +
+          `liveNotifications.customWidget, ` +
+          `so the generated widget has no SwiftUI to render it with. Point customWidget.sourceFile at your ` +
+          `SwiftUI file and set customWidget.structName.`
+      );
+    }
+    return null;
+  }
+
+  const structName = customWidget.structName?.trim();
+  if (!structName) {
+    logger.warn(
+      `${TAG} liveNotifications.customWidget.structName is required — the plugin never parses Swift, so it ` +
+        `cannot infer which struct to add to the generated WidgetBundle. ${SKIPPED}`
+    );
+    return null;
+  }
+
+  if (!customType && autoInitializes) {
+    // Only diagnosable on this path. With automatic initialization the generated code is what
+    // registers the identifier, so its absence means the widget draws a type nothing registers.
+    // A JavaScript-initialized app passes it to `CustomerIO.initialize` instead, which is correct
+    // and invisible here — warning there would fire on a supported setup.
+    logger.warn(
+      `${TAG} config.liveNotifications.customType is not set, so the generated initializer registers ` +
+        `no custom activity type and the widget would draw one nothing starts. Set it to your own ` +
+        `reverse-DNS identifier.`
+    );
+  }
+
+  const configured = (
+    Array.isArray(customWidget.sourceFile)
+      ? customWidget.sourceFile
+      : [customWidget.sourceFile]
+  ).filter((entry): entry is string => typeof entry === 'string' && entry.trim() !== '');
+
+  if (configured.length === 0) {
+    logger.warn(
+      `${TAG} liveNotifications.customWidget.sourceFile is required and must be a path to a .swift file. ${SKIPPED}`
+    );
+    return null;
+  }
+
+  const sourceFiles: string[] = [];
+  const filenames: string[] = [];
+  // Case-insensitively: the copies land on a case-insensitive filesystem (APFS by default), so
+  // `View.swift` and `view.swift` are the same destination even though the configs differ.
+  const taken = new Map(
+    reservedFilenames.map((filename) => [filename.toLowerCase(), 'generated by the plugin'])
+  );
+
+  for (const entry of configured) {
+    const configuredPath = entry.trim();
+
+    if (path.extname(configuredPath).toLowerCase() !== '.swift') {
+      logger.warn(
+        `${TAG} liveNotifications.customWidget.sourceFile "${configuredPath}" is not a .swift file. ${SKIPPED}`
+      );
+      return null;
+    }
+
+    const absolute = path.isAbsolute(configuredPath)
+      ? configuredPath
+      : path.resolve(projectRoot, configuredPath);
+    if (!FileManagement.exists(absolute)) {
+      logger.warn(
+        `${TAG} liveNotifications.customWidget.sourceFile "${configuredPath}" was not found at ${absolute}. ${SKIPPED}`
+      );
+      return null;
+    }
+
+    const filename = path.basename(absolute);
+    const collision = taken.get(filename.toLowerCase());
+    if (collision) {
+      logger.warn(
+        `${TAG} liveNotifications.customWidget.sourceFile "${configuredPath}" would be copied over a file ` +
+          `${collision} — every source file is flattened into one widget directory, so "${filename}" has to be ` +
+          `unique there. Rename it. ${SKIPPED}`
+      );
+      return null;
+    }
+
+    taken.set(filename.toLowerCase(), 'already copied from another sourceFile entry');
+    sourceFiles.push(absolute);
+    filenames.push(filename);
+  }
+
+  warnWhenStructIsMissing(sourceFiles, structName);
+
+  return { sourceFiles, filenames, structName };
+}
+
+/**
+ * Copy the resolved files into the widget directory and return the names to register on the widget
+ * target. Kept separate from resolution because the generated `WidgetBundle` needs `structName`
+ * before the target directory is written.
+ */
+export function installCustomLiveActivityWidget(
+  widget: ResolvedCustomWidget,
+  widgetPath: string
+): string[] {
+  widget.sourceFiles.forEach((source, index) => {
+    FileManagement.copyFile(source, `${widgetPath}/${widget.filenames[index]}`);
+  });
+
+  return [...widget.filenames];
+}
+
+/**
+ * A `structName` that matches nothing in the copied files fails at the Xcode build ("cannot find
+ * '…' in scope"), long after prebuild. A textual check can't be authoritative — the struct may be
+ * declared through a macro or a typealias — so this only warns.
+ */
+function warnWhenStructIsMissing(sourceFiles: string[], structName: string): void {
+  const declaration = new RegExp(`\\bstruct\\s+${escapeForRegExp(structName)}\\b`);
+  const declared = sourceFiles.some((source) =>
+    declaration.test(FileManagement.readFile(source))
+  );
+
+  if (!declared) {
+    logger.warn(
+      `${TAG} liveNotifications.customWidget.structName "${structName}" was not found in the configured ` +
+        `source file(s). The generated WidgetBundle instantiates it, so the widget target will fail to compile ` +
+        `unless the name is declared there.`
+    );
+  }
+}
+
+function escapeForRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/plugin/src/helpers/utils/liveNotificationLogo.ts
+++ b/plugin/src/helpers/utils/liveNotificationLogo.ts
@@ -1,0 +1,116 @@
+import path from 'path';
+
+import type { LiveNotificationBranding } from '../../types/cio-types';
+import { logger } from '../../utils/logger';
+import { FileManagement } from './fileManagement';
+import {
+  isRemoteLogo,
+  LIVE_NOTIFICATION_LOGO_ASSET,
+} from './patchLiveNotificationCode';
+
+/**
+ * The branding logo a customer points at with a local path has to become a real native asset on
+ * each platform: an Android drawable, and an image set inside the generated iOS widget's asset
+ * catalog. The generated code references it by the shared name
+ * {@link LIVE_NOTIFICATION_LOGO_ASSET}, so without these copies the logo silently renders as
+ * nothing.
+ *
+ * A remote URL is skipped here — Android downloads it at render time, and iOS can't use it at all
+ * because the widget is compiled ahead of time.
+ */
+
+/** Resolve the configured logo to an absolute path, or null when it isn't a usable local file. */
+function resolveLocalLogo(
+  branding: LiveNotificationBranding | undefined,
+  projectRoot: string
+): string | null {
+  const logo = branding?.logo;
+  if (!logo || isRemoteLogo(logo)) {
+    return null;
+  }
+
+  const absolute = path.isAbsolute(logo) ? logo : path.resolve(projectRoot, logo);
+  if (!FileManagement.exists(absolute)) {
+    logger.warn(
+      `[customerio-expo-plugin] liveNotifications.branding.logo "${logo}" was not found at ${absolute}. Live Notifications will render without a logo.`
+    );
+    return null;
+  }
+
+  return absolute;
+}
+
+/**
+ * Copy the logo into `android/app/src/main/res/drawable`, where the generated initializer resolves
+ * it by name at runtime via `Resources.getIdentifier`.
+ */
+export function installAndroidLiveNotificationLogo(
+  branding: LiveNotificationBranding | undefined,
+  androidPath: string,
+  projectRoot: string
+): void {
+  const source = resolveLocalLogo(branding, projectRoot);
+  if (!source) return;
+
+  // Android drawable names must be lowercase alphanumeric/underscore, so the asset name is fixed
+  // and only the extension follows the source file.
+  const extension = path.extname(source).toLowerCase() || '.png';
+  const drawableDir = `${androidPath}/app/src/main/res/drawable`;
+  const destination = `${drawableDir}/${LIVE_NOTIFICATION_LOGO_ASSET}${extension}`;
+
+  try {
+    FileManagement.mkdir(drawableDir, { recursive: true });
+    FileManagement.copyFile(source, destination);
+  } catch (error: unknown) {
+    logger.error(
+      `[customerio-expo-plugin] Failed to copy the Live Notifications logo to ${destination}: ${String(error)}`
+    );
+  }
+}
+
+/**
+ * Build `Assets.xcassets` inside the widget target containing the logo image set, and return the
+ * catalog's path so the caller can register it as a resource on the widget target. Returns null
+ * when there is no local logo to install.
+ */
+export function installIosLiveNotificationLogo(
+  branding: LiveNotificationBranding | undefined,
+  widgetPath: string,
+  projectRoot: string
+): string | null {
+  const source = resolveLocalLogo(branding, projectRoot);
+  if (!source) return null;
+
+  const filename = path.basename(source);
+  const catalogPath = `${widgetPath}/Assets.xcassets`;
+  const imageSetPath = `${catalogPath}/${LIVE_NOTIFICATION_LOGO_ASSET}.imageset`;
+
+  try {
+    FileManagement.mkdir(imageSetPath, { recursive: true });
+    FileManagement.copyFile(source, `${imageSetPath}/${filename}`);
+    FileManagement.writeFile(
+      `${catalogPath}/Contents.json`,
+      `${JSON.stringify({ info: { author: 'xcode', version: 1 } }, null, 2)}\n`
+    );
+    // A single universal image: the source is used at every scale rather than requiring the
+    // customer to supply @2x/@3x variants for a logo the templates render small.
+    FileManagement.writeFile(
+      `${imageSetPath}/Contents.json`,
+      `${JSON.stringify(
+        {
+          images: [{ filename, idiom: 'universal', scale: '1x' }],
+          info: { author: 'xcode', version: 1 },
+        },
+        null,
+        2
+      )}\n`
+    );
+  } catch (error: unknown) {
+    logger.error(
+      `[customerio-expo-plugin] Failed to create the Live Notifications asset catalog at ${catalogPath}: ${String(error)}`
+    );
+    return null;
+  }
+
+  return catalogPath;
+}

--- a/plugin/src/helpers/utils/liveNotificationsEnabled.ts
+++ b/plugin/src/helpers/utils/liveNotificationsEnabled.ts
@@ -1,0 +1,57 @@
+import type {
+  CustomerIOPluginLiveNotificationsOptions,
+  NativeSDKConfig,
+} from '../../types/cio-types';
+import {
+  resolveCustomLiveNotificationType,
+  resolveLiveNotificationTypes,
+} from './patchLiveNotificationCode';
+
+/**
+ * Whether to generate the iOS build-time setup for Live Notifications: the widget extension
+ * target, the `NSSupportsLiveActivities` Info.plist key, and the Podfile subspec.
+ *
+ * Two ways to turn it on, matching the two initialization paths:
+ * - **Auto initialization** — `config.liveNotifications` is present. The types it lists are
+ *   registered natively, so requiring a second `enabled` flag would only be a way to get the
+ *   two out of sync.
+ * - **JavaScript initialization** — there is no `config`, so the app sets
+ *   `liveNotifications.enabled` to get the native artifacts while registering its types at
+ *   runtime.
+ *
+ * Android needs no target of its own at build time — it reads its types from the SDK config and its
+ * branding from the build-time options, and the only file the plugin writes for it is the branding
+ * logo drawable.
+ *
+ * Push is not required here. It is what most setups use — Android reaches the feature through
+ * `ModuleMessagingPushFCM`, and iOS registers push-to-start against the device token push supplies —
+ * but an app can also obtain a token through another provider and pass it to Customer.io for
+ * backend-driven activities. The tap-URL wiring is installed on both paths (see `withCIOIosSwift`)
+ * so neither loses attribution.
+ */
+export function isLiveNotificationsEnabled(
+  liveNotifications: CustomerIOPluginLiveNotificationsOptions | undefined,
+  sdkConfig: NativeSDKConfig | undefined
+): boolean {
+  if (liveNotifications?.enabled === true) {
+    return true;
+  }
+
+  const configured = sdkConfig?.liveNotifications;
+  if (!configured) {
+    return false;
+  }
+
+  if (resolveLiveNotificationTypes(configured.types).length > 0) {
+    return true;
+  }
+
+  // A custom type on its own is enough: the widget extension renders the app's own SwiftUI, and the
+  // app still needs the Info.plist key and the Podfile subspec for it. Turning it on here is also
+  // what surfaces a `customType` configured without a `customWidget` to render it, rather than
+  // silently producing nothing.
+  //
+  // `customWidget` alone does not appear here: it is a build-time option that a
+  // JavaScript-initialized app pairs with `enabled`, already handled above.
+  return resolveCustomLiveNotificationType(configured.customType) !== undefined;
+}

--- a/plugin/src/helpers/utils/liveNotificationsEnabled.ts
+++ b/plugin/src/helpers/utils/liveNotificationsEnabled.ts
@@ -19,6 +19,11 @@ import {
  *   `liveNotifications.enabled` to get the native artifacts while registering its types at
  *   runtime.
  *
+ * `enabled: false` is an explicit kill switch and wins over both paths, so an app that has
+ * `config.liveNotifications` can still turn the build-time setup off without deleting its type list.
+ * Only an explicit `false` does this — omitting the flag under auto initialization means "infer it",
+ * which is the common case.
+ *
  * Android needs no target of its own at build time — it reads its types from the SDK config and its
  * branding from the build-time options, and the only file the plugin writes for it is the branding
  * logo drawable.
@@ -33,8 +38,8 @@ export function isLiveNotificationsEnabled(
   liveNotifications: CustomerIOPluginLiveNotificationsOptions | undefined,
   sdkConfig: NativeSDKConfig | undefined
 ): boolean {
-  if (liveNotifications?.enabled === true) {
-    return true;
+  if (liveNotifications?.enabled !== undefined) {
+    return liveNotifications.enabled;
   }
 
   const configured = sdkConfig?.liveNotifications;

--- a/plugin/src/helpers/utils/liveNotificationsEnabled.ts
+++ b/plugin/src/helpers/utils/liveNotificationsEnabled.ts
@@ -60,3 +60,30 @@ export function isLiveNotificationsEnabled(
   // JavaScript-initialized app pairs with `enabled`, already handled above.
   return resolveCustomLiveNotificationType(configured.customType) !== undefined;
 }
+
+/**
+ * The SDK config the generated initializers should be built from, with `liveNotifications` dropped
+ * when the feature is off.
+ *
+ * Two different inputs decide what gets generated: `isLiveNotificationsEnabled` gates the build-time
+ * artifacts (iOS widget target, `NSSupportsLiveActivities`, the `liveactivities` pod subspec), while
+ * the native registration in the generated initializer comes straight from `config.liveNotifications`.
+ * They have to agree. An explicit `enabled: false` turns the artifacts off, and leaving the
+ * registration in place would emit `import CioLiveActivities` and a `LiveActivitiesModule` against a
+ * pod that is no longer linked — an iOS compile failure — while Android would go on registering the
+ * types at runtime, so the opt-out wouldn't opt out of anything.
+ *
+ * Returns the config unchanged whenever the feature is on, or when there is nothing to strip.
+ */
+export function resolveSdkConfigForLiveNotifications(
+  liveNotifications: CustomerIOPluginLiveNotificationsOptions | undefined,
+  sdkConfig: NativeSDKConfig | undefined
+): NativeSDKConfig | undefined {
+  if (!sdkConfig?.liveNotifications) {
+    return sdkConfig;
+  }
+  if (isLiveNotificationsEnabled(liveNotifications, sdkConfig)) {
+    return sdkConfig;
+  }
+  return { ...sdkConfig, liveNotifications: undefined };
+}

--- a/plugin/src/helpers/utils/patchLiveNotificationCode.ts
+++ b/plugin/src/helpers/utils/patchLiveNotificationCode.ts
@@ -1,0 +1,486 @@
+import {
+  LIVE_NOTIFICATION_TYPES,
+  type LiveNotificationBranding,
+  type LiveNotificationsSDKConfig,
+} from '../../types/cio-types';
+import { PLATFORM, type Platform } from '../constants/common';
+
+/** Drawable/asset name the plugin gives a copied branding logo on both platforms. */
+export const LIVE_NOTIFICATION_LOGO_ASSET = 'cio_live_notification_logo';
+
+/**
+ * The app's Android render callback, once resolved to something the generated code can name.
+ * Android-only: iOS renders a custom type from SwiftUI compiled into the widget instead.
+ */
+export type CustomRendererRegistration = {
+  /** `CustomerIOLiveNotificationsCallback` class to instantiate. */
+  className: string;
+  /** Package it lives in, for the generated import. */
+  classPackage: string;
+};
+
+/**
+ * A built-in type the plugin knows how to generate code for, keyed by the
+ * reverse-DNS identifier shared with both native SDKs and the backend.
+ */
+type KnownType = {
+  /** Swift `ActivityAttributes` type registered on the iOS module. */
+  iosAttributes: string;
+  /** Swift `Widget` type rendered by the generated widget bundle. */
+  iosWidget: string;
+  /** Swift branding struct the widget's initializer takes. */
+  iosBranding: string;
+  /** Whether the template renders a progress bar (only Segments does). */
+  iosHasProgress: boolean;
+  /** Android `LiveNotificationType` enum constant. */
+  androidEnum: string;
+};
+
+const KNOWN_TYPES: Record<string, KnownType> = {
+  [LIVE_NOTIFICATION_TYPES.segments]: {
+    iosAttributes: 'CIOSegmentsAttributes',
+    iosWidget: 'CIOSegmentsLiveActivity',
+    iosBranding: 'CIOSegmentsBranding',
+    iosHasProgress: true,
+    androidEnum: 'SEGMENTS',
+  },
+  [LIVE_NOTIFICATION_TYPES.countdownTimer]: {
+    iosAttributes: 'CIOCountdownTimerAttributes',
+    iosWidget: 'CIOCountdownTimerLiveActivity',
+    iosBranding: 'CIOCountdownTimerBranding',
+    iosHasProgress: false,
+    androidEnum: 'COUNTDOWN_TIMER',
+  },
+};
+
+/** Every built-in type, used when an app enables the feature without listing types. */
+export const ALL_LIVE_NOTIFICATION_TYPES = Object.keys(KNOWN_TYPES);
+
+const HEX_COLOR = /^#[0-9a-fA-F]{6}$/;
+
+/**
+ * Resolve the configured identifiers to the types this plugin build can generate.
+ *
+ * Unrecognized identifiers are dropped with a warning rather than failing the build: a template
+ * added in a newer SDK would otherwise emit a Swift/Kotlin symbol that doesn't exist, turning a
+ * config typo into a compile error. When no types are listed the caller gets every built-in, which
+ * is what a JavaScript-initialized app needs (its types are chosen at runtime, not at prebuild).
+ */
+export function resolveLiveNotificationTypes(types?: string[]): string[] {
+  if (types === undefined) {
+    return ALL_LIVE_NOTIFICATION_TYPES;
+  }
+
+  const known: string[] = [];
+  for (const type of types) {
+    if (KNOWN_TYPES[type]) {
+      known.push(type);
+    } else {
+      console.warn(
+        `[customerio-expo-plugin] Ignoring unknown Live Notification type "${type}". ` +
+          `Supported types: ${ALL_LIVE_NOTIFICATION_TYPES.join(', ')}.`
+      );
+    }
+  }
+  // De-duplicate so a repeated identifier can't emit the same registration twice.
+  return [...new Set(known)];
+}
+
+/**
+ * The app's own identifier for its custom activity type, or undefined when none is configured.
+ *
+ * A blank value is treated as absent, and a built-in identifier is refused: iOS resolves an
+ * activity's reported type from its Swift attributes type, so registering `CIOCustomAttributes`
+ * under a built-in template's identifier would make every event for that template resolve to
+ * whichever type was registered first.
+ */
+export function resolveCustomLiveNotificationType(
+  customType: string | undefined
+): string | undefined {
+  const trimmed = customType?.trim();
+  if (!trimmed) return undefined;
+
+  if (KNOWN_TYPES[trimmed]) {
+    console.warn(
+      `[customerio-expo-plugin] Ignoring liveNotifications.customType "${trimmed}": it is a built-in ` +
+        `Live Notification type. Use your own reverse-DNS identifier, e.g. "com.myapp.rideshare".`
+    );
+    return undefined;
+  }
+
+  return trimmed;
+}
+
+/** True when `logo` points at a remote image rather than a file in the project. */
+export function isRemoteLogo(logo: string): boolean {
+  return /^https?:\/\//i.test(logo);
+}
+
+/**
+ * Validate branding up front so a malformed value fails prebuild with a clear message instead of
+ * producing native code that throws at runtime.
+ */
+export function validateLiveNotificationBranding(
+  branding: LiveNotificationBranding | undefined
+): void {
+  if (!branding) return;
+
+  const colors: (keyof LiveNotificationBranding)[] = [
+    'backgroundColorHex',
+    'textColorHex',
+    'accentColorHex',
+  ];
+  for (const key of colors) {
+    const value = branding[key];
+    if (value !== undefined && !HEX_COLOR.test(value)) {
+      throw new Error(
+        `[customerio-expo-plugin] liveNotifications.branding.${key} must be a "#RRGGBB" hex color, got "${value}".`
+      );
+    }
+  }
+}
+
+/** `#RRGGBB` -> the `0xRRGGBB` literal used by the generated native code. */
+function hexToLiteral(hex: string): string {
+  return `0x${hex.slice(1).toUpperCase()}`;
+}
+
+// MARK: - iOS
+
+/**
+ * Swift for the branding a generated widget passes to `type`'s Live Activity, or `nil` when the
+ * app configured no branding (the widget then uses the SDK's default styling).
+ */
+export function iosBrandingArguments(
+  type: string,
+  branding: LiveNotificationBranding | undefined
+): string | null {
+  const known = KNOWN_TYPES[type];
+  if (!known || !branding) return null;
+
+  const args: string[] = [];
+  // A remote URL can't be resolved at build time, so the widget simply renders no logo.
+  if (branding.logo && !isRemoteLogo(branding.logo)) {
+    args.push(`logo: Image("${LIVE_NOTIFICATION_LOGO_ASSET}")`);
+  }
+  if (branding.backgroundColorHex) {
+    args.push(`background: Color(hex: ${hexToLiteral(branding.backgroundColorHex)})`);
+  }
+  if (branding.textColorHex) {
+    args.push(`textColor: Color(hex: ${hexToLiteral(branding.textColorHex)})`);
+  }
+  if (known.iosHasProgress && branding.accentColorHex) {
+    args.push(
+      `progressCompleteStyle: Color(hex: ${hexToLiteral(branding.accentColorHex)})`
+    );
+  }
+  if (args.length === 0) return null;
+
+  return `${known.iosBranding}(${args.join(', ')})`;
+}
+
+/**
+ * The `WidgetBundle` body entries rendering each enabled type, branded when configured.
+ *
+ * `customStructName` is the app's own SwiftUI widget (see `liveNotifications.customWidget`). It
+ * takes no branding argument: branding is compiled into the SDK's templates, and a view the app
+ * wrote styles itself.
+ */
+export function iosWidgetBundleEntries(
+  types: string[],
+  branding: LiveNotificationBranding | undefined,
+  customStructName?: string
+): string[] {
+  const entries = types.map((type) => {
+    const known = KNOWN_TYPES[type];
+    const brandingArgs = iosBrandingArguments(type, branding);
+    return brandingArgs
+      ? `${known.iosWidget}(branding: ${brandingArgs})`
+      : `${known.iosWidget}()`;
+  });
+
+  if (customStructName) {
+    entries.push(`${customStructName}()`);
+  }
+
+  return entries;
+}
+
+/**
+ * The full `CIOLiveActivityWidgetBundle.swift` for the injected widget extension.
+ *
+ * Generated rather than copied so the bundle renders exactly the types the app enabled, with its
+ * branding compiled in — iOS branding is SwiftUI in the widget, so it can only be applied here at
+ * build time — plus the app's own widget struct when one is configured.
+ */
+export function generateWidgetBundleSwift(
+  types: string[],
+  branding: LiveNotificationBranding | undefined,
+  customStructName?: string,
+  autoInitializes = true
+): string {
+  let resolvedTypes = types;
+  if (!autoInitializes) {
+    // JavaScript initialization: the app chooses its types at runtime, so the plugin never learns
+    // them and the widget has to be able to render any built-in. Doing this only when nothing else
+    // resolved would leave an app that configures a `customWidget` with a widget that renders the
+    // custom type and none of the built-ins it also enables.
+    resolvedTypes = ALL_LIVE_NOTIFICATION_TYPES;
+  } else if (types.length === 0 && !customStructName) {
+    // A `WidgetBundle` body has to return at least one widget, so an empty bundle cannot be
+    // emitted — it wouldn't compile. This app told us its types, so reaching here is a
+    // misconfiguration (an unrecognized `types` list, or a `customWidget` that didn't resolve)
+    // worth reporting before falling back.
+    console.warn(
+      '[customerio-expo-plugin] No Live Notification type resolved for the generated iOS widget; ' +
+        'falling back to the built-in templates so the widget extension still compiles.'
+    );
+    resolvedTypes = ALL_LIVE_NOTIFICATION_TYPES;
+  }
+
+  const entries = iosWidgetBundleEntries(resolvedTypes, branding, customStructName)
+    .map((entry) => `        ${entry}`)
+    .join('\n');
+
+  // SwiftUI has no hex initializer, and the widget can't import the app's helpers.
+  const colorHelper = usesGeneratedColors(resolvedTypes, branding)
+    ? `
+private extension Color {
+    init(hex: UInt32) {
+        self.init(
+            .sRGB,
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255,
+            opacity: 1
+        )
+    }
+}
+`
+    : '';
+
+  return `import CioLiveActivities_Attributes
+import CioLiveActivities_Templates
+import SwiftUI
+import WidgetKit
+
+// Generated by customerio-expo-plugin from \`config.liveNotifications\`. Renders the Customer.io
+// built-in Live Activity templates; the SwiftUI for each one lives in the Customer.io iOS SDK, so
+// this bundle is all the host app needs. A custom template is rendered by the SwiftUI file named by
+// \`liveNotifications.customWidget\`, copied into this target and instantiated below.
+@main
+struct CIOLiveActivityWidgetBundle: WidgetBundle {
+    var body: some Widget {
+${entries}
+    }
+}
+${colorHelper}`;
+}
+
+function usesGeneratedColors(
+  types: string[],
+  branding: LiveNotificationBranding | undefined
+): boolean {
+  return types.some((type) => {
+    const args = iosBrandingArguments(type, branding);
+    return args !== null && args.includes('Color(hex:');
+  });
+}
+
+// MARK: - Placeholder patching
+
+/**
+ * Replace `{{LIVE_NOTIFICATION_MODULE_IMPORT}}` and `{{LIVE_NOTIFICATION_MODULE_INIT}}` in the
+ * generated SDK initializer.
+ *
+ * iOS registers the activity types on the SDK config builder, which is what makes push-to-start
+ * work on the auto-initialization path. Android applies the enabled types and branding onto the
+ * push module's config builder, since Live Notifications are hosted there.
+ *
+ * A configured `customType` is registered here too. On this path the generated initializer *is* the
+ * runtime registration — the React Native wrapper only registers what it is handed at
+ * `initialize()` — so without it a custom activity would never get a push-to-start token.
+ *
+ * `branding` arrives separately because it lives in the build-time options rather than SDK config
+ * (it has to reach the iOS widget on both initialization paths). Only Android consumes it here;
+ * iOS branding is compiled into the generated widget instead. `customRenderer` arrives the same way
+ * and for the same reason, and is likewise Android-only.
+ */
+export function patchLiveNotificationPlaceholders(
+  content: string,
+  platform: Platform,
+  liveNotifications?: LiveNotificationsSDKConfig,
+  branding?: LiveNotificationBranding,
+  customRenderer?: CustomRendererRegistration
+): string {
+  const types = liveNotifications
+    ? resolveLiveNotificationTypes(liveNotifications.types)
+    : [];
+  const customType = resolveCustomLiveNotificationType(liveNotifications?.customType);
+
+  if (types.length === 0 && !customType) {
+    return clearPlaceholders(content, platform);
+  }
+
+  validateLiveNotificationBranding(branding);
+
+  return platform === PLATFORM.ANDROID
+    ? patchAndroid(content, types, branding, customType, customRenderer)
+    : patchIos(content, types, customType);
+}
+
+function clearPlaceholders(content: string, platform: Platform): string {
+  const withoutImport = content.replace(
+    /\n\{\{LIVE_NOTIFICATION_MODULE_IMPORT\}\}\n/g,
+    '\n'
+  );
+
+  if (platform === PLATFORM.ANDROID) {
+    // The Android placeholder sits mid-chain on the push config builder. Collapse the whole chain
+    // back onto one line so apps that don't use Live Notifications get byte-identical output.
+    return withoutImport.replace(
+      /\n[ \t]*\{\{LIVE_NOTIFICATION_MODULE_INIT\}\}\n([ \t]*)\.build\(\)/g,
+      '.build()'
+    );
+  }
+
+  // `[ \t]*` rather than `\s*`: a greedy match would swallow the blank line the location
+  // placeholder leaves behind, changing output for apps that use neither module.
+  return withoutImport.replace(
+    /\n[ \t]*\{\{LIVE_NOTIFICATION_MODULE_INIT\}\}\n/g,
+    '\n'
+  );
+}
+
+function patchIos(
+  content: string,
+  types: string[],
+  customType: string | undefined
+): string {
+  const registrationLines = types.map(
+    (type) => `                .register(${KNOWN_TYPES[type].iosAttributes}.self)`
+  );
+
+  if (customType) {
+    // One SDK-owned Swift type registered under the app's own identifier. That indirection is what
+    // lets a JavaScript app have a custom activity at all: ActivityKit needs a metatype to register
+    // and to observe push-to-start for, and a metatype can't cross a bridge.
+    registrationLines.push(
+      `                .register(CIOCustomAttributes.self, identifier: "${customType}")`
+    );
+  }
+
+  const registrations = registrationLines.join('\n');
+
+  // `register` is annotated @available(iOS 16.2, *), so the guard is required to compile against
+  // a lower deployment target — the app simply has no Live Activities below 16.2.
+  const init = `if #available(iOS 16.2, *) {
+            _ = builder.addModule(LiveActivitiesModule(config:
+                LiveActivityConfigBuilder()
+${registrations}
+                    .build()))
+        }`;
+
+  return content
+    .replace(
+      /\{\{LIVE_NOTIFICATION_MODULE_IMPORT\}\}/g,
+      'import CioLiveActivities\nimport CioLiveActivities_Attributes\nimport CioLiveActivities_Templates'
+    )
+    .replace(/\{\{LIVE_NOTIFICATION_MODULE_INIT\}\}/g, init);
+}
+
+function patchAndroid(
+  content: string,
+  types: string[],
+  branding: LiveNotificationBranding | undefined,
+  customType: string | undefined,
+  customRenderer: CustomRendererRegistration | undefined
+): string {
+  const enumArgs = types
+    .map((type) => `                        LiveNotificationType.${KNOWN_TYPES[type].androidEnum},`)
+    .join('\n');
+
+  // The placeholder already sits at the chain's indentation, so the first line adds none.
+  const lines: string[] = [];
+  if (types.length > 0) {
+    lines.push('.enableLiveNotificationTypes(', enumArgs, '                    )');
+  }
+
+  if (customType) {
+    // Allowlisting the identifier stops the push handler dropping it; the render callback below is
+    // what actually draws it, since a custom type has no built-in template.
+    lines.push(
+      `${lines.length === 0 ? '' : '                    '}.enableCustomLiveNotificationTypes("${customType}")`
+    );
+  }
+
+  if (customRenderer) {
+    // On this path the generated initializer builds the push module config directly, so it never
+    // passes through the React Native wrapper — the static the wrapper exposes would never be read.
+    // Register the app's renderer here instead.
+    lines.push(
+      `${lines.length === 0 ? '' : '                    '}.setLiveNotificationCallback(${customRenderer.className}())`
+    );
+  }
+
+  const brandingCall = androidBrandingCall(branding);
+  if (brandingCall) {
+    lines.push(brandingCall);
+  }
+
+  const init = lines.join('\n');
+
+  const imports: string[] = [];
+  if (types.length > 0) {
+    // Only the enum overload needs the import; a custom type is passed as a plain string.
+    imports.push('import io.customer.messagingpush.livenotification.LiveNotificationType');
+  }
+  if (customRenderer) {
+    imports.push(`import ${customRenderer.classPackage}.${customRenderer.className}`);
+  }
+  if (brandingCall) {
+    imports.unshift(
+      'import android.graphics.Color',
+      'import io.customer.messagingpush.livenotification.LiveNotificationAsset',
+      'import io.customer.messagingpush.livenotification.LiveNotificationBranding'
+    );
+  }
+
+  // A custom type with no branding needs no import at all; drop the whole line rather than leaving
+  // the blank one an empty replacement would.
+  const withImports =
+    imports.length > 0
+      ? content.replace(/\{\{LIVE_NOTIFICATION_MODULE_IMPORT\}\}/g, imports.join('\n'))
+      : content.replace(/\n\{\{LIVE_NOTIFICATION_MODULE_IMPORT\}\}\n/g, '\n');
+
+  return withImports.replace(/\{\{LIVE_NOTIFICATION_MODULE_INIT\}\}/g, init);
+}
+
+function androidBrandingCall(
+  branding: LiveNotificationBranding | undefined
+): string | null {
+  if (!branding) return null;
+
+  const accent = branding.accentColorHex
+    ? `Color.parseColor("${branding.accentColorHex}")`
+    : 'Color.TRANSPARENT';
+
+  let logo = 'null';
+  if (branding.logo) {
+    logo = isRemoteLogo(branding.logo)
+      ? `LiveNotificationAsset.RemoteUrl("${branding.logo}")`
+      : // Resource ids are assigned at compile time, so the name is resolved at runtime.
+        `application.resources
+                                .getIdentifier("${LIVE_NOTIFICATION_LOGO_ASSET}", "drawable", application.packageName)
+                                .takeIf { it != 0 }
+                                ?.let(LiveNotificationAsset::Drawable)`;
+  }
+
+  return `                    .setLiveNotificationBranding(
+                        LiveNotificationBranding(
+                            companyName = "${branding.companyName ?? ''}",
+                            accentColor = ${accent},
+                            logo = ${logo},
+                        )
+                    )`;
+}

--- a/plugin/src/helpers/utils/patchPluginNativeCode.ts
+++ b/plugin/src/helpers/utils/patchPluginNativeCode.ts
@@ -1,7 +1,14 @@
-import type { NativeSDKConfig } from '../../types/cio-types';
+import type {
+  LiveNotificationBranding,
+  NativeSDKConfig,
+} from '../../types/cio-types';
 import { getPluginVersion } from '../../utils/plugin';
 import { validateNativeSDKConfig } from '../../utils/validation';
 import { PLATFORM, type Platform } from '../constants/common';
+import {
+  type CustomRendererRegistration,
+  patchLiveNotificationPlaceholders,
+} from './patchLiveNotificationCode';
 import {
   type LocationInitOptions,
   patchLocationPlaceholders,
@@ -12,12 +19,18 @@ export type { LocationInitOptions };
 /**
  * Shared utility function to perform common SDK config replacements
  * for both iOS and Android template files
+ *
+ * `liveNotificationBranding` comes from the build-time plugin options rather than `sdkConfig`, since
+ * it also has to reach the generated iOS widget on the JavaScript-initialization path. Only the
+ * Android initializer applies it; iOS compiles branding into the widget instead.
  */
 export function patchNativeSDKInitializer(
   rawContent: string,
   platform: Platform,
   sdkConfig: NativeSDKConfig,
-  locationOptions?: LocationInitOptions
+  locationOptions?: LocationInitOptions,
+  liveNotificationBranding?: LiveNotificationBranding,
+  customRenderer?: CustomRendererRegistration
 ): string {
   // Validate SDK configuration to ensure all fields are present and 
   // correct at the time of patching in prebuild
@@ -106,6 +119,17 @@ export function patchNativeSDKInitializer(
   );
 
   content = patchLocationPlaceholders(content, platform, locationOptions);
+
+  // The types and `customType` live on the SDK config itself — their presence is what enables the
+  // feature on the auto-initialization path. Branding is passed alongside because it is build-time
+  // configuration; see this function's doc comment.
+  content = patchLiveNotificationPlaceholders(
+    content,
+    platform,
+    sdkConfig.liveNotifications,
+    liveNotificationBranding,
+    customRenderer
+  );
 
   return content;
 }

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -1,6 +1,7 @@
 import type { ExpoConfig } from '@expo/config-types';
 
 import { withCIOAndroid } from './android/withCIOAndroid';
+import { resolveSdkConfigForLiveNotifications } from './helpers/utils/liveNotificationsEnabled';
 import { isExpoVersion53OrHigher } from './ios/utils';
 import { withCIOIos } from './ios/withCIOIos';
 import type {
@@ -70,9 +71,17 @@ function withCustomerIOPlugin(
   // strict store layouts, --ignore-scripts, cached CI installs, etc).
   config = withExpoVersion(config);
 
+  // Resolved once, here, because both platforms have to see the same thing: an explicit
+  // `liveNotifications.enabled: false` has to remove the native registration as well as the
+  // build-time artifacts, or the generated code references modules the build no longer links.
+  const sdkConfig = resolveSdkConfigForLiveNotifications(
+    props.liveNotifications,
+    props.config
+  );
+
   // Apply platform specific modifications
-  config = withCIOIos(config, props.config, props.ios, props.location, props.geofence, props.liveNotifications);
-  config = withCIOAndroid(config, props.config, props.android, props.location, props.geofence, props.liveNotifications);
+  config = withCIOIos(config, sdkConfig, props.ios, props.location, props.geofence, props.liveNotifications);
+  config = withCIOAndroid(config, sdkConfig, props.android, props.location, props.geofence, props.liveNotifications);
 
   return config;
 }

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -33,8 +33,8 @@ function withCustomerIOPlugin(
   config = withExpoVersion(config);
 
   // Apply platform specific modifications
-  config = withCIOIos(config, props.config, props.ios, props.location);
-  config = withCIOAndroid(config, props.config, props.android, props.location);
+  config = withCIOIos(config, props.config, props.ios, props.location, props.liveNotifications);
+  config = withCIOAndroid(config, props.config, props.android, props.location, props.liveNotifications);
 
   return config;
 }

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -8,6 +8,7 @@ import type {
   LocationTrackingMode,
   NativeSDKConfig,
 } from './types/cio-types';
+import { logger } from './utils/logger';
 import { withExpoVersion } from './utils/writeExpoVersion';
 
 export type { LocationTrackingMode, NativeSDKConfig };
@@ -32,6 +33,34 @@ function withCustomerIOPlugin(
     throw new Error(
       'CustomerIO geofence requires Expo SDK 53 or higher. ' +
       'Please upgrade to Expo SDK 53+ to enable geofence.'
+    );
+  }
+
+  // Live Notifications needs the Swift AppDelegate to route a tapped activity's URL through the SDK
+  // (see `withCIOIosSwift`), which the plugin only injects on Swift projects. Without that guard a
+  // pre-53 project would still get the widget target, the Info.plist key and the Podfile subspec,
+  // then silently lose tap attribution and deep links.
+  if (props.liveNotifications?.enabled && !isExpoVersion53OrHigher(config)) {
+    throw new Error(
+      'CustomerIO Live Notifications requires Expo SDK 53 or higher. ' +
+      'Please upgrade to Expo SDK 53+ to enable Live Notifications.'
+    );
+  }
+
+  // Auto initialization registers activity types from `config.liveNotifications`. Enabling the
+  // build-time setup without it produces an app whose initializer never adds the Live Activities
+  // module: nothing is registered for push-to-start, and a JavaScript `start()` has no module to
+  // reach. Warn rather than throw — the flag is still the right way to opt in when initializing
+  // from JavaScript, which is exactly the case where `config` is absent.
+  if (
+    props.liveNotifications?.enabled &&
+    props.config &&
+    !props.config.liveNotifications
+  ) {
+    logger.warn(
+      'liveNotifications.enabled is set and the Customer.io SDK initializes automatically, but ' +
+      'config.liveNotifications is missing, so no activity types are registered. Add ' +
+      'config.liveNotifications with types and/or customType, or drop liveNotifications.enabled.'
     );
   }
 

--- a/plugin/src/ios/withCIOIos.ts
+++ b/plugin/src/ios/withCIOIos.ts
@@ -95,6 +95,15 @@ export function withCIOIos(
   } else if (optionalModulesEnabled) {
     // No push, no config. Still add the Podfile subspecs so the relevant native modules are
     // compiled in and their flags set (CIO_LOCATION_ENABLED / CIO_GEOFENCE_ENABLED, live activities).
+    //
+    // Live Notifications additionally needs the AppDelegate to route a tapped activity's URL through
+    // the SDK. Without it the activity still renders, but the `opened` metric is never reported and
+    // the deep link the activity carries is never forwarded. `withCIOIosSwift` is built for exactly
+    // this shape — no push and no SDK config — and calls the Live Activities module directly, since
+    // `CioSdkAppDelegateHandler` imports the push module this configuration does not install.
+    if (liveNotificationsEnabled && isSwiftProject) {
+      config = withCIOIosSwift(config, sdkConfig, platformConfig, location, geofence, liveNotificationsEnabled);
+    }
     config = withCioXcodeProject(config, {
       ...platformConfig,
       podfileOptions: {

--- a/plugin/src/ios/withCIOIos.ts
+++ b/plugin/src/ios/withCIOIos.ts
@@ -108,7 +108,12 @@ export function withCIOIos(
 
   // Live Activities: set the host Info.plist flag and inject the widget extension target,
   // independent of push. Requires iOS 16.2+.
-  if (liveNotificationsEnabled && platformConfig) {
+  // Not gated on `platformConfig`: an app can enable Live Notifications without declaring an `ios`
+  // block (app.json is untyped, so `ios` being required in the TypeScript options doesn't enforce it),
+  // and the widget reads only optional values from it. Requiring it here still added the Podfile
+  // subspec while skipping the plist key and the widget target, leaving nothing able to start or
+  // render an activity and no warning to say why. Location and geofence already work without one.
+  if (liveNotificationsEnabled) {
     config = withLiveActivityInfoPlist(config);
     config = withCioLiveActivityWidgetXcodeProject(config, {
       props: platformConfig,

--- a/plugin/src/ios/withCIOIos.ts
+++ b/plugin/src/ios/withCIOIos.ts
@@ -3,16 +3,20 @@ import { withEntitlementsPlist } from '@expo/config-plugins';
 import type {
   CustomerIOPluginOptionsIOS,
   CustomerIOPluginPushNotificationOptions,
+  CustomerIOPluginLiveNotificationsOptions,
   CustomerIOPluginLocationOptions,
   NativeSDKConfig,
 } from '../types/cio-types';
+import { isLiveNotificationsEnabled } from '../helpers/utils/liveNotificationsEnabled';
 import { mergeConfigWithEnvValues } from '../utils/config';
 import { logger } from '../utils/logger';
 import { validatePushNotificationOptions } from '../utils/validation';
 import { isExpoVersion53OrHigher } from './utils';
 import { withAppDelegateModifications } from './withAppDelegateModifications';
 import { withCIOIosSwift } from './withCIOIosSwift';
+import { withCioLiveActivityWidgetXcodeProject } from './withCioLiveActivityWidgetXcodeProject';
 import { withGoogleServicesJsonFile } from './withGoogleServicesJsonFile';
+import { withLiveActivityInfoPlist } from './withLiveActivityInfoPlist';
 import { withCioNotificationsXcodeProject } from './withNotificationsXcodeProject';
 import { withCioXcodeProject } from './withXcodeProject';
 
@@ -21,15 +25,20 @@ export function withCIOIos(
   sdkConfig?: NativeSDKConfig,
   props?: CustomerIOPluginOptionsIOS,
   location?: CustomerIOPluginLocationOptions,
+  liveNotifications?: CustomerIOPluginLiveNotificationsOptions,
 ) {
   const isSwiftProject = isExpoVersion53OrHigher(config);
   const platformConfig = mergeDeprecatedPropertiesAndLogWarnings(props);
   const locationEnabled = location?.enabled === true;
+  const liveNotificationsEnabled = isLiveNotificationsEnabled(
+    liveNotifications,
+    sdkConfig
+  );
 
   if (platformConfig?.pushNotification) {
     validatePushNotificationOptions(platformConfig.pushNotification);
     if (isSwiftProject) {
-      config = withCIOIosSwift(config, sdkConfig, platformConfig, location);
+      config = withCIOIosSwift(config, sdkConfig, platformConfig, location, liveNotificationsEnabled);
     } else {
       // Auto initialization is only supported in Swift projects (Expo SDK 53+)
       // Legacy Objective-C projects only support push notifications
@@ -44,6 +53,7 @@ export function withCIOIos(
       podfileOptions: {
         locationEnabled,
         hasPush: true,
+        liveNotificationsEnabled,
       },
     });
     config = withGoogleServicesJsonFile(config, platformConfig);
@@ -61,18 +71,32 @@ export function withCIOIos(
       });
     }
   } else if (sdkConfig && isSwiftProject) {
-    config = withCIOIosSwift(config, sdkConfig, platformConfig, location);
-    if (locationEnabled) {
+    config = withCIOIosSwift(config, sdkConfig, platformConfig, location, liveNotificationsEnabled);
+    if (locationEnabled || liveNotificationsEnabled) {
       config = withCioXcodeProject(config, {
         ...platformConfig,
-        podfileOptions: { locationEnabled: true, hasPush: false },
+        podfileOptions: { locationEnabled, hasPush: false, liveNotificationsEnabled },
       });
     }
-  } else if (locationEnabled) {
-    // Location-only: no push, no config. Still add Podfile location subspec so CIO_LOCATION_ENABLED is set and native location code is included.
+  } else if (locationEnabled || liveNotificationsEnabled) {
+    // No push, no config. Still add the Podfile subspecs so the relevant native modules
+    // (location / live activities) are compiled in.
     config = withCioXcodeProject(config, {
       ...platformConfig,
-      podfileOptions: { locationEnabled: true, hasPush: false },
+      podfileOptions: { locationEnabled, hasPush: false, liveNotificationsEnabled },
+    });
+  }
+
+  // Live Activities: set the host Info.plist flag and inject the widget extension target,
+  // independent of push. Requires iOS 16.2+.
+  if (liveNotificationsEnabled && platformConfig) {
+    config = withLiveActivityInfoPlist(config);
+    config = withCioLiveActivityWidgetXcodeProject(config, {
+      props: platformConfig,
+      liveNotifications: sdkConfig?.liveNotifications,
+      // `customWidget` lives in the build-time options rather than SDK config, so it reaches the
+      // widget whether the app initializes automatically or from JavaScript.
+      buildOptions: liveNotifications,
     });
   }
 

--- a/plugin/src/ios/withCIOIosSwift.ts
+++ b/plugin/src/ios/withCIOIosSwift.ts
@@ -490,6 +490,48 @@ function hasCioOpenUrlHandling(contents: string): boolean {
 }
 
 /**
+ * The whole method {@link modifyAppDelegateForLiveActivityUrl} appends when the template has no
+ * `application(_:open:options:)` of its own. Removing the entire method — rather than just its guard —
+ * puts the file back as it was, so the push injector takes its normal "no implementation to wrap"
+ * path instead of grafting onto a method the Live Activity injector invented.
+ */
+const LIVE_ACTIVITY_URL_METHOD_REGEX =
+  /\n[ \t]*\/\/ Report a Live Activity tap and route the deep link it carries\n[ \t]*public override func application\(_ app: UIApplication, open url: URL, options: \[UIApplication\.OpenURLOptionsKey: Any\] = \[:\]\) -> Bool \{\n[ \t]*guard let url = CustomerIO\.liveActivities\.handleWidgetUrl\(url\) else \{ return true \}\n[ \t]*return super\.application\(app, open: url, options: options\)\n[ \t]*\}\n/g;
+
+/**
+ * The comment + guard pair {@link modifyAppDelegateForLiveActivityUrl} injects into a method that
+ * already existed.
+ *
+ * Both patterns are kept in sync with the injector by the round-trip test rather than by shared
+ * constants, because a removal has to match the emitted text exactly, indentation included.
+ */
+const LIVE_ACTIVITY_URL_GUARD_REGEX =
+  /\n[ \t]*\/\/ Report a Live Activity tap and route the deep link it carries\n[ \t]*guard let url = CustomerIO\.liveActivities\.handleWidgetUrl\(url\) else \{ return true \}/g;
+
+/**
+ * Strips the no-push Live Activity guard so the push handler can take over.
+ *
+ * An app can be prebuilt with Live Notifications and no push, which installs the direct call, and
+ * later add a push provider. `CioSdkAppDelegateHandler` routes activity URLs too, so leaving the
+ * direct call in place would report the same tap twice — and the push guard is inserted into the very
+ * method that already holds it, whether that method came from Expo's template or was created by the
+ * Live Activity injector.
+ *
+ * Leaves the imports alone: they stay valid while the feature is on, and `addSwiftImports` is
+ * idempotent.
+ */
+function removeLiveActivityUrlGuard(contents: string): string {
+  if (!contents.includes(LIVE_ACTIVITY_URL_CALL)) {
+    return contents;
+  }
+  // Whole-method shape first: it contains the guard shape's text, so the narrower pattern would
+  // otherwise strip the guard and leave an empty method behind.
+  return contents
+    .replace(LIVE_ACTIVITY_URL_METHOD_REGEX, '')
+    .replace(LIVE_ACTIVITY_URL_GUARD_REGEX, '');
+}
+
+/**
  * Add Swift imports after the file's last existing import.
  *
  * Matches an optional leading modifier because React Native 0.83 emits `internal import Expo` as the
@@ -515,6 +557,10 @@ const addOpenURLHandling = (content: string): string => {
   if (hasCioOpenUrlHandling(content)) {
     return content;
   }
+
+  // The push handler supersedes the no-push Live Activity call, so drop that one first — otherwise
+  // enabling push on an already-prebuilt project stacks a second guard in the same method.
+  content = removeLiveActivityUrlGuard(content);
 
   // Match either parameter spelling (`_ app` in Expo's template, `_ application` elsewhere) across
   // the multi-line signature Expo generates.

--- a/plugin/src/ios/withCIOIosSwift.ts
+++ b/plugin/src/ios/withCIOIosSwift.ts
@@ -222,6 +222,7 @@ export const withCIOIosSwift = (
   sdkConfig?: NativeSDKConfig,
   props?: CustomerIOPluginOptionsIOS,
   location?: CustomerIOPluginLocationOptions,
+  liveNotificationsEnabled = false,
 ) => {
   // First, copy required swift files to iOS folder and add it to Xcode project
   configOuter = withXcodeProject(configOuter, async (config) => {
@@ -238,12 +239,20 @@ export const withCIOIosSwift = (
       );
       return config;
     });
-  } else if (sdkConfig) {
-    // Without push notifications: directly inject auto initialization into AppDelegate
+  } else if (sdkConfig || liveNotificationsEnabled) {
+    // Without push notifications: inject auto initialization directly, plus the Live Activity tap
+    // route when the feature is on. `CioSdkAppDelegateHandler` is not an option here — it imports
+    // the push module, which this configuration does not install — so the tap goes straight to the
+    // Live Activities module instead.
     return withAppDelegate(configOuter, async (config) => {
-      config.modResults.contents = modifyAppDelegateForNativeSDKInitializer(
-        config.modResults.contents
-      );
+      let next = config.modResults.contents;
+      if (sdkConfig) {
+        next = modifyAppDelegateForNativeSDKInitializer(next);
+      }
+      if (liveNotificationsEnabled) {
+        next = modifyAppDelegateForLiveActivityUrl(next);
+      }
+      config.modResults.contents = next;
       return config;
     });
   } else {
@@ -262,9 +271,12 @@ export function modifyAppDelegateForPushHandler(
 ): string {
   if (contents.includes(CIO_SDK_APP_DELEGATE_HANDLER_CLASS)) {
     logger.info(
-      'CustomerIO Swift AppDelegate changes already exist. Skipping...'
+      'CustomerIO Swift AppDelegate changes already exist. Adding anything newer...'
     );
-    return contents;
+    // Don't return the file untouched: an AppDelegate integrated by an earlier plugin version has
+    // the handler but not the Live Activity tap route, and skipping outright leaves every upgraded
+    // app without it. `addOpenURLHandling` is idempotent, so re-running it is safe.
+    return addOpenURLHandling(contents);
   }
 
   let next = addHandlerPropertyDeclaration(contents);
@@ -274,12 +286,62 @@ export function modifyAppDelegateForPushHandler(
   );
   next = addDidRegisterForRemoteNotificationsWithDeviceToken(next);
   next = addDidFailToRegisterForRemoteNotificationsWithError(next);
+  next = addOpenURLHandling(next);
 
   if (props.pushNotification?.handleDeeplinkInKilledState === true) {
     next = addHandleDeeplinkInKilledState(next);
   }
 
   return next;
+}
+
+/**
+ * Pure string transform: routes opened URLs to the Live Activities module on the no-push path.
+ *
+ * The push path delegates this to `CioSdkAppDelegateHandler`, but that file imports the push module,
+ * which a Live-Notifications-without-push app does not install. Calling the module directly keeps
+ * the tap reporting its `opened` metric and returning the customer's deep link either way.
+ *
+ * Idempotent, and a no-op if the push handler already owns the method.
+ */
+export function modifyAppDelegateForLiveActivityUrl(contents: string): string {
+  if (contents.includes(LIVE_ACTIVITY_URL_CALL) || contents.includes(`${CIO_OPEN_URL_MARKER}app, open:`)) {
+    return contents;
+  }
+
+  const next = addSwiftImports(contents, LIVE_ACTIVITY_IMPORTS);
+
+  const methodRegex =
+    /func\s+application\s*\(\s*_\s+(app|application)\s*:\s*UIApplication\s*,\s*open\s+url\s*:\s*URL\s*,\s*options\s*:[^)]*\)\s*->\s*Bool\s*{/;
+  const match = next.match(methodRegex);
+
+  if (match) {
+    const insertAt = (match.index ?? 0) + match[0].length;
+    return (
+      next.substring(0, insertAt) +
+      '\n    // Report a Live Activity tap and route the deep link it carries\n' +
+      `    guard let url = ${LIVE_ACTIVITY_URL_CALL}(url) else { return true }\n` +
+      next.substring(insertAt)
+    );
+  }
+
+  const classEndRegex = /^}(\s*$|\s*\/\/)/m;
+  const classEndMatch = next.match(classEndRegex);
+  if (!classEndMatch) {
+    logger.warn('Could not find end of AppDelegate class');
+    return next;
+  }
+
+  const position = classEndMatch.index ?? 0;
+  return (
+    next.substring(0, position) +
+    '\n  // Report a Live Activity tap and route the deep link it carries\n' +
+    '  public override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {\n' +
+    `    guard let url = ${LIVE_ACTIVITY_URL_CALL}(url) else { return true }\n` +
+    '    return super.application(app, open: url, options: options)\n' +
+    '  }\n' +
+    next.substring(position)
+  );
 }
 
 /**
@@ -370,6 +432,97 @@ const modifyDidFinishLaunchingWithOptions = (content: string, codeToInject: stri
  * If the method already exists, it adds the handler call to the existing method
  * If the method doesn't exist, it adds a new method implementation
  */
+/**
+ * Route a tapped Live Activity through the Customer.io handler before the app's own deep-link
+ * handling runs.
+ *
+ * The handler reports the `opened` metric and returns the URL to actually open: for a Customer.io
+ * widget URL that's the customer's deep link, and any other URL comes back unchanged. The injected
+ * `guard let url = ...` shadows the parameter, so the rest of an existing implementation keeps
+ * working verbatim against the routed URL; `nil` means the activity carried no deep link and there
+ * is nothing left to open.
+ */
+const CIO_OPEN_URL_MARKER = 'cioSdkHandler.application(';
+/**
+ * Both are required to compile the injected call.
+ *
+ * `CustomerIO` itself is declared in `CioInternalCommon`, which `CioDataPipelines` re-exports with
+ * `@_exported`. `CioLiveActivities` only adds the `liveActivities` extension and imports
+ * `CioInternalCommon` plainly, so importing it alone leaves `CustomerIO` out of scope. The push-path
+ * handler imports the same pair for this reason.
+ */
+const LIVE_ACTIVITY_IMPORTS = [
+  'import CioDataPipelines',
+  'import CioLiveActivities',
+];
+const LIVE_ACTIVITY_URL_CALL = 'CustomerIO.liveActivities.handleWidgetUrl';
+
+/**
+ * Add Swift imports after the file's last existing import.
+ *
+ * Matches an optional leading modifier because React Native 0.83 emits `internal import Expo` as the
+ * first line of AppDelegate.swift. An expression anchored to a bare `import` at the start of the
+ * file silently matches nothing there, which leaves the injected call referencing symbols that were
+ * never imported — a failure that only surfaces at compile time.
+ */
+function addSwiftImports(contents: string, imports: string[]): string {
+  const missing = imports.filter((line) => !contents.includes(line));
+  if (missing.length === 0) return contents;
+
+  const matches = [...contents.matchAll(/^(?:\w+[ \t]+)?import[ \t]+\S+.*$/gm)];
+  if (matches.length === 0) return contents;
+
+  const last = matches[matches.length - 1];
+  const insertAt = (last.index ?? 0) + last[0].length;
+  return `${contents.slice(0, insertAt)}\n${missing.join('\n')}${contents.slice(insertAt)}`;
+}
+
+const addOpenURLHandling = (content: string): string => {
+  // Already wired — by this run or by an earlier prebuild. Injecting again would duplicate the guard
+  // inside the same method.
+  if (content.includes(`${CIO_OPEN_URL_MARKER}app, open:`) ||
+      content.includes(`${CIO_OPEN_URL_MARKER}application, open:`)) {
+    return content;
+  }
+
+  // Match either parameter spelling (`_ app` in Expo's template, `_ application` elsewhere) across
+  // the multi-line signature Expo generates.
+  const methodRegex =
+    /func\s+application\s*\(\s*_\s+(app|application)\s*:\s*UIApplication\s*,\s*open\s+url\s*:\s*URL\s*,\s*options\s*:[^)]*\)\s*->\s*Bool\s*{/;
+  const match = content.match(methodRegex);
+
+  if (match) {
+    const appParam = match[1];
+    const insertAt = (match.index ?? 0) + match[0].length;
+    return (
+      content.substring(0, insertAt) +
+      '\n    // Call CustomerIO SDK handler\n' +
+      `    guard let url = cioSdkHandler.application(${appParam}, open: url, options: options) else { return true }\n` +
+      content.substring(insertAt)
+    );
+  }
+
+  // No implementation to wrap, so add one that only reports and forwards to super.
+  const classEndRegex = /^}(\s*$|\s*\/\/)/m;
+  const classEndMatch = content.match(classEndRegex);
+  if (!classEndMatch) {
+    logger.warn('Could not find end of AppDelegate class');
+    return content;
+  }
+
+  const position = classEndMatch.index ?? 0;
+  return (
+    content.substring(0, position) +
+    '\n  // Report a Live Activity tap and route the deep link it carries\n' +
+    '  public override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {\n' +
+    '    // Call CustomerIO SDK handler\n' +
+    '    guard let url = cioSdkHandler.application(app, open: url, options: options) else { return true }\n' +
+    '    return super.application(app, open: url, options: options)\n' +
+    '  }\n' +
+    content.substring(position)
+  );
+};
+
 const addDidRegisterForRemoteNotificationsWithDeviceToken = (
   content: string
 ): string => {

--- a/plugin/src/ios/withCIOIosSwift.ts
+++ b/plugin/src/ios/withCIOIosSwift.ts
@@ -322,7 +322,7 @@ export function modifyAppDelegateForPushHandler(
  * Idempotent, and a no-op if the push handler already owns the method.
  */
 export function modifyAppDelegateForLiveActivityUrl(contents: string): string {
-  if (contents.includes(LIVE_ACTIVITY_URL_CALL) || contents.includes(`${CIO_OPEN_URL_MARKER}app, open:`)) {
+  if (contents.includes(LIVE_ACTIVITY_URL_CALL) || hasCioOpenUrlHandling(contents)) {
     return contents;
   }
 
@@ -475,6 +475,21 @@ const LIVE_ACTIVITY_IMPORTS = [
 const LIVE_ACTIVITY_URL_CALL = 'CustomerIO.liveActivities.handleWidgetUrl';
 
 /**
+ * Whether the push path already owns `application(_:open:options:)`.
+ *
+ * Both parameter spellings have to be checked: Expo's template names it `_ app`, other templates use
+ * `_ application`, and the injected marker carries whichever one the AppDelegate had. Shared by both
+ * injectors so they can't disagree — checking only one spelling lets the other path add a second
+ * guard inside the same method on a re-prebuild.
+ */
+function hasCioOpenUrlHandling(contents: string): boolean {
+  return (
+    contents.includes(`${CIO_OPEN_URL_MARKER}app, open:`) ||
+    contents.includes(`${CIO_OPEN_URL_MARKER}application, open:`)
+  );
+}
+
+/**
  * Add Swift imports after the file's last existing import.
  *
  * Matches an optional leading modifier because React Native 0.83 emits `internal import Expo` as the
@@ -497,8 +512,7 @@ function addSwiftImports(contents: string, imports: string[]): string {
 const addOpenURLHandling = (content: string): string => {
   // Already wired — by this run or by an earlier prebuild. Injecting again would duplicate the guard
   // inside the same method.
-  if (content.includes(`${CIO_OPEN_URL_MARKER}app, open:`) ||
-      content.includes(`${CIO_OPEN_URL_MARKER}application, open:`)) {
+  if (hasCioOpenUrlHandling(content)) {
     return content;
   }
 

--- a/plugin/src/ios/withCioLiveActivityWidgetXcodeProject.ts
+++ b/plugin/src/ios/withCioLiveActivityWidgetXcodeProject.ts
@@ -1,0 +1,432 @@
+import type { ConfigPlugin, XcodeProject } from '@expo/config-plugins';
+import { withXcodeProject } from '@expo/config-plugins';
+
+import {
+  CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME,
+  DEFAULT_BUNDLE_VERSION,
+  DEFAULT_LIVE_ACTIVITY_DEPLOYMENT_TARGET,
+} from '../helpers/constants/ios';
+import { replaceCodeByRegex } from '../helpers/utils/codeInjection';
+import { FileManagement } from '../helpers/utils/fileManagement';
+import { injectCIOLiveActivityWidgetPodfileCode } from '../helpers/utils/injectCIOPodfileCode';
+import {
+  installCustomLiveActivityWidget,
+  resolveCustomLiveActivityWidget,
+  type ResolvedCustomWidget,
+} from '../helpers/utils/liveNotificationCustomWidget';
+import { installIosLiveNotificationLogo } from '../helpers/utils/liveNotificationLogo';
+import {
+  generateWidgetBundleSwift,
+  resolveLiveNotificationTypes,
+  validateLiveNotificationBranding,
+} from '../helpers/utils/patchLiveNotificationCode';
+import type {
+  CustomerIOPluginLiveNotificationsOptions,
+  CustomerIOPluginOptionsIOS,
+  LiveNotificationsSDKConfig,
+} from '../types/cio-types';
+import { logger } from '../utils/logger';
+import { getIosNativeFilesPath } from '../utils/plugin';
+
+const PLIST_FILENAME = `${CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME}-Info.plist`;
+const WIDGET_BUNDLE_FILENAME = 'CIOLiveActivityWidgetBundle.swift';
+const ASSET_CATALOG_FILENAME = 'Assets.xcassets';
+
+// Files the plugin itself writes into the widget directory. A source file copied in from the app
+// must not shadow one of them — everything lands in this one flat directory.
+const GENERATED_WIDGET_FILENAMES = [
+  WIDGET_BUNDLE_FILENAME,
+  PLIST_FILENAME,
+  ASSET_CATALOG_FILENAME,
+];
+
+// Widget files registered in the Xcode group; `customFilenames` are the app's own SwiftUI files (see
+// `liveNotifications.customWidget`), so both lists are computed rather than fixed. Swift files are
+// compiled (Sources phase); the Info.plist is referenced via INFOPLIST_FILE (set by `addTarget`) but
+// still listed in the group so it appears in the Xcode navigator.
+const widgetSourceFiles = (customFilenames: string[] = []): string[] => [
+  WIDGET_BUNDLE_FILENAME,
+  ...customFilenames,
+];
+const widgetGroupFiles = (
+  customFilenames: string[] = [],
+  resourceFiles: string[] = []
+): string[] => [
+  ...widgetSourceFiles(customFilenames),
+  PLIST_FILENAME,
+  ...resourceFiles,
+];
+
+const TARGETED_DEVICE_FAMILY = `"1,2"`;
+// WidgetKit + SwiftUI + ActivityKit need Swift 5; the NSE target uses 4.2 for its ObjC-heavy code.
+const WIDGET_SWIFT_VERSION = '5.0';
+
+export type AddLiveActivityWidgetTargetOptions = {
+  appleTeamId?: string;
+  bundleIdentifier?: string;
+  iosDeploymentTarget?: string;
+  /** Asset catalog filename to compile into the widget, when a branding logo was installed. */
+  assetCatalogFilename?: string;
+  /** Swift files copied in from the app (`liveNotifications.customWidget`), to compile too. */
+  customSourceFilenames?: string[];
+};
+
+/**
+ * Injects a WidgetKit app-extension target that renders the Customer.io built-in Live Activity
+ * templates, plus the app's own SwiftUI when `liveNotifications.customWidget` names some. Clones the
+ * NotificationServiceExtension injection pattern: copies the widget template files, appends the
+ * widget Podfile target block, and registers the target/group/build-phases in the parsed Xcode
+ * project.
+ *
+ * Only the *contents* of the widget directory are re-synced once the target exists — see
+ * {@link addLiveActivityWidget}.
+ */
+export const withCioLiveActivityWidgetXcodeProject: ConfigPlugin<{
+  props: CustomerIOPluginOptionsIOS;
+  /** SDK config (automatic initialization): the enabled types and `customType`. */
+  liveNotifications?: LiveNotificationsSDKConfig;
+  /**
+   * Build-time plugin options, which carry `customWidget` and `branding` on either initialization
+   * path. Both are compiled into this widget, so neither can come from SDK config — that only
+   * exists when the app initializes automatically.
+   */
+  buildOptions?: CustomerIOPluginLiveNotificationsOptions;
+}> = (configOuter, { props, liveNotifications, buildOptions }) => {
+  return withXcodeProject(configOuter, async (config) => {
+    const { modRequest, ios, version: bundleShortVersion } = config;
+    const { appleTeamId, useFrameworks } = props;
+    // Fixed at the ActivityKit floor. Custom SwiftUI needing newer APIs uses availability
+    // annotations (`if #available(iOS 17, *)`), which work fine at this deployment target.
+    const iosDeploymentTarget = DEFAULT_LIVE_ACTIVITY_DEPLOYMENT_TARGET;
+
+    validateLiveNotificationBranding(buildOptions?.branding);
+
+    if (ios === undefined) {
+      throw new Error(
+        'Adding Live Activity widget failed: ios config missing from app.config.js or app.json.'
+      );
+    }
+
+    const { projectName, platformProjectRoot } = modRequest;
+    const { bundleIdentifier, buildNumber } = ios;
+
+    if (bundleIdentifier === undefined) {
+      throw new Error(
+        'Adding Live Activity widget failed: ios.bundleIdentifier missing from app.config.js or app.json.'
+      );
+    }
+
+    if (projectName === undefined) {
+      throw new Error(
+        'Adding Live Activity widget failed: name missing from app.config.js or app.json.'
+      );
+    }
+
+    try {
+      await addLiveActivityWidget(
+        {
+          iosPath: platformProjectRoot,
+          bundleIdentifier,
+          bundleShortVersion,
+          bundleVersion: buildNumber || DEFAULT_BUNDLE_VERSION,
+          appleTeamId,
+          iosDeploymentTarget,
+          useFrameworks,
+          liveNotifications,
+          buildOptions,
+          autoInitializes: liveNotifications !== undefined,
+          projectRoot: modRequest.projectRoot,
+        },
+        config.modResults
+      );
+    } catch (error: unknown) {
+      logger.error(String(error));
+    }
+
+    return config;
+  });
+};
+
+type AddLiveActivityWidgetInternalOptions = {
+  iosPath: string;
+  bundleIdentifier: string;
+  bundleShortVersion?: string;
+  bundleVersion: string;
+  appleTeamId?: string;
+  iosDeploymentTarget: string;
+  useFrameworks?: CustomerIOPluginOptionsIOS['useFrameworks'];
+  liveNotifications?: LiveNotificationsSDKConfig;
+  buildOptions?: CustomerIOPluginLiveNotificationsOptions;
+  /** True when the app initializes the SDK automatically (an SDK config is present). */
+  autoInitializes: boolean;
+  projectRoot: string;
+};
+
+/**
+ * Writes the widget directory and registers the target.
+ *
+ * **A re-run against a project that already has the target only refreshes file contents.** The
+ * group and build-phase entries were written by the first run and are keyed by file name, so a file
+ * that is *added* or *renamed* afterwards cannot be registered here — that needs
+ * `expo prebuild --clean`. Contents are still rewritten (the generated bundle, the app's custom
+ * SwiftUI, the branding asset) so the common case, iterating on a widget's SwiftUI, works without a
+ * clean prebuild.
+ */
+const addLiveActivityWidget = async (
+  options: AddLiveActivityWidgetInternalOptions,
+  xcodeProject: XcodeProject
+) => {
+  const { iosPath, useFrameworks, iosDeploymentTarget } = options;
+
+  await injectCIOLiveActivityWidgetPodfileCode(iosPath, useFrameworks);
+
+  const widgetPath = `${iosPath}/${CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME}`;
+  const getTargetFile = (filename: string) => `${widgetPath}/${filename}`;
+  FileManagement.mkdir(widgetPath, { recursive: true });
+
+  const customWidget = resolveCustomLiveActivityWidget({
+    liveNotifications: options.liveNotifications,
+    buildOptions: options.buildOptions,
+    autoInitializes: options.autoInitializes,
+    projectRoot: options.projectRoot,
+    reservedFilenames: GENERATED_WIDGET_FILENAMES,
+  });
+
+  const writeWidgetSources = (): {
+    customSourceFilenames: string[];
+    assetCatalogPath: string | null;
+  } => {
+    // The widget bundle is generated, not copied: it must render exactly the enabled types, and iOS
+    // branding is SwiftUI compiled into the widget, so it can only be applied here.
+    FileManagement.writeFile(
+      getTargetFile(WIDGET_BUNDLE_FILENAME),
+      generateWidgetBundleSwift(
+        resolveLiveNotificationTypes(options.liveNotifications?.types),
+        options.buildOptions?.branding,
+        customWidget?.structName,
+        options.autoInitializes
+      )
+    );
+
+    // iOS branding is SwiftUI compiled into the widget, so a local logo has to become a real asset
+    // in this target — the generated bundle references it by name.
+    const assetCatalogPath = installIosLiveNotificationLogo(
+      options.buildOptions?.branding,
+      widgetPath,
+      options.projectRoot
+    );
+
+    return {
+      customSourceFilenames: customWidget
+        ? installCustomLiveActivityWidget(customWidget, widgetPath)
+        : [],
+      assetCatalogPath,
+    };
+  };
+
+  if (xcodeProject.pbxTargetByName(CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME)) {
+    logger.warn(
+      `${CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME} already exists in project. Refreshing its generated files ` +
+        'only — files added or renamed since it was created cannot be registered on an existing target. ' +
+        'Run `expo prebuild --clean` to regenerate it from scratch.'
+    );
+    writeWidgetSources();
+    warnAboutUnregisteredSources(xcodeProject, customWidget);
+    return;
+  }
+
+  const sourceDir = `${getIosNativeFilesPath()}/widget`;
+  FileManagement.copyFile(
+    `${sourceDir}/${PLIST_FILENAME}`,
+    getTargetFile(PLIST_FILENAME)
+  );
+
+  const { customSourceFilenames, assetCatalogPath } = writeWidgetSources();
+
+  updateWidgetInfoPlist({
+    infoPlistTargetFile: getTargetFile(PLIST_FILENAME),
+    bundleVersion: options.bundleVersion,
+    bundleShortVersion: options.bundleShortVersion,
+  });
+
+  addLiveActivityWidgetToXcodeProject(xcodeProject, {
+    appleTeamId: options.appleTeamId,
+    bundleIdentifier: options.bundleIdentifier,
+    iosDeploymentTarget,
+    assetCatalogFilename: assetCatalogPath ? ASSET_CATALOG_FILENAME : undefined,
+    customSourceFilenames,
+  });
+};
+
+/**
+ * On a refresh-only run, a custom source file whose name isn't already in the project was added or
+ * renamed after the target was created, so nothing compiles it. Name it rather than leaving the
+ * failure to show up as a missing symbol at build time.
+ */
+function warnAboutUnregisteredSources(
+  xcodeProject: XcodeProject,
+  customWidget: ResolvedCustomWidget | null
+): void {
+  if (!customWidget) return;
+
+  const unregistered = customWidget.filenames.filter(
+    (filename) => !hasFileReference(xcodeProject, filename)
+  );
+  if (unregistered.length === 0) return;
+
+  logger.warn(
+    `${unregistered.join(', ')} ${unregistered.length === 1 ? 'is' : 'are'} not registered on the existing ` +
+      `${CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME} target, so ${unregistered.length === 1 ? 'it' : 'they'} will not ` +
+      'be compiled. Run `expo prebuild --clean` to pick up new or renamed custom widget files.'
+  );
+}
+
+function hasFileReference(xcodeProject: XcodeProject, filename: string): boolean {
+  const references = xcodeProject.hash.project.objects.PBXFileReference ?? {};
+  return Object.keys(references).some((key) => {
+    const reference = references[key];
+    if (typeof reference !== 'object' || reference === null) return false;
+    const value = String(reference.path ?? reference.name ?? '').replace(/"/g, '');
+    return value === filename || value.endsWith(`/${filename}`);
+  });
+}
+
+/**
+ * Pure string transform: substitutes the `{{BUNDLE_VERSION}}` and `{{BUNDLE_SHORT_VERSION}}`
+ * placeholders in the widget Info.plist template. Exported for tests.
+ */
+export function applyBundleVersionToWidgetPlist(
+  content: string,
+  payload: { bundleVersion?: string; bundleShortVersion?: string }
+): string {
+  let next = content;
+  if (payload.bundleVersion) {
+    next = replaceCodeByRegex(
+      next,
+      /\{\{BUNDLE_VERSION\}\}/,
+      payload.bundleVersion
+    );
+  }
+  if (payload.bundleShortVersion) {
+    next = replaceCodeByRegex(
+      next,
+      /\{\{BUNDLE_SHORT_VERSION\}\}/,
+      payload.bundleShortVersion
+    );
+  }
+  return next;
+}
+
+const updateWidgetInfoPlist = (payload: {
+  bundleVersion?: string;
+  bundleShortVersion?: string;
+  infoPlistTargetFile: string;
+}) => {
+  const next = applyBundleVersionToWidgetPlist(
+    FileManagement.readFile(payload.infoPlistTargetFile),
+    payload
+  );
+  FileManagement.writeFile(payload.infoPlistTargetFile, next);
+};
+
+/**
+ * Mutates the parsed XcodeProject to register the Live Activity widget extension target: creates a
+ * PBXGroup for its files, registers the group under the project's top-level group, adds the
+ * app_extension target (which auto-wires the host app's "Embed App Extensions" copy-files phase),
+ * wires the three build phases, and configures deployment target / Swift version / signing.
+ *
+ * Idempotent — returns the project unchanged if the widget target already exists.
+ */
+export function addLiveActivityWidgetToXcodeProject(
+  xcodeProject: XcodeProject,
+  options: AddLiveActivityWidgetTargetOptions
+): XcodeProject {
+  if (xcodeProject.pbxTargetByName(CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME)) {
+    logger.warn(
+      `${CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME} already exists in project. Skipping...`
+    );
+    return xcodeProject;
+  }
+
+  const {
+    appleTeamId,
+    bundleIdentifier,
+    iosDeploymentTarget,
+    assetCatalogFilename,
+    customSourceFilenames = [],
+  } = options;
+  const resourceFiles = assetCatalogFilename ? [assetCatalogFilename] : [];
+
+  // Create new PBXGroup for the widget files.
+  const widgetGroup = xcodeProject.addPbxGroup(
+    widgetGroupFiles(customSourceFilenames, resourceFiles),
+    CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME,
+    CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME
+  );
+
+  // Attach the group to the top-level (nameless/pathless) PBXGroup so it appears in Xcode.
+  const groups = xcodeProject.hash.project.objects.PBXGroup;
+  Object.keys(groups).forEach((key) => {
+    if (groups[key].name === undefined && groups[key].path === undefined) {
+      xcodeProject.addToPbxGroup(widgetGroup.uuid, key);
+    }
+  });
+
+  // WORK AROUND for xcodeProject.addTarget BUG (cordova-node-xcode): single-target projects lack
+  // these sections, which addTarget assumes exist.
+  const projObjects = xcodeProject.hash.project.objects;
+  projObjects.PBXTargetDependency = projObjects.PBXTargetDependency || {};
+  projObjects.PBXContainerItemProxy = projObjects.PBXContainerItemProxy || {};
+
+  // Bundle id must be prefixed by the host app's bundle id for an app extension.
+  const widgetTarget = xcodeProject.addTarget(
+    CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME,
+    'app_extension',
+    CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME,
+    `${bundleIdentifier}.${CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME}`
+  );
+
+  // Add build phases to the new target.
+  xcodeProject.addBuildPhase(
+    widgetSourceFiles(customSourceFilenames),
+    'PBXSourcesBuildPhase',
+    'Sources',
+    widgetTarget.uuid
+  );
+  xcodeProject.addBuildPhase(
+    resourceFiles,
+    'PBXResourcesBuildPhase',
+    'Resources',
+    widgetTarget.uuid
+  );
+  xcodeProject.addBuildPhase(
+    [],
+    'PBXFrameworksBuildPhase',
+    'Frameworks',
+    widgetTarget.uuid
+  );
+
+  // Edit the deployment info of the target.
+  const configurations = xcodeProject.pbxXCBuildConfigurationSection();
+  for (const key in configurations) {
+    if (
+      typeof configurations[key].buildSettings !== 'undefined' &&
+      configurations[key].buildSettings.PRODUCT_NAME ===
+        `"${CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME}"`
+    ) {
+      const buildSettingsObj = configurations[key].buildSettings;
+      buildSettingsObj.DEVELOPMENT_TEAM = appleTeamId;
+      buildSettingsObj.IPHONEOS_DEPLOYMENT_TARGET =
+        iosDeploymentTarget || DEFAULT_LIVE_ACTIVITY_DEPLOYMENT_TARGET;
+      buildSettingsObj.TARGETED_DEVICE_FAMILY = TARGETED_DEVICE_FAMILY;
+      buildSettingsObj.CODE_SIGN_STYLE = 'Automatic';
+      buildSettingsObj.SWIFT_VERSION = WIDGET_SWIFT_VERSION;
+    }
+  }
+
+  // Stamp the development team on the widget target and the project's main target.
+  xcodeProject.addTargetAttribute('DevelopmentTeam', appleTeamId, widgetTarget);
+  xcodeProject.addTargetAttribute('DevelopmentTeam', appleTeamId);
+
+  return xcodeProject;
+}

--- a/plugin/src/ios/withCioLiveActivityWidgetXcodeProject.ts
+++ b/plugin/src/ios/withCioLiveActivityWidgetXcodeProject.ts
@@ -82,7 +82,12 @@ export type AddLiveActivityWidgetTargetOptions = {
  * {@link addLiveActivityWidget}.
  */
 export const withCioLiveActivityWidgetXcodeProject: ConfigPlugin<{
-  props: CustomerIOPluginOptionsIOS;
+  /**
+   * Optional: an app can enable Live Notifications without declaring an `ios` block at all, and only
+   * the optional `appleTeamId`/`useFrameworks` are read from it. Everything else the target needs
+   * comes from the Expo config or from fixed defaults.
+   */
+  props?: CustomerIOPluginOptionsIOS;
   /** SDK config (automatic initialization): the enabled types and `customType`. */
   liveNotifications?: LiveNotificationsSDKConfig;
   /**
@@ -94,7 +99,7 @@ export const withCioLiveActivityWidgetXcodeProject: ConfigPlugin<{
 }> = (configOuter, { props, liveNotifications, buildOptions }) => {
   return withXcodeProject(configOuter, async (config) => {
     const { modRequest, ios, version: bundleShortVersion } = config;
-    const { appleTeamId, useFrameworks } = props;
+    const { appleTeamId, useFrameworks } = props ?? {};
     // Fixed at the ActivityKit floor. Custom SwiftUI needing newer APIs uses availability
     // annotations (`if #available(iOS 17, *)`), which work fine at this deployment target.
     const iosDeploymentTarget = DEFAULT_LIVE_ACTIVITY_DEPLOYMENT_TARGET;

--- a/plugin/src/ios/withCioLiveActivityWidgetXcodeProject.ts
+++ b/plugin/src/ios/withCioLiveActivityWidgetXcodeProject.ts
@@ -145,7 +145,14 @@ export const withCioLiveActivityWidgetXcodeProject: ConfigPlugin<{
         config.modResults
       );
     } catch (error: unknown) {
-      logger.error(String(error));
+      // Fail the prebuild rather than logging and carrying on. By the time this runs, other mods have
+      // already set `NSSupportsLiveActivities` and added the `liveactivities` pod subspec, so
+      // swallowing this leaves a project that advertises Live Activities support with no extension to
+      // render them — an app that looks correctly configured and silently never shows an activity.
+      // The two config errors above already throw; this makes runtime failures behave the same way.
+      throw new Error(
+        `Adding the Customer.io Live Activity widget failed: ${String(error)}`
+      );
     }
 
     return config;

--- a/plugin/src/ios/withLiveActivityInfoPlist.ts
+++ b/plugin/src/ios/withLiveActivityInfoPlist.ts
@@ -1,0 +1,14 @@
+import type { ConfigPlugin } from '@expo/config-plugins';
+import { withInfoPlist } from '@expo/config-plugins';
+
+/**
+ * Sets `NSSupportsLiveActivities` to `true` in the host app's Info.plist so iOS
+ * allows the app to start Live Activities. Applied only when Live Activities are
+ * enabled via `ios.liveActivity.enabled`.
+ */
+export const withLiveActivityInfoPlist: ConfigPlugin = (config) => {
+  return withInfoPlist(config, (cfg) => {
+    cfg.modResults.NSSupportsLiveActivities = true;
+    return cfg;
+  });
+};

--- a/plugin/src/types/cio-types.ts
+++ b/plugin/src/types/cio-types.ts
@@ -144,7 +144,8 @@ export type NativeSDKConfig = {
   };
   /**
    * Live Notifications config. Its presence enables the feature; there is no
-   * separate `enabled` flag to set when you use auto initialization.
+   * separate `enabled` flag to set when you use auto initialization. Setting
+   * `liveNotifications.enabled` to `false` still overrides it.
    */
   liveNotifications?: LiveNotificationsSDKConfig;
 };
@@ -223,6 +224,9 @@ export type CustomerIOPluginLiveNotificationsOptions = {
    *
    * Only needed when you initialize the SDK from JavaScript. With auto
    * initialization, `config.liveNotifications` implies this and you can omit it.
+   *
+   * Setting it to `false` explicitly turns the build-time setup off on either
+   * path, so an app can keep `config.liveNotifications` and still opt out.
    */
   enabled?: boolean;
   /**
@@ -400,6 +404,10 @@ export type LiveNotificationsSDKConfig = {
    * Built-in activity types to enable, as reverse-DNS identifiers (see
    * {@link LIVE_NOTIFICATION_TYPES}). Each one is registered for push-to-start
    * and rendered by the generated iOS widget.
+   *
+   * Omitting this enables **every** built-in type, which is what an app that
+   * chooses its types at runtime needs. To register only your own custom type,
+   * set this to an empty array alongside `customType`.
    *
    * Unrecognized identifiers are ignored with a warning, so a template added in
    * a newer SDK can't break a build on an older plugin.

--- a/plugin/src/types/cio-types.ts
+++ b/plugin/src/types/cio-types.ts
@@ -116,6 +116,11 @@ export type NativeSDKConfig = {
   location?: {
     trackingMode?: LocationTrackingMode;
   };
+  /**
+   * Live Notifications config. Its presence enables the feature; there is no
+   * separate `enabled` flag to set when you use auto initialization.
+   */
+  liveNotifications?: LiveNotificationsSDKConfig;
 };
 
 /**
@@ -141,6 +146,237 @@ export type CustomerIOPluginOptions = {
    * gradle.properties). Host apps must add their own location permissions and privacy usage strings.
    */
   location?: CustomerIOPluginLocationOptions;
+  /**
+   * Live Notifications build-time setup: the branding compiled into the iOS widget, the SwiftUI for
+   * a custom template, and the `enabled` switch.
+   *
+   * Only `enabled` is specific to initializing the SDK from JavaScript — with auto initialization
+   * `config.liveNotifications` turns the feature on by itself. The rest applies on both paths,
+   * because it describes artifacts the plugin builds rather than anything the SDK registers.
+   */
+  liveNotifications?: CustomerIOPluginLiveNotificationsOptions;
+};
+
+/**
+ * Live Notifications build-time setup, off by default. When enabled the plugin sets
+ * `NSSupportsLiveActivities` in the host Info.plist, adds the `liveactivities` pod subspec to the
+ * host app, and injects a WidgetKit app-extension target that renders the SDK's built-in Live
+ * Activity templates. Requires iOS 16.2+. Android needs no build-time setup.
+ *
+ * A custom (app-defined) template is rendered by that same generated target: name it with
+ * {@link LiveNotificationsSDKConfig.customType} and hand the plugin your SwiftUI file with
+ * {@link CustomerIOPluginLiveNotificationsOptions.customWidget}. You don't need a widget target of
+ * your own.
+ *
+ * Everything here except `enabled` is consumed at build time on both initialization paths — that is
+ * why {@link CustomerIOPluginLiveNotificationsOptions.branding} and `customWidget` live here rather
+ * than under `config.liveNotifications`, which exists only when the SDK initializes automatically.
+ * @public
+ */
+export type CustomerIOPluginLiveNotificationsOptions = {
+  /**
+   * Turn on Live Notifications build-time setup (iOS widget extension, the
+   * `NSSupportsLiveActivities` Info.plist key, and the Podfile subspec).
+   *
+   * Only needed when you initialize the SDK from JavaScript. With auto
+   * initialization, `config.liveNotifications` implies this and you can omit it.
+   */
+  enabled?: boolean;
+  /**
+   * The SwiftUI that renders your custom activity type on iOS.
+   *
+   * Lives here rather than under `config.liveNotifications` because it is purely build-time —
+   * a source file to compile into the generated widget extension and a struct to instantiate in
+   * its `WidgetBundle`. It has no runtime meaning, and keeping it here is what makes it usable
+   * whether you initialize the SDK automatically or from JavaScript.
+   *
+   * The activity's identifier is separate and belongs to SDK config: set
+   * `config.liveNotifications.customType` for automatic initialization, or pass it to
+   * `CustomerIO.initialize` when you initialize from JavaScript.
+   */
+  customWidget?: LiveNotificationCustomWidget;
+  /**
+   * The Kotlin that renders your custom activity type on Android.
+   *
+   * The Android counterpart to `customWidget`, and build-time for the same reason: a source file to
+   * copy into the app and a class to instantiate where the renderer is registered.
+   *
+   * Pair it with `customWidget` — configuring only one leaves that activity type unrendered on the
+   * other platform.
+   */
+  customRenderer?: LiveNotificationCustomRenderer;
+  /**
+   * Branding shared by every built-in template. Your `customWidget` styles itself.
+   *
+   * Lives here rather than under `config.liveNotifications` because neither platform reads it at
+   * runtime from the plugin: on iOS it is SwiftUI compiled into the generated widget extension, and
+   * on Android it is generated into your initializer. Keeping it here is what lets it reach the iOS
+   * widget whether you initialize the SDK automatically or from JavaScript — SDK config only exists
+   * on the automatic path, and there is no way to brand a compiled widget later.
+   *
+   * With automatic initialization this is the only place to set it. If you initialize from
+   * JavaScript, set it here *and* pass branding to `CustomerIO.initialize`: this value is what the
+   * plugin compiles into the iOS widget, and the value you pass at runtime is what Android applies —
+   * the plugin generates no initializer on that path, so it cannot forward it for you.
+   */
+  branding?: LiveNotificationBranding;
+};
+
+/**
+ * Reverse-DNS identifiers for the built-in Live Notification activity types.
+ *
+ * These are the same strings both native SDKs and the backend use, so a type
+ * listed here matches what Customer.io sends as `notificationType`.
+ * @public
+ */
+export const LIVE_NOTIFICATION_TYPES = {
+  segments: 'io.customer.livenotifications.segments',
+  countdownTimer: 'io.customer.livenotifications.countdowntimer',
+} as const;
+
+/**
+ * Branding applied to every built-in Live Notification template. Set it with
+ * {@link CustomerIOPluginLiveNotificationsOptions.branding}.
+ *
+ * The `logo` and colors are baked into the generated iOS widget at prebuild and passed to the
+ * Android SDK at initialization, so one block covers both platforms. Android renders
+ * `accentColorHex`; iOS renders all three colors.
+ * @public
+ */
+export type LiveNotificationBranding = {
+  /** Brand name. Reserved for future templates; not rendered today. */
+  companyName?: string;
+  /**
+   * Logo image: either a path relative to your project root
+   * (e.g. `./assets/brand-logo.png`) or an `http(s)` URL.
+   *
+   * A local path is copied into the Android drawables and the iOS widget's
+   * asset catalog. A URL is downloaded at render time on Android and is **not
+   * supported on iOS**, where the widget is compiled ahead of time.
+   */
+  logo?: string;
+  /** Lock-screen background color as `#RRGGBB`. iOS only. */
+  backgroundColorHex?: string;
+  /** Primary text color as `#RRGGBB`. iOS only. */
+  textColorHex?: string;
+  /** Accent color as `#RRGGBB`. Android notification tint; iOS progress fill. */
+  accentColorHex?: string;
+};
+
+/**
+ * The SwiftUI that renders your custom Live Activity, compiled into the widget extension the
+ * plugin generates. Required alongside {@link LiveNotificationsSDKConfig.customType} — without it
+ * the widget has nothing to draw for that type.
+ *
+ * Write a plain WidgetKit widget over the SDK's `CIOCustomAttributes` (shipped by the native iOS
+ * SDK, so there is no extra pod to add and no attributes type for you to define):
+ *
+ * ```swift
+ * import CioLiveActivities_Attributes
+ * import SwiftUI
+ * import WidgetKit
+ *
+ * struct RideshareLiveActivity: Widget {
+ *     var body: some WidgetConfiguration {
+ *         ActivityConfiguration(for: CIOCustomAttributes.self) { context in
+ *             Text(context.state.data["status"] ?? "")
+ *                 .cioWidgetUrl(context.state.cioMetadata)
+ *         } dynamicIsland: { context in
+ *             DynamicIsland { }
+ *                 .cioWidgetUrl(context.state.cioMetadata)
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * **`.cioWidgetUrl(context.state.cioMetadata)` is required on both the lock-screen view and the
+ * Dynamic Island.** It is the one thing the plugin cannot add for you — it never parses or rewrites
+ * your SwiftUI. That modifier carries the tap URL the SDK reports `opened` from and resolves your
+ * deep link with, so a custom template without it renders correctly and silently loses attribution
+ * and routing on every tap. The SDK's built-in templates apply it in exactly these two places.
+ *
+ * Both a path and a name are needed because the plugin never parses Swift: it copies the file into
+ * the widget target and instantiates `structName` in the generated `WidgetBundle`.
+ * @public
+ */
+export type LiveNotificationCustomWidget = {
+  /**
+   * Path to your SwiftUI file, relative to the project root (e.g.
+   * `'./ios-widgets/RideshareLiveActivity.swift'`), or absolute.
+   *
+   * Pass an array when the widget spans several files; all of them are compiled into the widget
+   * extension. They are copied into one directory, so their file names must be unique and must not
+   * collide with the files the plugin generates there.
+   */
+  sourceFile: string | string[];
+  /**
+   * Name of the `Widget` struct to instantiate in the generated `WidgetBundle`, e.g.
+   * `'RideshareLiveActivity'`.
+   */
+  structName: string;
+};
+
+/**
+ * The Android half of a custom activity type, and the counterpart to
+ * {@link LiveNotificationCustomWidget}.
+ *
+ * Custom types have no built-in template on either platform: iOS renders yours from SwiftUI
+ * compiled into the generated widget, and Android renders yours from a
+ * `CustomerIOLiveNotificationsCallback` that builds a `Notification`. Kotlin cannot cross the
+ * JavaScript bridge any more than SwiftUI can, so the plugin takes your file and wires it up.
+ *
+ * Without this, a configured `customType` still starts and reports on Android — the backend can
+ * push updates to it — but nothing is ever drawn.
+ * @public
+ */
+export type LiveNotificationCustomRenderer = {
+  /**
+   * Path to your Kotlin file, relative to the project root (e.g.
+   * `'./android-renderers/RideshareLiveNotification.kt'`), or absolute.
+   *
+   * Pass an array when the renderer spans several files. Each is copied into the source tree under
+   * its own `package` declaration, so every file must declare one.
+   */
+  sourceFile: string | string[];
+  /**
+   * Name of the `CustomerIOLiveNotificationsCallback` class the plugin instantiates, e.g.
+   * `'RideshareLiveNotificationCallback'`. It must have a no-argument constructor and live in the
+   * `package` declared by one of the files above.
+   */
+  className: string;
+};
+
+/**
+ * Live Notifications (Android) / Live Activities (iOS) configuration applied at
+ * SDK initialization. Its presence enables the feature — you don't also need
+ * `liveNotifications.enabled`.
+ * @public
+ */
+export type LiveNotificationsSDKConfig = {
+  /**
+   * Built-in activity types to enable, as reverse-DNS identifiers (see
+   * {@link LIVE_NOTIFICATION_TYPES}). Each one is registered for push-to-start
+   * and rendered by the generated iOS widget.
+   *
+   * Unrecognized identifiers are ignored with a warning, so a template added in
+   * a newer SDK can't break a build on an older plugin.
+   */
+  types?: string[];
+  /**
+   * Your own reverse-DNS identifier for a custom activity type, e.g. `'com.myapp.rideshare'`.
+   * Setting it enables the custom template on both platforms: iOS registers the SDK's
+   * `CIOCustomAttributes` under this name — which is what gives a custom activity push-to-start
+   * and metrics — and Android allowlists it so its push handler stops dropping it.
+   *
+   * Singular by design: iOS resolves an activity's type from its Swift attributes type, and every
+   * custom activity shares one. A second identifier could not be told apart, so one identifier is
+   * the limit rather than a silent mis-attribution.
+   *
+   * This identifier only enables the type; neither platform can draw it. Pair it with the top-level
+   * `liveNotifications.customWidget` (SwiftUI, iOS) and `liveNotifications.customRenderer` (Kotlin,
+   * Android) — those render the activity.
+   */
+  customType?: string;
 };
 
 /**

--- a/test-app/android-renderers/RideshareLiveNotification.kt
+++ b/test-app/android-renderers/RideshareLiveNotification.kt
@@ -1,0 +1,76 @@
+package com.customerio.testbed.livenotifications
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import io.customer.messagingpush.data.communication.CustomerIOLiveNotificationsCallback
+import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
+
+/**
+ * Renders the custom `rideshare` live notification, the Android counterpart to
+ * `ios-widgets/RideshareLiveActivity.swift`.
+ *
+ * The plugin copies this file into the generated Android project and registers the class, because
+ * `liveNotifications.customRenderer` names it in app.json. A custom activity type has no built-in
+ * SDK template on either platform, so the app draws it: SwiftUI on iOS, a `Notification` here.
+ *
+ * Returning null for any other type lets the SDK fall back to its built-in templates.
+ */
+class RideshareLiveNotificationCallback : CustomerIOLiveNotificationsCallback {
+    override fun createLiveNotification(
+        payload: CustomerIOParsedPushPayload,
+        context: Context,
+    ): Notification? {
+        // Template fields arrive flattened in `extras`; the activity type is under the reserved
+        // "notification_type" key.
+        val extras = payload.extras
+        if (extras.getString("notification_type") != RIDESHARE_TYPE) return null
+
+        // The SDK re-invokes this on the "end" event. Return a terminal, non-ongoing notification
+        // then so it can be dismissed instead of sticking around forever.
+        val ended = extras.getString("event") == "end"
+
+        val driverName = extras.getString("driverName") ?: "Your driver"
+        val status = extras.getString("status") ?: ""
+        // Every custom value crosses the bridge as a string; parse what you need.
+        val etaMinutes = extras.getString("etaMinutes")?.toDoubleOrNull()?.toInt()
+
+        // Same fields the SwiftUI shows, in the same order: status leads as the title, then the
+        // driver and the ETA. `status` is not repeated in the body since it is already the title.
+        val body = listOfNotNull(
+            driverName,
+            etaMinutes?.let { "ETA $it min" },
+        ).joinToString(" • ")
+
+        ensureChannel(context)
+        return NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(context.applicationInfo.icon)
+            .setContentTitle(status.ifEmpty { if (ended) "Arrived" else "Rideshare" })
+            .setContentText(body)
+            .setOngoing(!ended)
+            .setOnlyAlertOnce(true)
+            .build()
+    }
+
+    private fun ensureChannel(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (manager.getNotificationChannel(CHANNEL_ID) == null) {
+            manager.createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_ID,
+                    "Rideshare",
+                    NotificationManager.IMPORTANCE_DEFAULT,
+                ),
+            )
+        }
+    }
+
+    private companion object {
+        const val RIDESHARE_TYPE = "com.customerio.testbed.rideshare"
+        const val CHANNEL_ID = "rideshare_live_notification"
+    }
+}

--- a/test-app/app.json
+++ b/test-app/app.json
@@ -125,7 +125,7 @@
           "ios": {
             "useFrameworks": "static",
             "pushNotification": {
-              "provider": "fcm",
+              "provider": "apn",
               "useRichPush": true,
               "appGroupId": "group.io.customer.testbed.expo.apn.cio",
               "handleDeeplinkInKilledState": true,
@@ -136,8 +136,7 @@
               "env": {
                 "cdpApiKey": "test-cdp-api-key",
                 "region": "us"
-              },
-              "googleServicesFile": "./files/GoogleService-Info.plist"
+              }
             }
           },
           "location": {

--- a/test-app/app.json
+++ b/test-app/app.json
@@ -89,6 +89,13 @@
             "logLevel": "debug",
             "location": {
               "trackingMode": "MANUAL"
+            },
+            "liveNotifications": {
+              "types": [
+                "io.customer.livenotifications.segments",
+                "io.customer.livenotifications.countdowntimer"
+              ],
+              "customType": "com.customerio.testbed.rideshare"
             }
           },
           "android": {
@@ -121,6 +128,22 @@
           },
           "location": {
             "enabled": true
+          },
+          "liveNotifications": {
+            "branding": {
+              "companyName": "Customer.io Expo Testbed",
+              "accentColorHex": "#00A0DF",
+              "backgroundColorHex": "#101010",
+              "textColorHex": "#FFFFFF"
+            },
+            "customWidget": {
+              "sourceFile": "./ios-widgets/RideshareLiveActivity.swift",
+              "structName": "RideshareLiveActivity"
+            },
+            "customRenderer": {
+              "sourceFile": "./android-renderers/RideshareLiveNotification.kt",
+              "className": "RideshareLiveNotificationCallback"
+            }
           }
         }
       ],

--- a/test-app/app/_layout.tsx
+++ b/test-app/app/_layout.tsx
@@ -19,6 +19,7 @@ export default function RootLayout() {
         <Stack.Screen name="nav-test" options={{ title: "Navigation Test" }} />
         <Stack.Screen name="inline-examples" options={{ title: "Inline Examples" }} />
         <Stack.Screen name="location" options={{ title: "Location" }} />
+        <Stack.Screen name="live-activities" options={{ title: "Live Activities" }} />
       </Stack>
       <StatusBar style="auto" />
     </ThemeProvider>

--- a/test-app/app/live-activities.tsx
+++ b/test-app/app/live-activities.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import LiveActivitiesScreen from '../screens/LiveActivities';
+
+export default function LiveActivitiesRoute() {
+  return <LiveActivitiesScreen />;
+}

--- a/test-app/fastlane/Appfile
+++ b/test-app/fastlane/Appfile
@@ -1,6 +1,7 @@
 app_identifier([
   "io.customer.testbed.expo.apn",
   "io.customer.testbed.expo.apn.richpush",
+  "io.customer.testbed.expo.apn.CIOLiveActivityWidget",
 ])
 
 package_name("io.customer.testbed.expo")

--- a/test-app/fastlane/Fastfile
+++ b/test-app/fastlane/Fastfile
@@ -78,6 +78,16 @@ platform :ios do
       profile: ENV["sigh_io.customer.testbed.expo.apn.richpush_adhoc_profile-path"]
     )
 
+    # The Live Activity widget extension the plugin generates. Its target name comes from
+    # CIO_LIVE_ACTIVITY_WIDGET_TARGET_NAME, and its bundle id is that name suffixed onto the host
+    # app's. Without this the widget is the one embedded binary left without a profile, and the
+    # archive fails on it rather than on anything the app itself did.
+    update_project_provisioning(
+      xcodeproj: xcodeproj_path,
+      target_filter: "CIOLiveActivityWidget",
+      profile: ENV["sigh_io.customer.testbed.expo.apn.CIOLiveActivityWidget_adhoc_profile-path"]
+    )
+
     update_project_team(
       path: xcodeproj_path,
       teamid: "2YC97BQN3N"

--- a/test-app/ios-widgets/RideshareLiveActivity.swift
+++ b/test-app/ios-widgets/RideshareLiveActivity.swift
@@ -1,0 +1,56 @@
+import ActivityKit
+import CioLiveActivities_Attributes
+import SwiftUI
+import WidgetKit
+
+/// A custom Live Activity the test app owns, rendered alongside the SDK's built-in templates.
+///
+/// The plugin copies this file into the widget extension it generates and adds
+/// `RideshareLiveActivity()` to that bundle, next to the built-in `CIOSegmentsLiveActivity()` and
+/// `CIOCountdownTimerLiveActivity()` — which is the point of the exercise: a custom template and the
+/// built-ins coexist in one widget target.
+///
+/// The attributes type comes from the SDK (`CIOCustomAttributes`), so nothing here has to define one.
+/// Its content-state is an untyped `[String: String]`, which is what lets JavaScript drive the
+/// activity without handing a Swift type across the bridge. The keys below are the ones
+/// `screens/LiveActivities.js` sends.
+@available(iOS 16.2, *)
+struct RideshareLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: CIOCustomAttributes.self) { context in
+            // Lock screen / banner presentation.
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Rideshare").font(.headline)
+                Text(context.state.data["driverName"] ?? "").font(.subheadline)
+                Text(context.state.data["status"] ?? "").font(.body)
+                Text("ETA \(context.state.data["etaMinutes"] ?? "—") min")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding()
+            // Required on any custom template: this is what carries the tap URL the SDK
+            // reports `opened` from and routes the deep link with. The bundled templates do
+            // the same on both their lock screen and Dynamic Island.
+            .cioWidgetUrl(context.state.cioMetadata)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Text(context.state.data["driverName"] ?? "")
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text("\(context.state.data["etaMinutes"] ?? "—") min")
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text(context.state.data["status"] ?? "")
+                }
+            } compactLeading: {
+                Image(systemName: "car.fill")
+            } compactTrailing: {
+                Text("\(context.state.data["etaMinutes"] ?? "")m")
+            } minimal: {
+                Image(systemName: "car.fill")
+            }
+            .cioWidgetUrl(context.state.cioMetadata)
+        }
+    }
+}

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -15,7 +15,7 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.5.2",
+    "customerio-reactnative": "github:customerio/customerio-reactnative#live-activities-sdk",
     "dotenv": "^17.2.2",
     "expo": "~55.0.23",
     "expo-build-properties": "~55.0.13",

--- a/test-app/screens/Dashboard.js
+++ b/test-app/screens/Dashboard.js
@@ -55,6 +55,10 @@ export default function DashboardScreen() {
     router.push('/location');
   };
 
+  const handleNavigateToLiveActivitiesButtonPressed = () => {
+    router.push('/live-activities');
+  };
+
   const handleLogoutButtonPressed = () => {
     CustomerIO.clearIdentify();
   };
@@ -135,6 +139,13 @@ export default function DashboardScreen() {
         <Button
           title="Location"
           onPress={handleNavigateToLocationButtonPressed}
+        />
+      </ThemedView>
+
+      <ThemedView style={styles.section}>
+        <Button
+          title="Live Activities"
+          onPress={handleNavigateToLiveActivitiesButtonPressed}
         />
       </ThemedView>
 

--- a/test-app/screens/LiveActivities.js
+++ b/test-app/screens/LiveActivities.js
@@ -1,0 +1,220 @@
+import { CustomerIO, LiveActivityTemplate } from 'customerio-reactnative';
+import React, { useState } from 'react';
+import { Alert, Button, ScrollView, StyleSheet, View } from 'react-native';
+import { ThemedText } from '../components/themed-text';
+import { ThemedView } from '../components/themed-view';
+
+// Activity types are registered by the plugin's native auto-init from app.json — the built-ins from
+// `config.liveNotifications.types` and the custom one from `config.liveNotifications.customType` —
+// so no JavaScript initialization is needed. On iOS all three are rendered by the single widget
+// extension the plugin generates: the SDK ships the SwiftUI for the built-ins, and
+// `liveNotifications.customWidget` points at the app's own file for the custom one.
+
+export default function LiveActivitiesScreen() {
+  const [segmentsId, setSegmentsId] = useState(null);
+  const [segmentsComplete, setSegmentsComplete] = useState(0);
+  const [countdownId, setCountdownId] = useState(null);
+  const [customId, setCustomId] = useState(null);
+
+  const segmentsTotal = 4;
+
+  // MARK: - Segments
+
+  const startSegments = async () => {
+    try {
+      const id = await CustomerIO.liveActivities.start({
+        type: LiveActivityTemplate.Segments,
+        header: 'Order #4021',
+        status: 'Preparing your order',
+        segmentsTotal,
+        segmentsComplete: 1,
+      });
+      setSegmentsId(id);
+      setSegmentsComplete(1);
+      Alert.alert('Success', `Segments started (${id})`);
+    } catch (e) {
+      Alert.alert('Error', (e && e.message) || String(e));
+    }
+  };
+
+  const advanceSegments = async () => {
+    if (!segmentsId) return;
+    const next = Math.min(segmentsComplete + 1, segmentsTotal);
+    try {
+      await CustomerIO.liveActivities.update(segmentsId, {
+        type: LiveActivityTemplate.Segments,
+        header: 'Order #4021',
+        status: next >= segmentsTotal ? 'Delivered' : 'Out for delivery',
+        segmentsTotal,
+        segmentsComplete: next,
+      });
+      setSegmentsComplete(next);
+      Alert.alert('Success', `Segments → ${next}/${segmentsTotal}`);
+    } catch (e) {
+      Alert.alert('Error', (e && e.message) || String(e));
+    }
+  };
+
+  const endSegments = async () => {
+    if (!segmentsId) return;
+    try {
+      await CustomerIO.liveActivities.end(segmentsId);
+      setSegmentsId(null);
+      setSegmentsComplete(0);
+      Alert.alert('Info', 'Segments ended');
+    } catch (e) {
+      Alert.alert('Error', (e && e.message) || String(e));
+    }
+  };
+
+  // MARK: - Countdown Timer
+
+  const startCountdown = async () => {
+    try {
+      const id = await CustomerIO.liveActivities.start({
+        type: LiveActivityTemplate.CountdownTimer,
+        header: 'Flash Sale',
+        title: '50% off ends in',
+        statusMessage: 'Hurry!',
+        endTime: Math.floor(Date.now() / 1000) + 3600, // epoch seconds, +1h
+      });
+      setCountdownId(id);
+      Alert.alert('Success', `Countdown started (${id})`);
+    } catch (e) {
+      Alert.alert('Error', (e && e.message) || String(e));
+    }
+  };
+
+  const endCountdown = async () => {
+    if (!countdownId) return;
+    try {
+      await CustomerIO.liveActivities.end(countdownId);
+      setCountdownId(null);
+      Alert.alert('Info', 'Countdown ended');
+    } catch (e) {
+      Alert.alert('Error', (e && e.message) || String(e));
+    }
+  };
+
+  // MARK: - Custom
+
+  // The identifier comes from `config.liveNotifications.customType`; the SwiftUI that draws it comes
+  // from the top-level `liveNotifications.customWidget`. Values are strings — a bridge payload has no
+  // schema, so the widget parses what it needs.
+  const rideshare = (status, etaMinutes) => ({
+    type: LiveActivityTemplate.Custom,
+    data: { driverName: 'Alex', status, etaMinutes: String(etaMinutes) },
+  });
+
+  const startCustom = async () => {
+    try {
+      const id = await CustomerIO.liveActivities.start(rideshare('On the way', 5));
+      setCustomId(id);
+      Alert.alert('Success', `Rideshare started (${id})`);
+    } catch (e) {
+      Alert.alert('Error', (e && e.message) || String(e));
+    }
+  };
+
+  const updateCustom = async () => {
+    if (!customId) return;
+    try {
+      await CustomerIO.liveActivities.update(customId, rideshare('Almost there', 2));
+      Alert.alert('Success', 'Rideshare updated');
+    } catch (e) {
+      Alert.alert('Error', (e && e.message) || String(e));
+    }
+  };
+
+  const endCustom = async () => {
+    if (!customId) return;
+    try {
+      // A final content-state so the card reads as finished rather than freezing mid-trip.
+      await CustomerIO.liveActivities.end(customId, rideshare('Arrived', 0));
+      setCustomId(null);
+      Alert.alert('Info', 'Rideshare ended');
+    } catch (e) {
+      Alert.alert('Error', (e && e.message) || String(e));
+    }
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.scrollContent}>
+      <ThemedView style={styles.container}>
+        <ThemedView style={styles.sectionCard}>
+          <ThemedText style={styles.sectionHeading}>SEGMENTS</ThemedText>
+          <ThemedText style={styles.hint}>
+            A built-in template with a segmented progress bar.
+          </ThemedText>
+          <Button title="Start Segments" onPress={startSegments} />
+          <Button
+            title="Advance Segment (update)"
+            onPress={advanceSegments}
+            disabled={!segmentsId}
+          />
+          <Button title="End Segments" onPress={endSegments} disabled={!segmentsId} />
+          <ThemedText style={styles.hint}>
+            {segmentsId ? `Running: ${segmentsComplete}/${segmentsTotal}` : 'Not started'}
+          </ThemedText>
+        </ThemedView>
+
+        <ThemedView style={styles.sectionCard}>
+          <ThemedText style={styles.sectionHeading}>COUNTDOWN TIMER</ThemedText>
+          <ThemedText style={styles.hint}>
+            A built-in template counting down to a target time.
+          </ThemedText>
+          <Button title="Start Countdown (+1h)" onPress={startCountdown} />
+          <Button title="End Countdown" onPress={endCountdown} disabled={!countdownId} />
+          <ThemedText style={styles.hint}>
+            {countdownId ? 'Running' : 'Not started'}
+          </ThemedText>
+        </ThemedView>
+
+        <ThemedView style={styles.sectionCard}>
+          <ThemedText style={styles.sectionHeading}>CUSTOM (RIDESHARE)</ThemedText>
+          <ThemedText style={styles.hint}>
+            An app-defined template. A custom type has no built-in template on either platform, so
+            this app supplies both halves and the plugin wires them up: RideshareLiveActivity.swift
+            renders it on iOS, in the same widget bundle as the two built-ins above, and
+            RideshareLiveNotification.kt renders it on Android.
+          </ThemedText>
+          <ThemedText style={styles.hint}>
+            Configured with liveNotifications.customWidget and liveNotifications.customRenderer in
+            app.json. Neither is reachable from JavaScript — SwiftUI and Kotlin have to be compiled
+            in — which is why they are build-time options rather than SDK config.
+          </ThemedText>
+          <Button title="Start Custom" onPress={startCustom} />
+          <Button title="Update Custom" onPress={updateCustom} disabled={!customId} />
+          <Button title="End Custom" onPress={endCustom} disabled={!customId} />
+          <ThemedText style={styles.hint}>
+            {customId ? 'Running' : 'Not started'}
+          </ThemedText>
+        </ThemedView>
+      </ThemedView>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    paddingBottom: 24,
+  },
+  container: {
+    padding: 16,
+  },
+  sectionCard: {
+    padding: 16,
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  sectionHeading: {
+    fontWeight: '700',
+    marginBottom: 8,
+  },
+  hint: {
+    opacity: 0.9,
+    marginTop: 8,
+    marginBottom: 8,
+    fontSize: 14,
+  },
+});


### PR DESCRIPTION
Enable Live Notifications feature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large native prebuild and AppDelegate/deep-link changes affect iOS/Android builds; risk is mitigated by explicit gating, opt-out handling, and broad test coverage rather than security-critical runtime paths.
> 
> **Overview**
> **Adds Live Notifications** to the Customer.io Expo config plugin so prebuild can wire iOS Live Activities and Android live-notification rendering from `liveNotifications` / `config.liveNotifications` options (built-in types, custom widget/renderer, branding).
> 
> On **iOS**, when enabled it injects the `liveactivities` Pod subspec, `NSSupportsLiveActivities`, a generated **CIOLiveActivityWidget** extension (Podfile target + Xcode project), and Swift **AppDelegate** / `CioSdkAppDelegateHandler` hooks so tapped activities report metrics and route deep links (including coexistence with push URL handling). On **Android**, it patches the generated SDK initializer for enabled types/branding, copies custom Kotlin renderers and local logo drawables, and registers the render callback from `MainApplication` on the JavaScript-init path.
> 
> The entry plugin now **gates** Live Notifications to **Expo SDK 53+**, reconciles `enabled: false` with auto-init config (stripping native registration), and warns on common misconfigurations. **CI** pins global **npm@11** in deploy (OIDC on Node 20) instead of `@latest`.
> 
> Extensive new unit/scenario tests and public API types cover the config matrix and injection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b034654d2084b3dcfff95dfd86b95dcd41cb383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->