### PR TITLE
ci: repin setup-ios to macos-26 branch, drop simulator-runtime download

### DIFF
--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -215,7 +215,7 @@ jobs:
           echo "pushProvider=${{ matrix.push_provider }}" >> "test-app/local.env"
 
       - name: Setup iOS
-        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@macos-26
+        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@main
         with:
           xcode-version: "26.5"
 

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -215,7 +215,7 @@ jobs:
           echo "pushProvider=${{ matrix.push_provider }}" >> "test-app/local.env"
 
       - name: Setup iOS
-        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@MacOS-26+iOS-26
+        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@macos-26
         with:
           xcode-version: "26.5"
 

--- a/.github/workflows/test-pnpm-compatibility.yml
+++ b/.github/workflows/test-pnpm-compatibility.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   pnpm-dev-apps:
     name: Build pnpm dev apps (isolated + hoisted) and verify artifacts
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/validate-plugin-compatibility-matrix.yml
+++ b/.github/workflows/validate-plugin-compatibility-matrix.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Setup iOS
         if: matrix.platform == 'ios'
-        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@MacOS-26+iOS-26
+        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@macos-26
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 

--- a/.github/workflows/validate-plugin-compatibility-matrix.yml
+++ b/.github/workflows/validate-plugin-compatibility-matrix.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Setup iOS
         if: matrix.platform == 'ios'
-        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@macos-26
+        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@main
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 

--- a/.github/workflows/validate-plugin-compatibility.yml
+++ b/.github/workflows/validate-plugin-compatibility.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Setup iOS
         if: matrix.platform == 'ios'
-        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@MacOS-26+iOS-26
+        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@macos-26
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 

--- a/.github/workflows/validate-plugin-compatibility.yml
+++ b/.github/workflows/validate-plugin-compatibility.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Setup iOS
         if: matrix.platform == 'ios'
-        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@macos-26
+        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@main
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 


### PR DESCRIPTION
> ✅ **Unblocked.** [mobile-ci-tools#13](https://github.com/customerio/mobile-ci-tools/pull/13) is merged and the `setup-ios` ref here now points at `@main`, so nothing depends on the transitional `macos-26` branch.

[MBL-2224: Migrate iOS CI to `macos-26` + Xcode 26.6, and stop downloading simulator runtimes we already have](https://linear.app/customerio/issue/MBL-2224/migrate-ios-ci-to-macos-26-xcode-266-and-stop-downloading-simulator)

---

The shared iOS setup step installs a simulator runtime that our runner image already ships, so it does work that has no effect. On this repo it is a pure no-op on every invocation — around 78 of them a week.

Repins to a version of the shared setup that omits that install, and moves the one remaining job on macOS 15 to 26.

First repo in a staged fleet migration, picked because it already runs on the target image and so has the smallest blast radius. Xcode is unchanged here: all three call sites pin it explicitly, so the new default does not apply and the Pods cache keys are untouched.