### PR TITLE
fix: update customerio-reactnative to 6.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "xcode": "^3.0.1"
       },
       "peerDependencies": {
-        "customerio-reactnative": "6.6.1"
+        "customerio-reactnative": "6.6.2"
       }
     },
     "node_modules/@babel/cli": {
@@ -7892,9 +7892,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-6.6.1.tgz",
-      "integrity": "sha512-CBODNAwMkK7A9ODUFJz9JP3SdS8bzzn4vWotoh29KVGZ+9383IZim1qzF860lWdVWCiOTgWUFwS8gQXBL9XBhg==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-6.6.2.tgz",
+      "integrity": "sha512-xeSdnbZZ1ekBaPGXzHiXHwLWVU36oqBvZbs/zp+lvGXdFAkgOd8FDORwwxKXED4TQWQEw3vn+v54uLzcT+kc/g==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "customerio-reactnative": "6.6.1"
+    "customerio-reactnative": "6.6.2"
   },
   "devDependencies": {
     "dotenv": "^16.4.5",

--- a/test-app-pnpm-monorepo/apps/mobile/package.json
+++ b/test-app-pnpm-monorepo/apps/mobile/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@cio-test/shared-cio-utils": "workspace:*",
     "customerio-expo-plugin": "file:../../../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.6.1",
+    "customerio-reactnative": "^6.6.2",
     "expo": "~54.0.2",
     "expo-build-properties": "^1.0.8",
     "expo-status-bar": "~3.0.8",

--- a/test-app-pnpm-monorepo/packages/shared-cio-utils/package.json
+++ b/test-app-pnpm-monorepo/packages/shared-cio-utils/package.json
@@ -5,6 +5,6 @@
   "main": "index.ts",
   "types": "index.ts",
   "dependencies": {
-    "customerio-reactnative": "^6.6.1"
+    "customerio-reactnative": "^6.6.2"
   }
 }

--- a/test-app-pnpm/package.json
+++ b/test-app-pnpm/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.6.1",
+    "customerio-reactnative": "^6.6.2",
     "expo": "~54.0.2",
     "expo-build-properties": "^1.0.8",
     "expo-status-bar": "~3.0.8",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -15,7 +15,7 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.6.1",
+    "customerio-reactnative": "^6.6.2",
     "dotenv": "^17.2.2",
     "expo": "~55.0.23",
     "expo-build-properties": "~55.0.13",


### PR DESCRIPTION
Picks up the React Native SDK release that pins native iOS 4.7.2 and Android 4.20.1.

- `package.json` — peer dependency `customerio-reactnative` → `6.6.2`
- `package-lock.json` — resolved entry + integrity for 6.6.2
- `test-app/`, `test-app-pnpm/`, `test-app-pnpm-monorepo/apps/mobile/`, `test-app-pnpm-monorepo/packages/shared-cio-utils/` — `^6.6.2`

Same file set as the previous bumps (#367, #366, #365). Lockfile `resolved` and `integrity` were verified against the npm registry, and 6.6.2's `engines`, `peerDependencies`, `license`, and `postinstall` are unchanged from 6.6.1, so no other lock metadata moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only dependency alignment with no changes to plugin or runtime logic in this repo.
> 
> **Overview**
> Bumps the **`customerio-reactnative`** peer dependency from **6.6.1** to **6.6.2** so this Expo plugin aligns with the latest React Native SDK (native iOS **4.7.2** / Android **4.20.1** per the release).
> 
> **`package-lock.json`** is updated with the new resolved tarball and integrity. Sample apps (`test-app`, `test-app-pnpm`, and the pnpm monorepo mobile app and `shared-cio-utils`) now depend on **`^6.6.2`** for the same version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f35cfd338a66d5ad9c239fa76afdebc499f7b876. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->