### PR TITLE
ci: hold the expo compatibility app to the stable expo release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
         run: npm ci
 
       - name: Run utils tests
-        run: npm test -- __tests__/utils __tests__/ios/withCIOIos.test.ts __tests__/ios/withCIOIosSwift.test.ts
+        run: npm test -- __tests__/utils __tests__/scripts __tests__/ios/withCIOIos.test.ts __tests__/ios/withCIOIosSwift.test.ts
 
   test-scenarios:
     name: Test scenario suite

--- a/__tests__/scripts/expo-template.test.js
+++ b/__tests__/scripts/expo-template.test.js
@@ -1,0 +1,296 @@
+const {
+  templatePackageName,
+  parseTemplateCandidates,
+  selectTemplateVersion,
+  chooseStableExpoVersion,
+  describeTemplateResolutionFailure,
+} = require('../../scripts/utils/expo-template');
+
+// Real `npm view 'expo-template-default@>=57.0.0 <58.0.0' version dependencies.expo --json`
+// output, captured 2026-08-14. Each template pins the `expo` release from two
+// patches earlier, which is what makes the newest template unusable while
+// `expo@latest` catches up.
+const TEMPLATES_57 = [
+  { version: '57.0.0', expoRange: '~57.0.0-preview.0' },
+  { version: '57.0.1', expoRange: '~57.0.0-preview.1' },
+  { version: '57.0.2', expoRange: '~57.0.0' },
+  { version: '57.0.3', expoRange: '~57.0.1' },
+  { version: '57.0.4', expoRange: '~57.0.2' },
+  { version: '57.0.5', expoRange: '~57.0.3' },
+  { version: '57.0.6', expoRange: '~57.0.4' },
+  { version: '57.0.7', expoRange: '~57.0.5' },
+  { version: '57.0.8', expoRange: '~57.0.6' },
+  { version: '57.0.9', expoRange: '~57.0.7' },
+  { version: '57.0.10', expoRange: '~57.0.8' },
+  { version: '57.0.11', expoRange: '~57.0.9' },
+  { version: '57.0.12', expoRange: '~57.0.10' },
+  { version: '57.0.13', expoRange: '~57.0.11' },
+  { version: '57.0.14', expoRange: '~57.0.12' },
+  { version: '57.0.15', expoRange: '~57.0.13' },
+];
+
+// Tail of the same query for major 54, captured 2026-08-14.
+const TEMPLATES_54 = [
+  { version: '54.0.59', expoRange: '~54.0.33' },
+  { version: '54.0.60', expoRange: '~54.0.34' },
+  { version: '54.0.61', expoRange: '~54.0.35' },
+  { version: '54.0.62', expoRange: '~54.0.36' },
+];
+
+describe('selectTemplateVersion', () => {
+  // The regression test for this whole change. On 2026-08-14 `expo@latest` was
+  // 57.0.12 while the `sdk-57` template tag pointed at 57.0.15, which pins
+  // ~57.0.13 — a `next`-channel expo whose expo-file-system was unpublished.
+  // Hardcoding @sdk-<major> took that template and turned every Expo PR red.
+  it('skips templates pinning an expo release newer than stable latest', () => {
+    const selected = selectTemplateVersion(TEMPLATES_57, '57.0.12');
+
+    expect(selected).toEqual({ version: '57.0.14', expoRange: '~57.0.12' });
+  });
+
+  it('takes the newest template once stable latest catches up', () => {
+    // Same table, one `expo` patch later: 57.0.15 becomes usable again, so the
+    // selection floats forward on its own. This is not a pin.
+    const selected = selectTemplateVersion(TEMPLATES_57, '57.0.13');
+
+    expect(selected).toEqual({ version: '57.0.15', expoRange: '~57.0.13' });
+  });
+
+  it('selects within an explicitly requested older major', () => {
+    const selected = selectTemplateVersion(TEMPLATES_54, '54.0.36');
+
+    expect(selected).toEqual({ version: '54.0.62', expoRange: '~54.0.36' });
+  });
+
+  it('returns the newest satisfiable template regardless of input order', () => {
+    const shuffled = [TEMPLATES_57[2], TEMPLATES_57[15], TEMPLATES_57[13], TEMPLATES_57[7]];
+
+    expect(selectTemplateVersion(shuffled, '57.0.12')).toEqual({
+      version: '57.0.13',
+      expoRange: '~57.0.11',
+    });
+  });
+
+  it('returns null when no template in the major is satisfiable', () => {
+    // Every template ahead of stable latest: the "upstream registry
+    // inconsistent" case, which must be reported as such rather than as a
+    // plugin regression.
+    expect(selectTemplateVersion(TEMPLATES_57.slice(-2), '57.0.11')).toBeNull();
+  });
+
+  it('returns null for an empty candidate list', () => {
+    expect(selectTemplateVersion([], '57.0.13')).toBeNull();
+  });
+
+  it('ignores prerelease template versions even when satisfiable', () => {
+    const withCanary = [
+      ...TEMPLATES_57.slice(0, 14),
+      { version: '58.0.0-canary-20260812-27f94d4', expoRange: '~57.0.12' },
+    ];
+
+    expect(selectTemplateVersion(withCanary, '57.0.12')).toEqual({
+      version: '57.0.13',
+      expoRange: '~57.0.11',
+    });
+  });
+
+  it('skips candidates with no expo pin instead of throwing', () => {
+    const withGap = [...TEMPLATES_57.slice(0, 15), { version: '57.0.15', expoRange: undefined }];
+
+    expect(selectTemplateVersion(withGap, '57.0.12')).toEqual({
+      version: '57.0.14',
+      expoRange: '~57.0.12',
+    });
+  });
+
+  it('skips candidates with an unparseable expo range', () => {
+    const withJunk = [...TEMPLATES_57.slice(0, 15), { version: '57.0.15', expoRange: 'workspace:*' }];
+
+    expect(selectTemplateVersion(withJunk, '57.0.12')).toEqual({
+      version: '57.0.14',
+      expoRange: '~57.0.12',
+    });
+  });
+});
+
+describe('chooseStableExpoVersion', () => {
+  // Helper that records which sources were consulted, so the tests can assert
+  // the current major never falls back to the published-version list.
+  function sources({ latest = null, sdkTag = null, newestStableInMajor = null } = {}) {
+    const calls = [];
+    return {
+      calls,
+      latest: () => {
+        calls.push('latest');
+        return latest;
+      },
+      sdkTag: (major) => {
+        calls.push(`sdkTag:${major}`);
+        return sdkTag;
+      },
+      newestStableInMajor: (major) => {
+        calls.push(`newestStableInMajor:${major}`);
+        return newestStableInMajor;
+      },
+    };
+  }
+
+  it('uses the latest dist-tag for the current major', () => {
+    const src = sources({ latest: '57.0.13' });
+
+    expect(chooseStableExpoVersion(57, src)).toBe('57.0.13');
+    expect(src.calls).toEqual(['latest']);
+  });
+
+  // The load-bearing detail. During the outage, 57.0.13 was already published
+  // as a plain, non-prerelease semver version — it was just tagged `next`
+  // rather than `latest`. Gating on "newest non-prerelease version in the
+  // major" would have resolved 57.0.13, found template 57.0.15's ~57.0.13
+  // satisfied, and reproduced the outage exactly. Channel, not version string,
+  // is what makes a release usable.
+  it('never falls back to the published version list for the current major', () => {
+    const src = sources({ latest: '57.0.12', newestStableInMajor: '57.0.13' });
+
+    expect(chooseStableExpoVersion(57, src)).toBe('57.0.12');
+    expect(src.calls).toEqual(['latest']);
+    expect(src.calls).not.toContain('newestStableInMajor:57');
+  });
+
+  it('uses the sdk-<major> dist-tag for an older major', () => {
+    const src = sources({ latest: '57.0.13', sdkTag: '54.0.36' });
+
+    expect(chooseStableExpoVersion(54, src)).toBe('54.0.36');
+    expect(src.calls).toEqual(['latest', 'sdkTag:54']);
+  });
+
+  it('falls back to the newest stable release for a major with no sdk tag', () => {
+    // `expo` prunes old channel tags: sdk-52 is the oldest that still exists,
+    // so `--expo-version=50` has to come from the version list. Safe there —
+    // `next` and `canary` never point at a superseded major.
+    const src = sources({ latest: '57.0.13', sdkTag: null, newestStableInMajor: '50.0.21' });
+
+    expect(chooseStableExpoVersion(50, src)).toBe('50.0.21');
+    expect(src.calls).toEqual(['latest', 'sdkTag:50', 'newestStableInMajor:50']);
+  });
+
+  it('returns null for a major with no stable release yet', () => {
+    const src = sources({ latest: '57.0.13' });
+
+    expect(chooseStableExpoVersion(58, src)).toBeNull();
+  });
+
+  it('rejects a prerelease sdk dist-tag', () => {
+    const src = sources({ latest: '57.0.13', sdkTag: '55.0.3-canary-20260429-a5e59cf' });
+
+    expect(chooseStableExpoVersion(55, src)).toBeNull();
+  });
+
+  it('rejects a prerelease latest dist-tag', () => {
+    const src = sources({ latest: '58.0.0-canary-20260812-27f94d4' });
+
+    expect(chooseStableExpoVersion(58, src)).toBeNull();
+  });
+
+  it('ignores an sdk dist-tag from the wrong major', () => {
+    const src = sources({ latest: '57.0.13', sdkTag: '54.0.36', newestStableInMajor: '53.0.27' });
+
+    expect(chooseStableExpoVersion(53, src)).toBe('53.0.27');
+  });
+});
+
+describe('parseTemplateCandidates', () => {
+  it('parses the multi-match array shape', () => {
+    const raw = [
+      { 'version': '57.0.14', 'dependencies.expo': '~57.0.12' },
+      { 'version': '57.0.15', 'dependencies.expo': '~57.0.13' },
+    ];
+
+    expect(parseTemplateCandidates(raw)).toEqual([
+      { version: '57.0.14', expoRange: '~57.0.12' },
+      { version: '57.0.15', expoRange: '~57.0.13' },
+    ]);
+  });
+
+  it('parses the single-match object shape', () => {
+    // `npm view` collapses a one-result range query to a bare object.
+    const raw = { 'version': '57.0.15', 'dependencies.expo': '~57.0.13' };
+
+    expect(parseTemplateCandidates(raw)).toEqual([{ version: '57.0.15', expoRange: '~57.0.13' }]);
+  });
+
+  it('keeps entries whose expo pin is absent so they can be skipped downstream', () => {
+    const raw = [{ 'version': '57.0.15' }];
+
+    expect(parseTemplateCandidates(raw)).toEqual([{ version: '57.0.15', expoRange: undefined }]);
+  });
+
+  it('returns an empty list for empty registry output', () => {
+    expect(parseTemplateCandidates(null)).toEqual([]);
+    expect(parseTemplateCandidates(undefined)).toEqual([]);
+    expect(parseTemplateCandidates([])).toEqual([]);
+  });
+});
+
+describe('describeTemplateResolutionFailure', () => {
+  // Misattributing an upstream registry state to a plugin regression is what
+  // actually cost the time on 2026-08-14, so the diagnosis has to name the
+  // versions that disagree rather than just failing.
+  it('reports the template channel running ahead of the stable expo release', () => {
+    const report = describeTemplateResolutionFailure({
+      major: 57,
+      templatePackage: 'expo-template-default',
+      stableExpoVersion: '57.0.12',
+      candidates: TEMPLATES_57,
+    }).join('\n');
+
+    expect(report).toContain('Stable `expo` for SDK 57: 57.0.12');
+    expect(report).toContain('Newest `expo-template-default`: 57.0.15, pins expo ~57.0.13 — unsatisfied');
+    expect(report).toContain('Checked 16 template version(s)');
+    expect(report).toContain('template channel is ahead of the stable expo release');
+  });
+
+  it('identifies the newest template by version, not by registry ordering', () => {
+    const report = describeTemplateResolutionFailure({
+      major: 57,
+      templatePackage: 'expo-template-default',
+      stableExpoVersion: '57.0.11',
+      candidates: [TEMPLATES_57[14], TEMPLATES_57[15], TEMPLATES_57[13]],
+    }).join('\n');
+
+    expect(report).toContain('Newest `expo-template-default`: 57.0.15');
+  });
+
+  it('reports a major with no stable expo release', () => {
+    const report = describeTemplateResolutionFailure({
+      major: 58,
+      templatePackage: 'expo-template-default',
+      stableExpoVersion: null,
+      candidates: [],
+    }).join('\n');
+
+    expect(report).toContain('No stable `expo` release published for SDK 58');
+    expect(report).toContain('`sdk-58`');
+  });
+
+  it('reports a major with no stable template published', () => {
+    const report = describeTemplateResolutionFailure({
+      major: 57,
+      templatePackage: 'expo-template-default',
+      stableExpoVersion: '57.0.13',
+      candidates: [],
+    }).join('\n');
+
+    expect(report).toContain('No stable `expo-template-default` version published for SDK 57');
+  });
+});
+
+describe('templatePackageName', () => {
+  it('expands create-expo-app template shorthand to the npm package name', () => {
+    expect(templatePackageName('default')).toBe('expo-template-default');
+    expect(templatePackageName('blank')).toBe('expo-template-blank');
+  });
+
+  it('leaves an already-qualified package name alone', () => {
+    expect(templatePackageName('expo-template-default')).toBe('expo-template-default');
+  });
+});

--- a/__tests__/scripts/expo-template.test.js
+++ b/__tests__/scripts/expo-template.test.js
@@ -4,6 +4,7 @@ const {
   selectTemplateVersion,
   chooseStableExpoVersion,
   describeTemplateResolutionFailure,
+  pinnedExactVersion,
 } = require('../../scripts/utils/expo-template');
 
 // Real `npm view 'expo-template-default@>=57.0.0 <58.0.0' version dependencies.expo --json`
@@ -29,12 +30,14 @@ const TEMPLATES_57 = [
   { version: '57.0.15', expoRange: '~57.0.13' },
 ];
 
-// Tail of the same query for major 54, captured 2026-08-14.
+// Tail of the same query for major 54. `sdk-54` points at 54.0.62; 54.0.63 is
+// published but carries no dist-tag.
 const TEMPLATES_54 = [
-  { version: '54.0.59', expoRange: '~54.0.33' },
-  { version: '54.0.60', expoRange: '~54.0.34' },
-  { version: '54.0.61', expoRange: '~54.0.35' },
-  { version: '54.0.62', expoRange: '~54.0.36' },
+  { version: '54.0.59', expoRange: '~54.0.32' },
+  { version: '54.0.60', expoRange: '~54.0.33' },
+  { version: '54.0.61', expoRange: '~54.0.34' },
+  { version: '54.0.62', expoRange: '~54.0.35' },
+  { version: '54.0.63', expoRange: '~54.0.36' },
 ];
 
 describe('selectTemplateVersion', () => {
@@ -42,30 +45,47 @@ describe('selectTemplateVersion', () => {
   // 57.0.12 while the `sdk-57` template tag pointed at 57.0.15, which pins
   // ~57.0.13 — a `next`-channel expo whose expo-file-system was unpublished.
   // Hardcoding @sdk-<major> took that template and turned every Expo PR red.
-  it('skips templates pinning an expo release newer than stable latest', () => {
-    const selected = selectTemplateVersion(TEMPLATES_57, '57.0.12');
+  it('walks back from the tagged template when it pins an unreleased expo', () => {
+    const selected = selectTemplateVersion(TEMPLATES_57, '57.0.12', '57.0.15');
 
     expect(selected).toEqual({ version: '57.0.14', expoRange: '~57.0.12' });
   });
 
-  it('takes the newest template once stable latest catches up', () => {
-    // Same table, one `expo` patch later: 57.0.15 becomes usable again, so the
-    // selection floats forward on its own. This is not a pin.
-    const selected = selectTemplateVersion(TEMPLATES_57, '57.0.13');
+  it('takes the tagged template once stable latest catches up', () => {
+    // Same table, one `expo` patch later: the tag becomes usable again, so the
+    // selection returns to it on its own. This is not a pin.
+    const selected = selectTemplateVersion(TEMPLATES_57, '57.0.13', '57.0.15');
 
     expect(selected).toEqual({ version: '57.0.15', expoRange: '~57.0.13' });
   });
 
-  it('selects within an explicitly requested older major', () => {
-    const selected = selectTemplateVersion(TEMPLATES_54, '54.0.36');
+  // `sdk-54` is the curated template for that SDK. 54.0.63 is newer and also
+  // satisfiable, but carries no dist-tag — taking it would mean trusting an
+  // unblessed publish on a leg of the matrix that was never broken.
+  it('prefers the curated dist-tag over a newer untagged template', () => {
+    const selected = selectTemplateVersion(TEMPLATES_54, '54.0.36', '54.0.62');
 
-    expect(selected).toEqual({ version: '54.0.62', expoRange: '~54.0.36' });
+    expect(selected).toEqual({ version: '54.0.62', expoRange: '~54.0.35' });
+  });
+
+  it('falls back to the newest satisfiable template when the tag is unknown', () => {
+    expect(selectTemplateVersion(TEMPLATES_54, '54.0.36', null)).toEqual({
+      version: '54.0.63',
+      expoRange: '~54.0.36',
+    });
+  });
+
+  it('ignores a tagged version that is absent from the candidate list', () => {
+    expect(selectTemplateVersion(TEMPLATES_54, '54.0.36', '54.0.99')).toEqual({
+      version: '54.0.63',
+      expoRange: '~54.0.36',
+    });
   });
 
   it('returns the newest satisfiable template regardless of input order', () => {
     const shuffled = [TEMPLATES_57[2], TEMPLATES_57[15], TEMPLATES_57[13], TEMPLATES_57[7]];
 
-    expect(selectTemplateVersion(shuffled, '57.0.12')).toEqual({
+    expect(selectTemplateVersion(shuffled, '57.0.12', '57.0.15')).toEqual({
       version: '57.0.13',
       expoRange: '~57.0.11',
     });
@@ -75,11 +95,11 @@ describe('selectTemplateVersion', () => {
     // Every template ahead of stable latest: the "upstream registry
     // inconsistent" case, which must be reported as such rather than as a
     // plugin regression.
-    expect(selectTemplateVersion(TEMPLATES_57.slice(-2), '57.0.11')).toBeNull();
+    expect(selectTemplateVersion(TEMPLATES_57.slice(-2), '57.0.11', '57.0.15')).toBeNull();
   });
 
   it('returns null for an empty candidate list', () => {
-    expect(selectTemplateVersion([], '57.0.13')).toBeNull();
+    expect(selectTemplateVersion([], '57.0.13', '57.0.15')).toBeNull();
   });
 
   it('ignores prerelease template versions even when satisfiable', () => {
@@ -88,7 +108,7 @@ describe('selectTemplateVersion', () => {
       { version: '58.0.0-canary-20260812-27f94d4', expoRange: '~57.0.12' },
     ];
 
-    expect(selectTemplateVersion(withCanary, '57.0.12')).toEqual({
+    expect(selectTemplateVersion(withCanary, '57.0.12', null)).toEqual({
       version: '57.0.13',
       expoRange: '~57.0.11',
     });
@@ -97,7 +117,7 @@ describe('selectTemplateVersion', () => {
   it('skips candidates with no expo pin instead of throwing', () => {
     const withGap = [...TEMPLATES_57.slice(0, 15), { version: '57.0.15', expoRange: undefined }];
 
-    expect(selectTemplateVersion(withGap, '57.0.12')).toEqual({
+    expect(selectTemplateVersion(withGap, '57.0.12', '57.0.15')).toEqual({
       version: '57.0.14',
       expoRange: '~57.0.12',
     });
@@ -106,10 +126,33 @@ describe('selectTemplateVersion', () => {
   it('skips candidates with an unparseable expo range', () => {
     const withJunk = [...TEMPLATES_57.slice(0, 15), { version: '57.0.15', expoRange: 'workspace:*' }];
 
-    expect(selectTemplateVersion(withJunk, '57.0.12')).toEqual({
+    expect(selectTemplateVersion(withJunk, '57.0.12', '57.0.15')).toEqual({
       version: '57.0.14',
       expoRange: '~57.0.12',
     });
+  });
+});
+
+// The template only decides which `expo` *range* lands in package.json. npm
+// resolves a `~` range to the highest published version, ignoring dist-tags, so
+// `~57.0.12` still installs 57.0.13 when that release exists on `next` only.
+// Closing the channel requires writing an exact version into the generated app.
+describe('pinnedExactVersion', () => {
+  it('recognises an exact version', () => {
+    expect(pinnedExactVersion('57.0.12')).toBe('57.0.12');
+  });
+
+  it('rejects ranges, which are what let a next-channel release back in', () => {
+    expect(pinnedExactVersion('~57.0.12')).toBeNull();
+    expect(pinnedExactVersion('^57.0.12')).toBeNull();
+    expect(pinnedExactVersion('>=57.0.0 <58.0.0')).toBeNull();
+    expect(pinnedExactVersion('*')).toBeNull();
+  });
+
+  it('rejects absent or non-semver values', () => {
+    expect(pinnedExactVersion(undefined)).toBeNull();
+    expect(pinnedExactVersion('')).toBeNull();
+    expect(pinnedExactVersion('file:../local')).toBeNull();
   });
 });
 
@@ -177,6 +220,17 @@ describe('chooseStableExpoVersion', () => {
     const src = sources({ latest: '57.0.13' });
 
     expect(chooseStableExpoVersion(58, src)).toBeNull();
+  });
+
+  // A major ahead of `latest` is where the `next` channel lives, so the version
+  // list is exactly the wrong source there: 58.0.0 can be published, entirely
+  // non-prerelease, months before it is blessed as `latest`. The list is only
+  // safe for majors already superseded.
+  it('never consults the version list for a major ahead of latest', () => {
+    const src = sources({ latest: '57.0.13', newestStableInMajor: '58.0.0' });
+
+    expect(chooseStableExpoVersion(58, src)).toBeNull();
+    expect(src.calls).not.toContain('newestStableInMajor:58');
   });
 
   it('rejects a prerelease sdk dist-tag', () => {
@@ -272,6 +326,28 @@ describe('describeTemplateResolutionFailure', () => {
     expect(report).toContain('`sdk-58`');
   });
 
+  // The count and the "newest" it names must describe the templates actually
+  // evaluated. Reporting unevaluated entries — or printing `pins expo undefined`
+  // — undermines the one job this message has: closing the "is this us?"
+  // question on sight.
+  it('counts only the candidates the selector could evaluate', () => {
+    const report = describeTemplateResolutionFailure({
+      major: 57,
+      templatePackage: 'expo-template-default',
+      stableExpoVersion: '57.0.11',
+      candidates: [
+        { version: '57.0.14', expoRange: '~57.0.12' },
+        { version: '57.0.15', expoRange: undefined },
+        { version: '58.0.0-canary-20260812-27f94d4', expoRange: '~57.0.11' },
+      ],
+    }).join('\n');
+
+    expect(report).toContain('Newest `expo-template-default`: 57.0.14, pins expo ~57.0.12');
+    expect(report).toContain('Checked 1 template version(s)');
+    expect(report).not.toContain('undefined');
+    expect(report).not.toContain('canary');
+  });
+
   it('reports a major with no stable template published', () => {
     const report = describeTemplateResolutionFailure({
       major: 57,
@@ -280,7 +356,7 @@ describe('describeTemplateResolutionFailure', () => {
       candidates: [],
     }).join('\n');
 
-    expect(report).toContain('No stable `expo-template-default` version published for SDK 57');
+    expect(report).toContain('No usable `expo-template-default` version published for SDK 57');
   });
 });
 

--- a/scripts/compatibility/README.md
+++ b/scripts/compatibility/README.md
@@ -18,13 +18,20 @@ npm run compatibility:create-test-app -- --expo-version=<version>
 | - | - | - | - |
 | `--expo-version` | Expo SDK version to test (e.g., `50`, `52` `latest`) | - | ✅ |
 
-#### Template selection
+#### Expo version selection
 
-The script does not use the `sdk-<major>` template dist-tag. That tag tracks `next`, so it can point at a template pinning an `expo` release that hasn't reached `latest` yet — and a template pinning an unreleased `expo` fails to install, with no cause anywhere in this repository.
+The generated app is held to the **stable** `expo` release — the one on the `latest` dist-tag — resolved fresh on every run.
 
-Instead it resolves the Expo major (floating, unchanged), reads the stable `expo` release for that major from its dist-tag, and generates from the **newest** `expo-template-<name>` in the major whose pinned `expo` range that release satisfies. The major still floats and the template is still as new as possible — it is not a pin.
+This is not a committed pin. Nothing is stored in this repository and nothing needs bumping: the day a new release is promoted to `latest`, the next run tests against it, so a genuinely incompatible release still turns CI red immediately. What it excludes is releases that have not reached `latest` yet, which is not what customers install.
 
-If no template in the major is satisfiable, the script fails with an `Upstream registry inconsistent` diagnosis naming the versions that disagree. That state is upstream and resolves on its own; it is not a plugin regression, and nothing in this repository needs to change in response to it.
+Two things are needed to make that hold, because there are two independent places the version gets decided:
+
+1. **Template choice.** `sdk-<major>` tracks `next`, so it can point at a template pinning an `expo` that isn't out yet. The curated tag is still used whenever it is usable; the script walks back to the newest usable template in the major only when it isn't.
+2. **The pin itself.** Choosing the template is *not* sufficient. Templates pin `expo` with a `~` range, and npm resolves a range to the highest **published** version regardless of dist-tag — `~57.0.12` still installs 57.0.13 when that release exists on `next` only. So the exact stable version is written into the app before installing, and re-asserted in `compatibility:setup-test-app` after `npx expo install --fix`, which otherwise rewrites it.
+
+If no template in the major is usable, the script fails with an `Upstream registry inconsistent` diagnosis naming the versions that disagree. That state is upstream and resolves on its own; it is not a plugin regression. A bad `--expo-template` argument is reported separately, as our problem.
+
+**Known limitation:** only `expo` is held to the stable release. The template pins ~20 other `expo-*` packages with their own `~` ranges, so a broken pre-stable release of one of those can still fail the install. `expo install --fix` realigns them to the SDK, but only after the first install has already run.
 
 Dependencies are installed by this script (`create-expo-app` runs with `--no-install`), with retries. `create-expo-app`'s own installer reports failures as a warning and still prints `Your project is ready!`, which hides a broken dependency graph until a later build step fails for an unrelated-looking reason.
 

--- a/scripts/compatibility/README.md
+++ b/scripts/compatibility/README.md
@@ -18,6 +18,16 @@ npm run compatibility:create-test-app -- --expo-version=<version>
 | - | - | - | - |
 | `--expo-version` | Expo SDK version to test (e.g., `50`, `52` `latest`) | - | ✅ |
 
+#### Template selection
+
+The script does not use the `sdk-<major>` template dist-tag. That tag tracks `next`, so it can point at a template pinning an `expo` release that hasn't reached `latest` yet — and a template pinning an unreleased `expo` fails to install, with no cause anywhere in this repository.
+
+Instead it resolves the Expo major (floating, unchanged), reads the stable `expo` release for that major from its dist-tag, and generates from the **newest** `expo-template-<name>` in the major whose pinned `expo` range that release satisfies. The major still floats and the template is still as new as possible — it is not a pin.
+
+If no template in the major is satisfiable, the script fails with an `Upstream registry inconsistent` diagnosis naming the versions that disagree. That state is upstream and resolves on its own; it is not a plugin regression, and nothing in this repository needs to change in response to it.
+
+Dependencies are installed by this script (`create-expo-app` runs with `--no-install`), with retries. `create-expo-app`'s own installer reports failures as a warning and still prints `Your project is ready!`, which hides a broken dependency graph until a later build step fails for an unrelated-looking reason.
+
 ### 2. `compatibility:setup-test-app`
 
 Sets up the test app by installing dependencies, copying Google services files, and updating `app.json` with necessary configurations like app package and bundle id.

--- a/scripts/compatibility/create-test-app.js
+++ b/scripts/compatibility/create-test-app.js
@@ -1,14 +1,25 @@
 const fs = require("fs");
 const path = require("path");
+const semver = require("semver");
 const { execSync } = require("child_process");
 const { getArgValue, isFlagEnabled, logMessage, runCommand, runScript } = require("../utils/cli");
+const {
+  chooseStableExpoVersion,
+  describeTemplateResolutionFailure,
+  expoRegistrySources,
+  fetchTemplateCandidates,
+  selectTemplateVersion,
+  templatePackageName,
+} = require("../utils/expo-template");
+
+const INSTALL_ATTEMPTS = 3;
+const INSTALL_RETRY_DELAY_SECONDS = 10;
 
 // `expo-template-default`'s npm `latest` dist-tag lags Expo SDK releases by
 // weeks (e.g. SDK 55 has been out for a while but `default` still resolves
 // to the SDK 54 template), so `--template default` silently downgrades the
 // generated app a major version. Resolve `--expo-version=latest` to the
-// current Expo SDK major from `npm view expo version` and always pass the
-// pinned `default@sdk-<major>` template to create-expo-app instead.
+// current Expo SDK major from `npm view expo version` instead.
 function resolveExpoVersion(input) {
   if (input !== "latest") return input;
   const full = execSync("npm view expo version", { encoding: "utf8" }).trim();
@@ -26,6 +37,83 @@ const APP_NAME = getArgValue("--app-name", {
 });
 const DIRECTORY_NAME = getArgValue("--dir-name", { default: "ci-test-apps" });
 const CLEAN_FLAG = isFlagEnabled("--clean");
+
+// Fails the job with an explicit "this is upstream, not us" verdict. The
+// 2026-08-14 incident cost ~58 minutes of red CI across every open Expo PR
+// before anyone established that nothing in this repo had changed, so the
+// distinction is worth spelling out at the point of failure.
+function exitUpstreamInconsistent(lines) {
+  logMessage(
+    [
+      "",
+      "❌ Upstream registry inconsistent — this is not a plugin regression.",
+      ...lines.map((line) => `   ${line}`),
+      "",
+      "   Nothing in this repository needs to change. Re-run once the registry",
+      "   settles, or pass --expo-version=<major> to target a published SDK.",
+      "",
+    ].join("\n"),
+    "error",
+  );
+  process.exit(1);
+}
+
+// Resolves the exact `expo-template-<name>` version to generate from, rather
+// than trusting the `sdk-<major>` dist-tag. That tag tracks `next`, so it can
+// point at a template pinning an `expo` release that isn't on `latest` yet —
+// which on 2026-08-14 meant a template requiring an unpublished
+// expo-file-system. Gating on the stable `expo` release keeps the major
+// floating and the template as new as possible while excluding that channel.
+function resolveTemplateSpec() {
+  const coerced = semver.coerce(EXPO_VERSION);
+  if (!coerced) {
+    console.error(`❌ Could not read an Expo SDK major from --expo-version=${EXPO_VERSION}`);
+    process.exit(1);
+  }
+
+  const major = coerced.major;
+  const templatePackage = templatePackageName(EXPO_TEMPLATE);
+
+  const stableExpoVersion = chooseStableExpoVersion(major, expoRegistrySources());
+  const candidates = stableExpoVersion ? fetchTemplateCandidates(templatePackage, major) : [];
+  const selected = stableExpoVersion ? selectTemplateVersion(candidates, stableExpoVersion) : null;
+
+  if (!selected) {
+    exitUpstreamInconsistent(
+      describeTemplateResolutionFailure({ major, templatePackage, stableExpoVersion, candidates }),
+    );
+  }
+
+  logMessage(`🔹 Stable Expo Release: ${stableExpoVersion}`);
+  logMessage(`🔹 Template: ${templatePackage}@${selected.version} (pins expo ${selected.expoRange})`);
+
+  return `${EXPO_TEMPLATE}@${selected.version}`;
+}
+
+// create-expo-app swallows install failures — it prints "Something went wrong
+// installing JavaScript dependencies... Continuing" and then "Your project is
+// ready!", so a broken dependency graph only surfaces several steps later as
+// an unrelated-looking prebuild or Gradle error. Running the install here makes
+// it fail where it happened, and gives transient registry errors a retry.
+function installAppDependencies(appPath) {
+  for (let attempt = 1; attempt <= INSTALL_ATTEMPTS; attempt++) {
+    try {
+      runCommand(`cd ${appPath} && npm install`);
+      return;
+    } catch (error) {
+      if (attempt === INSTALL_ATTEMPTS) {
+        logMessage(`❌ Dependency installation failed after ${INSTALL_ATTEMPTS} attempts.`, "error");
+        throw error;
+      }
+
+      logMessage(
+        `⚠️  Dependency installation failed (attempt ${attempt}/${INSTALL_ATTEMPTS}), retrying in ${INSTALL_RETRY_DELAY_SECONDS}s...`,
+        "warning",
+      );
+      execSync(`sleep ${INSTALL_RETRY_DELAY_SECONDS}`);
+    }
+  }
+}
 
 /**
  * Main entry point for the script to handle the execution logic.
@@ -57,10 +145,15 @@ function execute() {
 
   // Step 3: Create a new Expo app
   logMessage(`\n🔧 Creating new Expo app: ${APP_NAME} (Expo ${EXPO_VERSION})`);
-  const RESOLVED_EXPO_TEMPLATE = `${EXPO_TEMPLATE}@sdk-${EXPO_VERSION}`;
+  const RESOLVED_EXPO_TEMPLATE = resolveTemplateSpec();
   runCommand(
-    `cd ${APP_DIRECTORY_PATH} && npx create-expo-app '${APP_NAME}' --template ${RESOLVED_EXPO_TEMPLATE}`,
+    `cd ${APP_DIRECTORY_PATH} && npx create-expo-app '${APP_NAME}' --template ${RESOLVED_EXPO_TEMPLATE} --no-install`,
   );
+
+  // Step 4: Install dependencies (skipped above via --no-install)
+  logMessage("\n📦 Installing app dependencies...");
+  installAppDependencies(APP_PATH);
+
   logMessage("✅ Expo app created successfully!", "success");
 }
 

--- a/scripts/compatibility/create-test-app.js
+++ b/scripts/compatibility/create-test-app.js
@@ -7,8 +7,10 @@ const {
   chooseStableExpoVersion,
   describeTemplateResolutionFailure,
   expoRegistrySources,
+  fetchTaggedTemplateVersion,
   fetchTemplateCandidates,
   selectTemplateVersion,
+  templatePackageExists,
   templatePackageName,
 } = require("../utils/expo-template");
 
@@ -19,11 +21,21 @@ const INSTALL_RETRY_DELAY_SECONDS = 10;
 // weeks (e.g. SDK 55 has been out for a while but `default` still resolves
 // to the SDK 54 template), so `--template default` silently downgrades the
 // generated app a major version. Resolve `--expo-version=latest` to the
-// current Expo SDK major from `npm view expo version` instead.
+// current Expo SDK major from the `latest` dist-tag instead.
+//
+// Read once and reused for the stable-release lookup below: two separate reads
+// of the same dist-tag can straddle a release and disagree about the major.
+const EXPO_REGISTRY = expoRegistrySources();
+const EXPO_LATEST_VERSION = EXPO_REGISTRY.latest();
+
 function resolveExpoVersion(input) {
   if (input !== "latest") return input;
-  const full = execSync("npm view expo version", { encoding: "utf8" }).trim();
-  return full.split(".")[0];
+
+  if (!EXPO_LATEST_VERSION) {
+    exitUpstreamInconsistent(["The `expo` package has no `latest` dist-tag."]);
+  }
+
+  return String(EXPO_LATEST_VERSION).split(".")[0];
 }
 
 const EXPO_VERSION = resolveExpoVersion(getArgValue("--expo-version", { required: true }));
@@ -58,12 +70,20 @@ function exitUpstreamInconsistent(lines) {
   process.exit(1);
 }
 
-// Resolves the exact `expo-template-<name>` version to generate from, rather
-// than trusting the `sdk-<major>` dist-tag. That tag tracks `next`, so it can
-// point at a template pinning an `expo` release that isn't on `latest` yet —
-// which on 2026-08-14 meant a template requiring an unpublished
-// expo-file-system. Gating on the stable `expo` release keeps the major
-// floating and the template as new as possible while excluding that channel.
+// Resolves which template to generate from and which `expo` release the app
+// should end up on.
+//
+// The template is chosen against the stable `expo` release rather than taken
+// from `sdk-<major>`, because that tag tracks `next` — on 2026-08-14 it pointed
+// at a template pinning an `expo` requiring an unpublished expo-file-system.
+// The curated tag still wins whenever it is usable; we only walk back when it
+// is not.
+//
+// Choosing the template is necessary but not sufficient: templates pin `expo`
+// with a `~` range, and npm resolves a range to the highest *published* version
+// regardless of dist-tag. `~57.0.12` still installs 57.0.13 when that release
+// exists on `next` only, so the caller writes the exact stable version into the
+// generated app before installing.
 function resolveTemplateSpec() {
   const coerced = semver.coerce(EXPO_VERSION);
   if (!coerced) {
@@ -74,9 +94,24 @@ function resolveTemplateSpec() {
   const major = coerced.major;
   const templatePackage = templatePackageName(EXPO_TEMPLATE);
 
-  const stableExpoVersion = chooseStableExpoVersion(major, expoRegistrySources());
+  // A `--expo-template` typo also produces "nothing published", so rule that
+  // out before blaming the registry for our own bad argument.
+  if (!templatePackageExists(templatePackage)) {
+    console.error(
+      `❌ No npm package named \`${templatePackage}\` (from --expo-template=${EXPO_TEMPLATE}).\n` +
+        `   Expected a create-expo-app template such as \`default\` or \`blank\`.`,
+    );
+    process.exit(1);
+  }
+
+  const stableExpoVersion = chooseStableExpoVersion(major, {
+    ...EXPO_REGISTRY,
+    latest: () => EXPO_LATEST_VERSION,
+  });
+
   const candidates = stableExpoVersion ? fetchTemplateCandidates(templatePackage, major) : [];
-  const selected = stableExpoVersion ? selectTemplateVersion(candidates, stableExpoVersion) : null;
+  const taggedVersion = stableExpoVersion ? fetchTaggedTemplateVersion(templatePackage, major) : null;
+  const selected = selectTemplateVersion(candidates, stableExpoVersion, taggedVersion);
 
   if (!selected) {
     exitUpstreamInconsistent(
@@ -84,10 +119,11 @@ function resolveTemplateSpec() {
     );
   }
 
+  const viaTag = selected.version === taggedVersion ? ` (sdk-${major})` : " (walked back from sdk tag)";
   logMessage(`🔹 Stable Expo Release: ${stableExpoVersion}`);
-  logMessage(`🔹 Template: ${templatePackage}@${selected.version} (pins expo ${selected.expoRange})`);
+  logMessage(`🔹 Template: ${templatePackage}@${selected.version}${viaTag}, pins expo ${selected.expoRange}`);
 
-  return `${EXPO_TEMPLATE}@${selected.version}`;
+  return { template: `${templatePackage}@${selected.version}`, expoVersion: stableExpoVersion };
 }
 
 // create-expo-app swallows install failures — it prints "Something went wrong
@@ -103,6 +139,11 @@ function installAppDependencies(appPath) {
     } catch (error) {
       if (attempt === INSTALL_ATTEMPTS) {
         logMessage(`❌ Dependency installation failed after ${INSTALL_ATTEMPTS} attempts.`, "error");
+        // Leave no half-built app behind: the directory exists but has no
+        // node_modules, so the next run would refuse to start with a confusing
+        // "directory already exists" instead of retrying the install.
+        logMessage(`🧹 Removing incomplete app: ${appPath}`, "warning");
+        runCommand(`rm -rf ${appPath}`);
         throw error;
       }
 
@@ -145,12 +186,19 @@ function execute() {
 
   // Step 3: Create a new Expo app
   logMessage(`\n🔧 Creating new Expo app: ${APP_NAME} (Expo ${EXPO_VERSION})`);
-  const RESOLVED_EXPO_TEMPLATE = resolveTemplateSpec();
+  const { template, expoVersion } = resolveTemplateSpec();
   runCommand(
-    `cd ${APP_DIRECTORY_PATH} && npx create-expo-app '${APP_NAME}' --template ${RESOLVED_EXPO_TEMPLATE} --no-install`,
+    `cd ${APP_DIRECTORY_PATH} && npx create-expo-app '${APP_NAME}' --template ${template} --no-install`,
   );
 
-  // Step 4: Install dependencies (skipped above via --no-install)
+  // Step 4: Hold the app to the stable `expo` release. The template's `~` range
+  // would otherwise resolve to the highest published version, dist-tag ignored,
+  // which is how a `next`-only release gets in. Resolved fresh every run, so a
+  // new stable release is still picked up the day it ships.
+  logMessage(`\n📌 Setting expo to the stable release: ${expoVersion}`);
+  runCommand(`cd ${APP_PATH} && npm pkg set dependencies.expo=${expoVersion}`);
+
+  // Step 5: Install dependencies (skipped above via --no-install)
   logMessage("\n📦 Installing app dependencies...");
   installAppDependencies(APP_PATH);
 

--- a/scripts/compatibility/setup-test-app.js
+++ b/scripts/compatibility/setup-test-app.js
@@ -6,6 +6,7 @@ const {
   CUSTOMER_IO_REACT_NATIVE_SDK_NAME,
   EXPO_BUILD_PROPERTIES_PLUGIN,
 } = require("../utils/constants");
+const { pinnedExactVersion } = require("../utils/expo-template");
 
 const APP_PATH = getArgValue("--app-path", { required: true });
 
@@ -24,6 +25,19 @@ const APP_ARTIFACTS_DIR_PATH = path.join(APP_PATH, APP_ARTIFACTS_DIR_NAME);
 
 // Get additional dependencies to install
 const ADDITIONAL_DEPENDENCIES = parseArrayArg("--dependencies");
+
+// The app's `expo` dependency when it is an exact version, or null when it is a
+// range. Only an exact version represents a deliberate pin — a range is npm's
+// default and is meant to float.
+function readPinnedExpoVersion() {
+  try {
+    const appPackageJson = JSON.parse(fs.readFileSync(path.join(APP_PATH, "package.json"), "utf8"));
+    return pinnedExactVersion((appPackageJson.dependencies || {}).expo);
+  } catch (error) {
+    logMessage(`⚠️  Could not read the app's expo version: ${error.message}`, "warning");
+    return null;
+  }
+}
 
 /**
  * Main entry point for the script to handle the execution logic.
@@ -130,12 +144,31 @@ function execute() {
   }
 
   // Step 6: Run npx expo install
+  //
+  // `--fix` realigns every expo-* package to the SDK, which is what we want —
+  // but it also rewrites `expo` itself to the newest patch it considers
+  // appropriate, discarding the exact version create-test-app pinned. It is the
+  // last writer, so capture the pin first and restore it afterwards; otherwise
+  // the app silently ends up on whichever release `--fix` picked.
+  const pinnedExpoVersion = readPinnedExpoVersion();
+
   logMessage("🚀 Running npx expo install...");
   try {
     runCommand(`cd ${APP_PATH} && npx expo install --fix`);
   } catch (error) {
     logMessage(`❌ Error running npx expo install: ${error.message}`, "error");
     process.exit(1);
+  }
+
+  if (pinnedExpoVersion && readPinnedExpoVersion() !== pinnedExpoVersion) {
+    logMessage(`📌 Restoring pinned expo version: ${pinnedExpoVersion}`);
+    try {
+      runCommand(`cd ${APP_PATH} && npm pkg set dependencies.expo=${pinnedExpoVersion}`);
+      runCommand(`cd ${APP_PATH} && npm install`);
+    } catch (error) {
+      logMessage(`❌ Error restoring pinned expo version: ${error.message}`, "error");
+      process.exit(1);
+    }
   }
 
   logMessage("✅ App setup and dependency installation completed successfully!", "success");

--- a/scripts/utils/expo-template.js
+++ b/scripts/utils/expo-template.js
@@ -25,22 +25,42 @@ function parseTemplateCandidates(raw) {
   }));
 }
 
-// Picks the newest template whose pinned `expo` range accepts the stable `expo`
-// release. Templates ship ahead of the `expo` releases they pin, so the newest
-// one is regularly unusable for a day or two; walking back to the newest usable
-// one keeps the job on the latest template without pinning it to a version.
-function selectTemplateVersion(candidates, stableExpoVersion) {
-  const usable = candidates.filter(
+// An exact version, or null for anything with range semantics. A `~`/`^` range
+// is resolved by npm to the highest *published* version regardless of dist-tag,
+// so only an exact version keeps an unblessed release out of the install.
+function pinnedExactVersion(dependencyRange) {
+  return dependencyRange && semver.valid(dependencyRange) ? dependencyRange : null;
+}
+
+// Candidates the selector can actually reason about: real stable versions that
+// declare a parseable `expo` pin.
+function evaluableCandidates(candidates) {
+  return candidates.filter(
     (candidate) =>
       semver.valid(candidate.version) &&
       !semver.prerelease(candidate.version) &&
       candidate.expoRange &&
       semver.validRange(candidate.expoRange),
   );
+}
 
-  const newestFirst = [...usable].sort((a, b) => semver.rcompare(a.version, b.version));
+function newestFirst(candidates) {
+  return [...candidates].sort((a, b) => semver.rcompare(a.version, b.version));
+}
 
-  return newestFirst.find((candidate) => semver.satisfies(stableExpoVersion, candidate.expoRange)) || null;
+// Prefers the curated `sdk-<major>` template, and only walks back when that one
+// pins an `expo` release that isn't out yet. Templates ship ahead of the `expo`
+// releases they pin, so the tagged one is regularly unusable for a day or two;
+// deviating only in that window keeps every unaffected run on the blessed
+// template rather than trusting whatever was published most recently.
+function selectTemplateVersion(candidates, stableExpoVersion, taggedVersion) {
+  const usable = newestFirst(evaluableCandidates(candidates));
+  const satisfied = (candidate) => semver.satisfies(stableExpoVersion, candidate.expoRange);
+
+  const tagged = taggedVersion && usable.find((candidate) => candidate.version === taggedVersion);
+  if (tagged && satisfied(tagged)) return tagged;
+
+  return usable.find(satisfied) || null;
 }
 
 function isStableRelease(version, expectedMajor) {
@@ -67,7 +87,12 @@ function chooseStableExpoVersion(requestedMajor, sources) {
 
   // `expo` prunes old channel tags — sdk-52 is currently the oldest that still
   // exists — so anything older has to come from the published version list.
-  // Safe there: `next` and `canary` never point at a superseded major.
+  // Safe only for a *superseded* major: `next` and `canary` never point back at
+  // one. For a major at or ahead of `latest` the list is the wrong source, since
+  // that is exactly where an unblessed release sits as ordinary semver.
+  const supersededMajor = semver.valid(latest) && requestedMajor < semver.major(latest);
+  if (!supersededMajor) return null;
+
   const newestStable = sources.newestStableInMajor(requestedMajor);
   if (isStableRelease(newestStable, requestedMajor)) return newestStable;
 
@@ -86,19 +111,27 @@ function describeTemplateResolutionFailure({ major, templatePackage, stableExpoV
     ];
   }
 
-  if (candidates.length === 0) {
+  // Only the candidates the selector could evaluate are worth reporting on —
+  // counting entries it silently skipped would overstate what was checked, and
+  // naming one of them prints an `undefined` pin.
+  const evaluable = newestFirst(evaluableCandidates(candidates));
+
+  if (evaluable.length === 0) {
     return [
-      `No stable \`${templatePackage}\` version published for SDK ${major}.`,
+      `No usable \`${templatePackage}\` version published for SDK ${major}.`,
       `Stable \`expo\` for SDK ${major}: ${stableExpoVersion}`,
+      candidates.length > 0
+        ? `${candidates.length} version(s) exist but none declare a parseable \`expo\` pin.`
+        : "The registry returned no stable versions in this major.",
     ];
   }
 
-  const newest = [...candidates].sort((a, b) => semver.rcompare(a.version, b.version))[0];
+  const newest = evaluable[0];
 
   return [
     `Stable \`expo\` for SDK ${major}: ${stableExpoVersion}`,
     `Newest \`${templatePackage}\`: ${newest.version}, pins expo ${newest.expoRange} — unsatisfied`,
-    `Checked ${candidates.length} template version(s); none pin an expo range that ${stableExpoVersion} satisfies.`,
+    `Checked ${evaluable.length} template version(s); none pin an expo range that ${stableExpoVersion} satisfies.`,
     "The template channel is ahead of the stable expo release.",
   ];
 }
@@ -136,6 +169,18 @@ function fetchTemplateCandidates(templatePackage, major) {
   );
 }
 
+// The curated template for an SDK, or null when the tag doesn't exist.
+function fetchTaggedTemplateVersion(templatePackage, major) {
+  return npmViewJson(`${templatePackage}@sdk-${major}`, ["version"]);
+}
+
+// Distinguishes "this package isn't published at all" (a bad `--expo-template`
+// argument — our problem) from "published, but nothing usable in this major"
+// (upstream). Conflating the two sends the reader upstream to chase a typo.
+function templatePackageExists(templatePackage) {
+  return npmViewJson(templatePackage, ["name"]) !== null;
+}
+
 function expoRegistrySources() {
   return {
     latest: () => npmViewJson("expo@latest", ["version"]),
@@ -154,6 +199,9 @@ module.exports = {
   selectTemplateVersion,
   chooseStableExpoVersion,
   describeTemplateResolutionFailure,
+  pinnedExactVersion,
   fetchTemplateCandidates,
+  fetchTaggedTemplateVersion,
+  templatePackageExists,
   expoRegistrySources,
 };

--- a/scripts/utils/expo-template.js
+++ b/scripts/utils/expo-template.js
@@ -1,0 +1,159 @@
+const { execFileSync } = require("child_process");
+const semver = require("semver");
+
+const TEMPLATE_PACKAGE_PREFIX = "expo-template-";
+
+// ---------------------------------------------------------------------------
+// Selection logic (pure — no registry access, covered by unit tests)
+// ---------------------------------------------------------------------------
+
+// `create-expo-app --template` accepts shorthand (`default`, `blank`), but the
+// registry queries below need the real package name.
+function templatePackageName(template) {
+  return template.startsWith(TEMPLATE_PACKAGE_PREFIX) ? template : `${TEMPLATE_PACKAGE_PREFIX}${template}`;
+}
+
+// `npm view <range> version dependencies.expo --json` returns an array for a
+// multi-version match but collapses to a bare object for a single match, and
+// omits `dependencies.expo` entirely for versions that don't declare it.
+function parseTemplateCandidates(raw) {
+  if (!raw) return [];
+
+  return (Array.isArray(raw) ? raw : [raw]).map((entry) => ({
+    version: entry.version,
+    expoRange: entry["dependencies.expo"],
+  }));
+}
+
+// Picks the newest template whose pinned `expo` range accepts the stable `expo`
+// release. Templates ship ahead of the `expo` releases they pin, so the newest
+// one is regularly unusable for a day or two; walking back to the newest usable
+// one keeps the job on the latest template without pinning it to a version.
+function selectTemplateVersion(candidates, stableExpoVersion) {
+  const usable = candidates.filter(
+    (candidate) =>
+      semver.valid(candidate.version) &&
+      !semver.prerelease(candidate.version) &&
+      candidate.expoRange &&
+      semver.validRange(candidate.expoRange),
+  );
+
+  const newestFirst = [...usable].sort((a, b) => semver.rcompare(a.version, b.version));
+
+  return newestFirst.find((candidate) => semver.satisfies(stableExpoVersion, candidate.expoRange)) || null;
+}
+
+function isStableRelease(version, expectedMajor) {
+  return Boolean(version) && semver.valid(version) && !semver.prerelease(version) && semver.major(version) === expectedMajor;
+}
+
+// Resolves the stable `expo` release for a major from dist-tags, in priority
+// order. `sources` holds lazy lookups so only the needed queries run.
+//
+// The current major MUST come from the `latest` dist-tag and nothing else.
+// During the 2026-08-14 outage `expo@next` was 57.0.13 — a plain, non-prerelease
+// version — while `latest` was still 57.0.12. Falling back to "newest published
+// version in the major" would have picked 57.0.13, accepted the template that
+// pins it, and reproduced the breakage. What made that release unusable was its
+// channel, not its version string.
+function chooseStableExpoVersion(requestedMajor, sources) {
+  const latest = sources.latest();
+  if (isStableRelease(latest, requestedMajor)) return latest;
+
+  // Superseded majors live on `sdk-<major>`, which never carries a prerelease
+  // (canaries get their own `canary-sdk-<major>` tag).
+  const sdkTag = sources.sdkTag(requestedMajor);
+  if (isStableRelease(sdkTag, requestedMajor)) return sdkTag;
+
+  // `expo` prunes old channel tags — sdk-52 is currently the oldest that still
+  // exists — so anything older has to come from the published version list.
+  // Safe there: `next` and `canary` never point at a superseded major.
+  const newestStable = sources.newestStableInMajor(requestedMajor);
+  if (isStableRelease(newestStable, requestedMajor)) return newestStable;
+
+  return null;
+}
+
+// Explains why no template could be selected, naming the versions that
+// disagree. Misreading an upstream registry state as a plugin regression is
+// what made the 2026-08-14 incident expensive, so the diagnosis has to be
+// specific enough to close that question immediately.
+function describeTemplateResolutionFailure({ major, templatePackage, stableExpoVersion, candidates }) {
+  if (!stableExpoVersion) {
+    return [
+      `No stable \`expo\` release published for SDK ${major}.`,
+      `Checked the \`latest\` and \`sdk-${major}\` dist-tags and the published version list.`,
+    ];
+  }
+
+  if (candidates.length === 0) {
+    return [
+      `No stable \`${templatePackage}\` version published for SDK ${major}.`,
+      `Stable \`expo\` for SDK ${major}: ${stableExpoVersion}`,
+    ];
+  }
+
+  const newest = [...candidates].sort((a, b) => semver.rcompare(a.version, b.version))[0];
+
+  return [
+    `Stable \`expo\` for SDK ${major}: ${stableExpoVersion}`,
+    `Newest \`${templatePackage}\`: ${newest.version}, pins expo ${newest.expoRange} — unsatisfied`,
+    `Checked ${candidates.length} template version(s); none pin an expo range that ${stableExpoVersion} satisfies.`,
+    "The template channel is ahead of the stable expo release.",
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Registry access
+// ---------------------------------------------------------------------------
+
+// `npm view` exits 1 with E404 when a dist-tag or range matches nothing. That's
+// a legitimate "not published" answer, not a failure, so it maps to null.
+function npmViewJson(spec, fields) {
+  try {
+    const output = execFileSync("npm", ["view", spec, ...fields, "--json"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+
+    return output ? JSON.parse(output) : null;
+  } catch (error) {
+    const details = `${error.stdout || ""}${error.stderr || ""}`;
+    if (details.includes("E404")) return null;
+    throw error;
+  }
+}
+
+function majorRange(major) {
+  return `>=${major}.0.0 <${major + 1}.0.0`;
+}
+
+// One round trip for every stable template version in the major. The semver
+// range excludes template canaries on its own.
+function fetchTemplateCandidates(templatePackage, major) {
+  return parseTemplateCandidates(
+    npmViewJson(`${templatePackage}@${majorRange(major)}`, ["version", "dependencies.expo"]),
+  );
+}
+
+function expoRegistrySources() {
+  return {
+    latest: () => npmViewJson("expo@latest", ["version"]),
+    sdkTag: (major) => npmViewJson(`expo@sdk-${major}`, ["version"]),
+    newestStableInMajor: (major) => {
+      const versions = npmViewJson(`expo@${majorRange(major)}`, ["version"]);
+      const list = Array.isArray(versions) ? versions : [versions].filter(Boolean);
+      return list.length ? semver.rsort([...list])[0] : null;
+    },
+  };
+}
+
+module.exports = {
+  templatePackageName,
+  parseTemplateCandidates,
+  selectTemplateVersion,
+  chooseStableExpoVersion,
+  describeTemplateResolutionFailure,
+  fetchTemplateCandidates,
+  expoRegistrySources,
+};


### PR DESCRIPTION
The Expo compatibility job could generate a test app running a pre-stable `expo` release, turning every open PR red for reasons outside this repo. It now holds the app to the release on the `latest` dist-tag, resolved fresh on every run.

Not a committed pin — nothing is stored here and nothing needs bumping. The day a release is promoted to `latest`, the next run tests against it, so a genuinely incompatible release still fails CI immediately. Only releases that haven't reached `latest` are excluded, and those aren't what customers install.

Two independent places decide the version, so both are handled:

1. **Template choice** — `sdk-<major>` tracks `next`, so it can point at a template pinning an `expo` that isn't out yet. The curated tag is still preferred; the script walks back to the newest usable template only when the tag is unusable.
2. **The version itself** — choosing the template is *not* sufficient. npm resolves a `~` range to the highest published version regardless of dist-tag, so `~57.0.12` still installs 57.0.13 when that release exists on `next` only. The exact stable version is written into the app before install, and re-asserted in `setup-test-app` after `npx expo install --fix`, which is an independent second writer and otherwise overwrites it.

An unsatisfiable major is reported as an upstream registry state rather than a plugin regression; a bad `--expo-template` is reported as our error.

Applies to all three consumers of these scripts: the PR smoke matrix, the release matrix, and the nightly iOS toolchain workflow.

**Verified end to end** on a real generated app with the divergence forced: `--fix` attempts the bump, the restore wins, the final installed version is the stable one.

**Known limitation** (documented in the README): only `expo` is held to stable. The template's other ~20 `expo-*` pins still float, so a broken pre-stable release of one of those can still fail the install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)