### PR TITLE
fix: update customerio-reactnative to 6.6.3

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -50,9 +50,12 @@ jobs:
         uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4.2.0
         id: semantic-release        
         with:
-          semantic_version: latest
+          # Both pinned deliberately. The conventionalcommits 10.x line renders through
+          # @conventional-changelog/template, which needs conventional-changelog-writer@9;
+          # every released semantic-release resolves writer@8, so 10.x cannot render here.
+          semantic_version: 25.0.9
           extra_plugins: |
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@9.3.1
             @semantic-release/changelog
             @semantic-release/git
             @semantic-release/github

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-expo-plugin",
-  "version": "3.6.2",
+  "version": "3.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-expo-plugin",
-      "version": "3.6.2",
+      "version": "3.7.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -36,7 +36,7 @@
         "yaml": "^2.8.3"
       },
       "peerDependencies": {
-        "customerio-reactnative": "6.6.2"
+        "customerio-reactnative": "6.6.3"
       }
     },
     "node_modules/@babel/cli": {
@@ -7893,9 +7893,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-6.6.2.tgz",
-      "integrity": "sha512-xeSdnbZZ1ekBaPGXzHiXHwLWVU36oqBvZbs/zp+lvGXdFAkgOd8FDORwwxKXED4TQWQEw3vn+v54uLzcT+kc/g==",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/customerio-reactnative/-/customerio-reactnative-6.6.3.tgz",
+      "integrity": "sha512-g4qCLgHAeKWmLC4L9pr+DRFDTk04AVwPuA9O/ngIMWkNnbCRRTeMzMDWG38Ewe72hQpshsxYxPkPTd7D+iJHAA==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "customerio-reactnative": "6.6.2"
+    "customerio-reactnative": "6.6.3"
   },
   "devDependencies": {
     "dotenv": "^16.4.5",

--- a/test-app-pnpm-monorepo/apps/mobile/package.json
+++ b/test-app-pnpm-monorepo/apps/mobile/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@cio-test/shared-cio-utils": "workspace:*",
     "customerio-expo-plugin": "file:../../../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.6.2",
+    "customerio-reactnative": "^6.6.3",
     "expo": "~54.0.2",
     "expo-build-properties": "^1.0.8",
     "expo-status-bar": "~3.0.8",

--- a/test-app-pnpm-monorepo/packages/shared-cio-utils/package.json
+++ b/test-app-pnpm-monorepo/packages/shared-cio-utils/package.json
@@ -5,6 +5,6 @@
   "main": "index.ts",
   "types": "index.ts",
   "dependencies": {
-    "customerio-reactnative": "^6.6.2"
+    "customerio-reactnative": "^6.6.3"
   }
 }

--- a/test-app-pnpm/package.json
+++ b/test-app-pnpm/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.6.2",
+    "customerio-reactnative": "^6.6.3",
     "expo": "~54.0.2",
     "expo-build-properties": "^1.0.8",
     "expo-status-bar": "~3.0.8",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -15,7 +15,7 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "customerio-expo-plugin": "file:../customerio-expo-plugin-latest.tgz",
-    "customerio-reactnative": "^6.6.2",
+    "customerio-reactnative": "^6.6.3",
     "dotenv": "^17.2.2",
     "expo": "~55.0.23",
     "expo-build-properties": "~55.0.13",


### PR DESCRIPTION
Updates `customerio-reactnative` to 6.6.3, and fixes the release-workflow bug that blocked the Android and React Native releases before it.

Ticket: [INAPP-14655](https://linear.app/customerio/issue/INAPP-14655/mobile-add-app-identifier-header-for-app-filtering) — the app-identifier header lands here through 6.6.3's native bump.

## 1. SDK bump

`6.6.2` → `6.6.3` across the peer dependency and the four test apps. 6.6.3 is a native-SDK bump only: **iOS 4.7.5, Android 4.20.2**.

Diffed the published tarballs to confirm no plugin-side work is needed:

| change | affects the plugin? |
|---|---|
| `cioNativeiOSSdkVersion` `= 4.7.2` → `= 4.7.5` | no — resolved transitively |
| `cioSDKVersionAndroid` `4.20.1` → `4.20.2` | no — resolved transitively |
| podspecs, subspec names | **unchanged** — the plugin's Podfile injection is unaffected |
| new `ios/cocoapods_deployment_target.rb` | no — see below |

### On the new CocoaPods helper

6.6.3 ships an **opt-in** Podfile helper for Xcode 27 deployment-target normalization. Deliberately not adopted here: its own docs carry a warning that it raises app and extension targets to the computed floor (iOS 15.1 on RN 0.83), which would stop iOS 15.0-and-earlier users from installing updates. That is a consumer's decision, not something the plugin should inject. Happy to do it as a separate PR if we want it.

## 2. Release workflow — same failure as Android #817 / RN #639

Expo has the identical latent bug: [`deploy-sdk.yml`](.github/workflows/deploy-sdk.yml) installs `conventional-changelog-conventionalcommits` **unpinned**, so every run resolves npm's newest at that moment. Since preset `10.0.0` (2026-06-26) the preset renders through `@conventional-changelog/template`, which requires `conventional-changelog-writer@9` — and no released semantic-release resolves writer@9 (`semantic-release@25.0.9` → `release-notes-generator@^14.1.0` → `writer@^8.0.0`). So bumping semantic-release cannot fix it.

**It has already been failing here, silently.** `CHANGELOG.md` is unedited machine output, and the boundary lands exactly on preset 10.0.0:

| release | date | `###` sections |
|---|---|---|
| 3.7.1 | 2026-08-07 | **0** |
| 3.7.0 | 2026-07-30 | **0** |
| 3.6.2 | 2026-06-23 | 1 |

Empty notes never blocked a release. A *crashing* notes step is different: preset `10.4.0` (2026-08-18) replaced the quiet misrender with a hard `throw`, and `generateNotes` sits upstream of tagging — so the next release would abort before `prepare`/`publish` and create no tag. That is exactly what happened on Android and RN.

This PR is what triggers the next release, so it fixes the workflow in the same change.

### Verification

Reproduced both directions locally against real npm installs, calling `generateNotes` with this PR's own commit:

**Current config (`semantic_version: latest`, unpinned preset)** — resolves preset 10.4.0, writer 8.4.0:
```
RESULT: THREW
Missing helper: "conventional-changelog-conventionalcommits requires
conventional-changelog-writer@9 or newer ..."
```

**This PR's config (`25.0.9` + preset `9.3.1`)** — no `@conventional-changelog/template` in the tree at all:
```markdown
## [3.7.2](https://github.com/customerio/customerio-expo-plugin/compare/3.7.1...3.7.2) (2026-08-21)

### Bug Fixes

* update customerio-reactnative to 6.6.3 (#392) (abc1234)
```

So this also ends the silent-empty-notes phase — 3.7.2 gets real release notes.

`9.3.1` is the last preset version with no template dependency (its only dep is `compare-func`), and is the last known-good combination: published 2026-03-29, superseded by 10.0.0 on 2026-06-26, so 3.6.0/3.6.1/3.6.2 all rendered correct notes through this exact pipeline while resolving it unpinned.

`semantic_version: 25.0.9` is **defensive, not required** — `latest` already resolves to 25.0.9 today, so it is a no-op right now. It stops the other half of the tree drifting onto a future semantic-release that ships writer@9, which would break preset 9.3.1 in the opposite direction. Also confirmed it parses as the string `"25.0.9"`, not a float, and that its engines (`^22.14.0 || >= 24.10.0`) are satisfied — unchanged from what `latest` already resolved to.

`deploy-sdk.yml` is the only workflow in this repo that uses semantic-release.

## Test plan

Rebased onto `main` (through #391) and re-ran every PR CI job locally against the **current** workflow definitions, on node 24 to match #388. Run in an isolated worktree so no local state leaked in:

| job | result |
|---|---|
| `lint` | pass |
| `typescript` | pass |
| `check-api-changes` (`api-extractor run`) | pass — API report up to date |
| `test-utils` | 257 tests pass — includes the new `__tests__/scripts` and `__tests__/workflows` suites |
| `test-scenarios` | 129 tests pass |
| `test-plugin-android` | 37 pass, 1 skipped |
| `test-plugin-ios` (apn) | 6 pass |
| `test-plugin-ios` (fcm) | 7 pass |
| `test-deploy` (`npm run build` + `npm pack --dry-run`) | pass |

`npm ci` resolves `customerio-reactnative@6.6.3` from the updated lockfile, and `expo prebuild` + `pod install` complete against it on both push providers. End-to-end proof the bump is real, from the generated `test-app/ios/Podfile.lock`:

```
- customerio-reactnative (6.6.3):
  - CustomerIO/DataPipelines (= 4.7.5)
  - CustomerIO/MessagingInApp (= 4.7.5)
  - CustomerIO/MessagingInbox (= 4.7.5)
- customerio-reactnative/geofence (6.6.3):
  - CustomerIO/LocationGeofence (= 4.7.5)
```
plus `cioSDKVersionAndroid=4.20.2` in the installed package.

The new `__tests__/workflows` suite covers `ios-toolchain-compatibility.yml` only, so the `deploy-sdk.yml` change here has no test to update.

## Note on `package-lock.json`

The lockfile's own top-level `version` was stale at `3.6.2` and regenerating synced it to `3.7.1`. That drift is structural, not something this PR introduces: `.releaserc.json`'s `@semantic-release/git` `assets` commits only `CHANGELOG.md` and `package.json`, so the lock's version never gets the release bump. Harmless, and it will re-stale on the next release. Flagging it rather than hiding it — worth a follow-up to add `package-lock.json` to those assets if we care.

## What happens on merge

The squashed commit is a `fix:`, so `Deploy SDK` cuts **3.7.2** with the pinned workflow already in place (the `workflow_run` head SHA is the squash commit, which contains the pin).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency bump across the plugin and test apps, plus a release workflow tooling pin. The workflow change is release-critical but narrowly scoped and verified against npm.
> 
> **Overview**
> Bumps the `customerio-reactnative` peer dependency and all test apps from `6.6.2` to `6.6.3`, pulling in native SDK versions iOS `4.7.5` and Android `4.20.2`.
> 
> Pins the release workflow's semantic-release stack to `semantic_version: 25.0.9` and `conventional-changelog-conventionalcommits@9.3.1`. This fixes a latent crash where the unpinned preset `10.x` line requires `conventional-changelog-writer@9`, which no released semantic-release resolves, causing the next release to abort before tagging.
> 
> Also syncs `package-lock.json`'s top-level version from `3.6.2` to `3.7.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90995ea38e9ab05e59422f5197a55e8587fdcc11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

