### PR TITLE
ci: install with npm ci in the npm deploy job

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -168,10 +168,10 @@ jobs:
         run: npm install -g npm@11
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: npm ci
 
       - name: Compile TypeScript
-        run: yarn typescript
+        run: npm run typescript
 
       - name: Publish to npm
         run: npm publish


### PR DESCRIPTION
The 3.7.2 release created its tag and GitHub release, then failed before publishing — npm is still on 3.7.1. This fixes the cause.

## What broke

`deploy-npm` installed with `yarn install --frozen-lockfile`, but there is no `yarn.lock` in this repo. Yarn 1 does not fail on a missing lockfile — it ignores `package-lock.json` and re-resolves every range:

```
info No lockfile found.
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn.
```

That pulled `@tsconfig/node18` **18.2.7** instead of the locked **18.2.6**. 18.2.7 adds one line:

```diff
   "target": "es2022",
+  "types": ["node"],
```

`types: ["node"]` excludes `@types/jest`. `tsconfig.json` extends `expo-module-scripts/tsconfig.plugin` → `@tsconfig/node18`, and has no `include`, so `__tests__` is type-checked — giving 1523 `Cannot find name 'jest' / 'describe' / 'expect'` errors and a failed `Compile TypeScript` step.

18.2.7 was published **2026-08-15**; 3.7.1 shipped Aug 7, before it existed. Nothing in the repo changed. `expo-module-scripts` depends on `^18.2.2`, so only the lockfile was holding it back.

## Why CI didn't catch it

These two lines were the only yarn usage in the repo — all 8 other workflows use `npm ci`. So the deploy job resolved a different dependency graph than anything PR CI validates, and `deploy-npm` only runs when a release is actually cut, never on a PR. `Lint and TypeScript check` runs the same `npm run typescript` on every PR and passed, because `npm ci` gave it 18.2.6.

Switching to `npm ci` removes the divergence rather than testing it: dependency changes can now only enter via a lockfile diff, which PR CI type-checks.

## Test plan

Verified at tag `3.7.2`, two clean installs of the same commit:

| install | `tsc --noEmit` |
|---|---|
| `npm ci` | **0 errors** |
| `yarn install --frozen-lockfile` | **1523 errors** |

`typescript`, `@types/jest` and `expo-module-scripts` resolved to identical versions in both trees — `@tsconfig/node18` was the only difference.

Also confirmed `npm ci` + `npm pack` at tag `3.7.2` produces a valid 3.7.2 tarball (347 files, matching the live 3.7.1), and that `lint`, `typescript` and the `__tests__/workflows` suite pass.

## Notes

This does not publish 3.7.2 — there is no path to publish an existing tag. That is #394.

Deliberately scoped to the bug. The four `@semantic-release/*` plugins in `extra_plugins` are still unpinned and do auto-adopt majors (changelog v7 and git v11 both shipped 2026-07-21), but that is unrelated to this failure and belongs in its own change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk CI-only change that makes the release pipeline consistent with existing PR workflows and prevents unvalidated dependency drift during deploys.
> 
> **Overview**
> Fixes the npm deploy job so it installs dependencies with `npm ci` instead of `yarn install --frozen-lockfile`, and runs the TypeScript compile via `npm run typescript` instead of `yarn typescript`.
> 
> The previous yarn-based install ignored `package-lock.json` and re-resolved ranges, which pulled a newer `@tsconfig/node18` patch on release day and broke the `Compile TypeScript` step. Switching to `npm ci` aligns the deploy job with the rest of CI so releases use the same locked dependency tree that PR checks validate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aff54dbd1a6779e889834e5a037f85a616865694. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->