### PR TITLE
ci: add a manual publish path for an already-tagged version

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -7,10 +7,19 @@ name: Deploy SDK
 #      accidentally adds a `workflow_dispatch` trigger to the release matrix —
 #      a manually-dispatched run would not satisfy `event == 'push'`), AND
 #   3. The push targeted `main` (the only branch in `.releaserc.json`).
+#
+# `workflow_dispatch` here is publish-only: it publishes an existing tag, never tags or
+# re-releases, and reaches only `publish-npm-manual` — the gates above still hold.
 on:
   workflow_run:
     workflows: ["Validate Plugin Compatibility Release"]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing git tag to publish to npm (e.g. 3.7.2)'
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -245,6 +254,44 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+  # Same file and `release` environment as deploy-npm, so npm OIDC still applies. The
+  # automated jobs gate on workflow_run.*, which is null here, so they skip on a dispatch.
+  publish-npm-manual:
+    name: Publish existing tag to npm (manual recovery)
+    if: github.event_name == 'workflow_dispatch'
+    environment: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install npm 11.5.1+ for OIDC support
+        run: npm install -g npm@11
+
+      - name: Install dependencies
+        run: npm ci
+
+      # npm forbids republishing a version, so check the tag before anything is published.
+      - name: Verify package version matches tag
+        env:
+          EXPECTED_TAG: ${{ inputs.tag }}
+        run: |
+          pkg_version="$(node -p "require('./package.json').version")"
+          if [[ "$pkg_version" != "$EXPECTED_TAG" ]]; then
+            echo "::error::package.json version ($pkg_version) does not match requested tag ($EXPECTED_TAG)."
+            exit 1
+          fi
+          echo "package.json version matches tag: $pkg_version"
+
+      - name: Publish to npm
+        run: npm publish
 
   publish-sample-apps-public-builds:
     needs: deploy-npm


### PR DESCRIPTION
Adds a way to publish an already-tagged version to npm. Needed because 3.7.2 is tagged and released on GitHub but absent from npm, and there was no path to finish it.

## The gap

When `deploy-git-tag` succeeds and `deploy-npm` fails, the tag, GitHub release and `chore: prepare for X` commit all exist while npm does not have the version. Nothing can complete that release:

- `deploy-npm` only runs off a `workflow_run` with `new_release_published == 'true'`, and semantic-release will not re-release an existing tag.
- Re-running the failed run reuses that run's workflow file, so it repeats the original failure.
- A `ci:` fix does not cut a new version, so nothing republishes on its own.

The only remaining options were publishing from a laptop or burning a version number to roll forward. This adds the missing third option.

## What it does

A `workflow_dispatch` job taking one input — an existing git tag — that runs **only** the publish half: checkout the tag, `npm ci`, verify, `npm publish`.

It never tags, bumps, or writes a changelog; semantic-release owns all of that.

## Safety

- **Same workflow file and `release` environment as `deploy-npm`**, so npm OIDC trusted publishing still applies — no long-lived token, no local credentials, and the environment's protection rules still gate it.
- **The automated jobs cannot fire on a dispatch.** `deploy-git-tag` and `deploy-npm` both gate on `github.event.workflow_run.*`, which is null for `workflow_dispatch`, so they skip; `publish-sample-apps-public-builds` needs `deploy-npm` and skips with it.
- **A version guard.** The tag is the only thing typed by hand, so the job refuses to publish when `package.json` disagrees with it. npm forbids republishing a version, so a wrong publish is not reversible. The tag is passed via `env:`, not interpolated into the shell.

## Test plan

Guard logic exercised directly:

| tag input | package.json | result |
|---|---|---|
| `3.7.2` | `3.7.2` | passes |
| `3.7.3` | `3.7.2` | blocked |
| empty | `3.7.2` | blocked |

Workflow YAML parses; the dispatch input and the four job gates resolve as intended. Confirmed `npm ci` + `npm pack` at tag `3.7.2` yields a valid 3.7.2 tarball (347 files, matching live 3.7.1).

Not verified end-to-end: the actual `npm publish` and its OIDC handshake can only run in CI. The OIDC subject covers repo, workflow file and environment — all unchanged here — so a dispatch should satisfy the same trusted-publisher config, but worth watching on first use.

## Ordering

Independent of #393 but merge that one first — this branch does not include the `yarn` → `npm ci` fix, so on its own the automated `deploy-npm` job stays broken. They touch different regions of the file and cherry-pick cleanly in either order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches npm publishing infrastructure, but the change is an isolated recovery path with safeguards: it uses the same OIDC-gated `release` environment, does not tag or bump versions, and verifies the package version matches the input tag before publishing.
> 
> **Overview**
> Adds a manual recovery path to `deploy-sdk.yml` for publishing an already-tagged version to npm. A new `workflow_dispatch` trigger accepts an existing git tag and runs only the `publish-npm-manual` job, which checks out the tag, installs dependencies, verifies `package.json` matches the tag, and runs `npm publish`.
> 
> The existing automated jobs remain gated on `workflow_run` conditions, so they skip during a manual dispatch. The manual job uses the same `release` environment as `deploy-npm`, preserving OIDC trusted-publishing protections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5f87b71a03d1b4e346fe7eeb826c64302824736. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->