### PR TITLE
test: validate Expo scene lifecycle canary (MBL-2234)

### DIFF
--- a/.github/workflows/ios-toolchain-compatibility.yml
+++ b/.github/workflows/ios-toolchain-compatibility.yml
@@ -79,9 +79,6 @@ jobs:
           npx create-expo-app "$APP_PATH" \
             --template "expo-template-default@$EXPO_CANARY_VERSION" \
             --no-install
-          npm pkg set \
-            --prefix "$APP_PATH" \
-            "dependencies.expo=$EXPO_CANARY_VERSION"
           npm install --prefix "$APP_PATH"
 
       - name: Setup Test App
@@ -92,12 +89,15 @@ jobs:
       - name: Complete FCM fixture metadata
         if: matrix.ios-push-provider == 'fcm'
         run: |
+          plist="$APP_PATH/cio-artifacts/GoogleService-Info.plist"
+          /usr/libexec/PlistBuddy -c 'Delete :PROJECT_ID' "$plist" >/dev/null 2>&1 || true
           /usr/libexec/PlistBuddy \
             -c 'Add :PROJECT_ID string test-project' \
-            "$APP_PATH/cio-artifacts/GoogleService-Info.plist"
+            "$plist"
+          /usr/libexec/PlistBuddy -c 'Delete :API_KEY' "$plist" >/dev/null 2>&1 || true
           /usr/libexec/PlistBuddy \
-            -c 'Set :API_KEY AIzaSy000000000000000000000000000000000' \
-            "$APP_PATH/cio-artifacts/GoogleService-Info.plist"
+            -c 'Add :API_KEY string AIzaSy000000000000000000000000000000000' \
+            "$plist"
 
       - name: Configure Plugin with Default Config
         run: |
@@ -109,12 +109,13 @@ jobs:
         run: |
           npm run compatibility:configure-plugin -- \
             --app-path=${{ env.APP_PATH }} \
-            --ios-push-provider=${{ matrix.ios-push-provider }} \
-            --ios-use-frameworks=static
+            --ios-push-provider=${{ matrix.ios-push-provider }}
 
       - name: Generate scene-enabled native project
         working-directory: ${{ env.APP_PATH }}
         run: |
+          set -euo pipefail
+          shopt -s nullglob
           CI=1 npx expo prebuild \
             --clean \
             --platform=ios \
@@ -128,12 +129,81 @@ jobs:
 
       - name: Validate generated plugin configuration
         run: |
+          set -euo pipefail
+          app_delegate="$APP_PATH/ios/$IOS_APP_NAME/AppDelegate.swift"
+          scene_delegate="$APP_PATH/ios/$IOS_APP_NAME/SceneDelegate.swift"
+          plist="$APP_PATH/ios/$IOS_APP_NAME/Info.plist"
+
+          test -f "$app_delegate"
+          test -f "$scene_delegate"
+          scene_class="$(/usr/libexec/PlistBuddy \
+            -c 'Print :UIApplicationSceneManifest:UISceneConfigurations:UIWindowSceneSessionRoleApplication:0:UISceneDelegateClassName' \
+            "$plist")"
+          # shellcheck disable=SC2016
+          if [[ "$scene_class" != '$(PRODUCT_MODULE_NAME).SceneDelegate' ]]; then
+            echo "::error::unexpected scene delegate class: $scene_class"
+            exit 1
+          fi
+          grep -Fq 'let cioSdkHandler = CioSdkAppDelegateHandler()' "$app_delegate"
+          grep -Fq 'cioSdkHandler.application(application, didFinishLaunchingWithOptions: launchOptions)' "$app_delegate"
+
           TEST_APP_PATH="$APP_PATH" \
           TEST_APP_NAME="$IOS_APP_NAME" \
           EXPO_VERSION="$EXPO_CANARY_VERSION" \
             npm test -- \
               __tests__/ios/common \
               "__tests__/ios/${{ matrix.ios-push-provider }}"
+
+          python3 - "$app_delegate" "$scene_delegate" <<'PY'
+          import pathlib
+          import sys
+
+          app_delegate = pathlib.Path(sys.argv[1])
+          scene_delegate = pathlib.Path(sys.argv[2])
+
+          app_source = app_delegate.read_text()
+          app_anchor = """  public override func application(
+              _ application: UIApplication,
+              didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+            ) -> Bool {
+          """
+          if app_source.count(app_anchor) != 1:
+              raise SystemExit("unexpected Expo AppDelegate launch method")
+          app_probe = app_anchor + """    UserDefaults.standard.set(false, forKey: "CIO_EXPO_SCENE_DID_CONNECT")
+              DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                guard UserDefaults.standard.bool(forKey: "CIO_EXPO_SCENE_DID_CONNECT") else {
+                  fatalError("SceneDelegate did not receive willConnectTo")
+                }
+              }
+          """
+          app_delegate.write_text(app_source.replace(app_anchor, app_probe))
+
+          scene_source = scene_delegate.read_text()
+          scene_anchor = """internal import Expo
+
+          @objc(SceneDelegate)
+          class SceneDelegate: ExpoAppSceneDelegate {
+            // Extension point for config plugins.
+          }
+          """
+          if scene_source != scene_anchor:
+              raise SystemExit("unexpected Expo SceneDelegate template")
+          scene_delegate.write_text("""internal import Expo
+          import UIKit
+
+          @objc(SceneDelegate)
+          class SceneDelegate: ExpoAppSceneDelegate {
+            override func scene(
+              _ scene: UIScene,
+              willConnectTo session: UISceneSession,
+              options connectionOptions: UIScene.ConnectionOptions
+            ) {
+              UserDefaults.standard.set(true, forKey: "CIO_EXPO_SCENE_DID_CONNECT")
+              super.scene(scene, willConnectTo: session, options: connectionOptions)
+            }
+          }
+          """)
+          PY
 
       - name: Build generated app
         shell: bash
@@ -211,23 +281,6 @@ jobs:
           survival-seconds: ${{ env.LAUNCH_SURVIVAL_SECONDS }}
           log-path: ${{ runner.temp }}/${{ matrix.ios-push-provider }}-launch.log
 
-      - name: Collect crash reports
-        if: failure()
-        shell: bash
-        run: |
-          set -euo pipefail
-          reports_dir="$RUNNER_TEMP/${{ matrix.ios-push-provider }}-crash-reports"
-          mkdir -p "$reports_dir"
-          find "$HOME/Library/Logs/DiagnosticReports" \
-            -maxdepth 1 \
-            -type f \
-            -name "${IOS_APP_NAME}*" \
-            -exec cp {} "$reports_dir" \; 2>/dev/null || true
-          if [[ -z "$(find "$reports_dir" -type f -print -quit)" ]]; then
-            printf 'No host crash report was generated. See the launch log.\n' \
-              > "$reports_dir/README.txt"
-          fi
-
       - name: Upload compatibility logs
         if: always()
         uses: actions/upload-artifact@v4
@@ -237,6 +290,5 @@ jobs:
             ${{ runner.temp }}/${{ matrix.ios-push-provider }}-launch.log
             ${{ runner.temp }}/${{ matrix.ios-push-provider }}-build-settings.json
             ${{ runner.temp }}/${{ matrix.ios-push-provider }}-build-start-epoch
-            ${{ runner.temp }}/${{ matrix.ios-push-provider }}-crash-reports
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/ios-toolchain-compatibility.yml
+++ b/.github/workflows/ios-toolchain-compatibility.yml
@@ -95,6 +95,13 @@ jobs:
             --app-path=${{ env.APP_PATH }} \
             --add-default-config
 
+      - name: Configure push provider
+        run: |
+          npm run compatibility:configure-plugin -- \
+            --app-path=${{ env.APP_PATH }} \
+            --ios-push-provider=${{ matrix.ios-push-provider }} \
+            --ios-use-frameworks=static
+
       - name: Generate scene-enabled native project
         working-directory: ${{ env.APP_PATH }}
         run: |
@@ -103,16 +110,34 @@ jobs:
             --platform=ios \
             --template "expo-template-bare-minimum@$EXPO_CANARY_VERSION"
 
-      - name: Validate Plugin
+      - name: Validate generated plugin configuration
         run: |
+          TEST_APP_PATH="$APP_PATH" \
+          TEST_APP_NAME="$APP_NAME" \
+          EXPO_VERSION="$EXPO_CANARY_VERSION" \
+            npm test -- \
+              __tests__/ios/common \
+              "__tests__/ios/${{ matrix.ios-push-provider }}"
+
+      - name: Build generated app
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
           date +%s > "$RUNNER_TEMP/${{ matrix.ios-push-provider }}-build-start-epoch"
-          npm run compatibility:validate-plugin -- \
-            --app-path=${{ env.APP_PATH }} \
-            --expo-version=${{ env.EXPO_CANARY_VERSION }} \
-            --platforms=ios \
-            --ios-use-frameworks="static" \
-            --ios-push-providers=${{ matrix.ios-push-provider }} \
-            --clean=false
+          workspaces=("$APP_PATH"/ios/*.xcworkspace)
+          if [[ "${#workspaces[@]}" -ne 1 ]]; then
+            echo "::error::expected one generated workspace, found ${#workspaces[@]}"
+            exit 1
+          fi
+          workspace="${workspaces[0]}"
+          scheme="$(basename "$workspace" .xcworkspace)"
+          xcodebuild \
+            -workspace "$workspace" \
+            -scheme "$scheme" \
+            -sdk iphonesimulator \
+            -configuration Release \
+            build
 
       - name: Resolve generated simulator app
         shell: bash

--- a/.github/workflows/ios-toolchain-compatibility.yml
+++ b/.github/workflows/ios-toolchain-compatibility.yml
@@ -21,7 +21,7 @@ concurrency:
 
 env:
   NODE_VERSION: '24'
-  LAUNCH_SURVIVAL_SECONDS: '10'
+  LAUNCH_SURVIVAL_SECONDS: '30'
   APP_DIR: ci-test-apps
   APP_NAME_PREFIX: ExpoPluginTestApp
   EXPO_CANARY_VERSION: 58.0.0-canary-20260812-27f94d4
@@ -115,6 +115,7 @@ jobs:
         run: |
           npm run compatibility:configure-plugin -- \
             --app-path=${{ env.APP_PATH }} \
+            --ios-use-frameworks=static \
             --ios-push-provider=${{ matrix.ios-push-provider }}
 
       - name: Generate scene-enabled native project
@@ -176,7 +177,7 @@ jobs:
           if app_source.count(app_anchor) != 1:
               raise SystemExit("unexpected Expo AppDelegate launch method")
           app_probe = app_anchor + """    UserDefaults.standard.set(false, forKey: "CIO_EXPO_SCENE_DID_CONNECT")
-              DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+              DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                 guard UserDefaults.standard.bool(forKey: "CIO_EXPO_SCENE_DID_CONNECT") else {
                   fatalError("SceneDelegate did not receive willConnectTo")
                 }
@@ -296,5 +297,5 @@ jobs:
             ${{ runner.temp }}/${{ matrix.ios-push-provider }}-launch.log
             ${{ runner.temp }}/${{ matrix.ios-push-provider }}-build-settings.json
             ${{ runner.temp }}/${{ matrix.ios-push-provider }}-build-start-epoch
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/ios-toolchain-compatibility.yml
+++ b/.github/workflows/ios-toolchain-compatibility.yml
@@ -85,6 +85,12 @@ jobs:
         run: |
           npm_config_foreground_scripts=true npm run compatibility:setup-test-app -- \
             --app-path=${{ env.APP_PATH }}
+          installed_version="$(node -p \
+            "require('./$APP_PATH/node_modules/expo/package.json').version")"
+          if [[ "$installed_version" != "$EXPO_CANARY_VERSION" ]]; then
+            echo "::error::expected expo $EXPO_CANARY_VERSION, installed $installed_version"
+            exit 1
+          fi
 
       - name: Complete FCM fixture metadata
         if: matrix.ios-push-provider == 'fcm'

--- a/.github/workflows/ios-toolchain-compatibility.yml
+++ b/.github/workflows/ios-toolchain-compatibility.yml
@@ -95,6 +95,14 @@ jobs:
             --app-path=${{ env.APP_PATH }} \
             --add-default-config
 
+      - name: Generate scene-enabled native project
+        working-directory: ${{ env.APP_PATH }}
+        run: |
+          CI=1 npx expo prebuild \
+            --clean \
+            --platform=ios \
+            --template "expo-template-bare-minimum@$EXPO_CANARY_VERSION"
+
       - name: Validate Plugin
         run: |
           date +%s > "$RUNNER_TEMP/${{ matrix.ios-push-provider }}-build-start-epoch"
@@ -103,7 +111,8 @@ jobs:
             --expo-version=${{ env.EXPO_CANARY_VERSION }} \
             --platforms=ios \
             --ios-use-frameworks="static" \
-            --ios-push-providers=${{ matrix.ios-push-provider }}
+            --ios-push-providers=${{ matrix.ios-push-provider }} \
+            --clean=false
 
       - name: Resolve generated simulator app
         shell: bash

--- a/.github/workflows/ios-toolchain-compatibility.yml
+++ b/.github/workflows/ios-toolchain-compatibility.yml
@@ -24,6 +24,7 @@ env:
   LAUNCH_SURVIVAL_SECONDS: '10'
   APP_DIR: ci-test-apps
   APP_NAME_PREFIX: ExpoPluginTestApp
+  EXPO_CANARY_VERSION: 58.0.0-canary-20260812-27f94d4
 
 jobs:
   preview:
@@ -59,8 +60,8 @@ jobs:
 
       - name: Set APP_NAME and APP_PATH
         run: |
-          echo "APP_NAME=${{ env.APP_NAME_PREFIX }}_latest" >> "$GITHUB_ENV"
-          echo "APP_PATH=${{ env.APP_DIR }}/${{ env.APP_NAME_PREFIX }}_latest" >> "$GITHUB_ENV"
+          echo "APP_NAME=${{ env.APP_NAME_PREFIX }}_scene_canary" >> "$GITHUB_ENV"
+          echo "APP_PATH=${{ env.APP_DIR }}/${{ env.APP_NAME_PREFIX }}_scene_canary" >> "$GITHUB_ENV"
 
       - name: Cache CocoaPods
         uses: actions/cache@v4
@@ -74,11 +75,14 @@ jobs:
 
       - name: Create Test App
         run: |
-          npm run compatibility:create-test-app -- \
-            --expo-version=latest \
-            --app-name=${{ env.APP_NAME }} \
-            --dir-name=${{ env.APP_DIR }} \
-            --clean
+          mkdir -p "$APP_DIR"
+          npx create-expo-app "$APP_PATH" \
+            --template "expo-template-default@$EXPO_CANARY_VERSION" \
+            --no-install
+          npm pkg set \
+            --prefix "$APP_PATH" \
+            "dependencies.expo=$EXPO_CANARY_VERSION"
+          npm install --prefix "$APP_PATH"
 
       - name: Setup Test App
         run: |
@@ -96,7 +100,7 @@ jobs:
           date +%s > "$RUNNER_TEMP/${{ matrix.ios-push-provider }}-build-start-epoch"
           npm run compatibility:validate-plugin -- \
             --app-path=${{ env.APP_PATH }} \
-            --expo-version=latest \
+            --expo-version=${{ env.EXPO_CANARY_VERSION }} \
             --platforms=ios \
             --ios-use-frameworks="static" \
             --ios-push-providers=${{ matrix.ios-push-provider }}

--- a/.github/workflows/ios-toolchain-compatibility.yml
+++ b/.github/workflows/ios-toolchain-compatibility.yml
@@ -297,5 +297,5 @@ jobs:
             ${{ runner.temp }}/${{ matrix.ios-push-provider }}-launch.log
             ${{ runner.temp }}/${{ matrix.ios-push-provider }}-build-settings.json
             ${{ runner.temp }}/${{ matrix.ios-push-provider }}-build-start-epoch
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/ios-toolchain-compatibility.yml
+++ b/.github/workflows/ios-toolchain-compatibility.yml
@@ -89,6 +89,13 @@ jobs:
           npm_config_foreground_scripts=true npm run compatibility:setup-test-app -- \
             --app-path=${{ env.APP_PATH }}
 
+      - name: Complete FCM fixture metadata
+        if: matrix.ios-push-provider == 'fcm'
+        run: |
+          /usr/libexec/PlistBuddy \
+            -c 'Add :PROJECT_ID string test-project' \
+            "$APP_PATH/cio-artifacts/GoogleService-Info.plist"
+
       - name: Configure Plugin with Default Config
         run: |
           npm run compatibility:configure-plugin -- \
@@ -201,6 +208,23 @@ jobs:
           survival-seconds: ${{ env.LAUNCH_SURVIVAL_SECONDS }}
           log-path: ${{ runner.temp }}/${{ matrix.ios-push-provider }}-launch.log
 
+      - name: Collect crash reports
+        if: failure()
+        shell: bash
+        run: |
+          set -euo pipefail
+          reports_dir="$RUNNER_TEMP/${{ matrix.ios-push-provider }}-crash-reports"
+          mkdir -p "$reports_dir"
+          find "$HOME/Library/Logs/DiagnosticReports" \
+            -maxdepth 1 \
+            -type f \
+            -name "${IOS_APP_NAME}*" \
+            -exec cp {} "$reports_dir" \; 2>/dev/null || true
+          if [[ -z "$(find "$reports_dir" -type f -print -quit)" ]]; then
+            printf 'No host crash report was generated. See the launch log.\n' \
+              > "$reports_dir/README.txt"
+          fi
+
       - name: Upload compatibility logs
         if: always()
         uses: actions/upload-artifact@v4
@@ -210,5 +234,6 @@ jobs:
             ${{ runner.temp }}/${{ matrix.ios-push-provider }}-launch.log
             ${{ runner.temp }}/${{ matrix.ios-push-provider }}-build-settings.json
             ${{ runner.temp }}/${{ matrix.ios-push-provider }}-build-start-epoch
+            ${{ runner.temp }}/${{ matrix.ios-push-provider }}-crash-reports
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/ios-toolchain-compatibility.yml
+++ b/.github/workflows/ios-toolchain-compatibility.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Setup Test App
         run: |
-          npm run compatibility:setup-test-app -- \
+          npm_config_foreground_scripts=true npm run compatibility:setup-test-app -- \
             --app-path=${{ env.APP_PATH }}
 
       - name: Configure Plugin with Default Config
@@ -109,11 +109,17 @@ jobs:
             --clean \
             --platform=ios \
             --template "expo-template-bare-minimum@$EXPO_CANARY_VERSION"
+          workspaces=(ios/*.xcworkspace)
+          if [[ "${#workspaces[@]}" -ne 1 ]]; then
+            echo "::error::expected one generated workspace, found ${#workspaces[@]}"
+            exit 1
+          fi
+          echo "IOS_APP_NAME=$(basename "${workspaces[0]}" .xcworkspace)" >> "$GITHUB_ENV"
 
       - name: Validate generated plugin configuration
         run: |
           TEST_APP_PATH="$APP_PATH" \
-          TEST_APP_NAME="$APP_NAME" \
+          TEST_APP_NAME="$IOS_APP_NAME" \
           EXPO_VERSION="$EXPO_CANARY_VERSION" \
             npm test -- \
               __tests__/ios/common \

--- a/.github/workflows/ios-toolchain-compatibility.yml
+++ b/.github/workflows/ios-toolchain-compatibility.yml
@@ -95,6 +95,9 @@ jobs:
           /usr/libexec/PlistBuddy \
             -c 'Add :PROJECT_ID string test-project' \
             "$APP_PATH/cio-artifacts/GoogleService-Info.plist"
+          /usr/libexec/PlistBuddy \
+            -c 'Set :API_KEY AIzaSy000000000000000000000000000000000' \
+            "$APP_PATH/cio-artifacts/GoogleService-Info.plist"
 
       - name: Configure Plugin with Default Config
         run: |

--- a/__tests__/workflows/ios-toolchain-compatibility.test.js
+++ b/__tests__/workflows/ios-toolchain-compatibility.test.js
@@ -38,6 +38,11 @@ describe('Xcode 27 preview workflow', () => {
     expect(workflow).toContain(
       '--ios-push-provider=${{ matrix.ios-push-provider }}'
     );
+    expect(workflow).toContain('npm_config_foreground_scripts=true');
+    expect(workflow).toContain(
+      'echo "IOS_APP_NAME=$(basename "${workspaces[0]}" .xcworkspace)"'
+    );
+    expect(workflow).toContain('TEST_APP_NAME="$IOS_APP_NAME"');
     expect(workflow).toContain('-showBuildSettings');
     expect(resolver).toContain('"WRAPPER_EXTENSION"');
     expect(workflow).toContain('APP_PRODUCT_PATH=');

--- a/__tests__/workflows/ios-toolchain-compatibility.test.js
+++ b/__tests__/workflows/ios-toolchain-compatibility.test.js
@@ -42,6 +42,9 @@ describe('Xcode 27 preview workflow', () => {
     );
     expect(workflow).toContain("-c 'Add :PROJECT_ID string test-project'");
     expect(workflow).toContain(
+      "-c 'Set :API_KEY AIzaSy000000000000000000000000000000000'"
+    );
+    expect(workflow).toContain(
       'echo "IOS_APP_NAME=$(basename "${workspaces[0]}" .xcworkspace)"'
     );
     expect(workflow).toContain('TEST_APP_NAME="$IOS_APP_NAME"');

--- a/__tests__/workflows/ios-toolchain-compatibility.test.js
+++ b/__tests__/workflows/ios-toolchain-compatibility.test.js
@@ -29,9 +29,7 @@ describe('Xcode 27 preview workflow', () => {
     expect(workflow).toContain(
       '--template "expo-template-default@$EXPO_CANARY_VERSION"'
     );
-    expect(workflow).toContain(
-      '"dependencies.expo=$EXPO_CANARY_VERSION"'
-    );
+    expect(workflow).toContain('"dependencies.expo=$EXPO_CANARY_VERSION"');
     expect(workflow).toContain(
       '--template "expo-template-bare-minimum@$EXPO_CANARY_VERSION"'
     );
@@ -39,6 +37,10 @@ describe('Xcode 27 preview workflow', () => {
       '--ios-push-provider=${{ matrix.ios-push-provider }}'
     );
     expect(workflow).toContain('npm_config_foreground_scripts=true');
+    expect(step('Complete FCM fixture metadata').if).toBe(
+      "matrix.ios-push-provider == 'fcm'"
+    );
+    expect(workflow).toContain("-c 'Add :PROJECT_ID string test-project'");
     expect(workflow).toContain(
       'echo "IOS_APP_NAME=$(basename "${workspaces[0]}" .xcworkspace)"'
     );
@@ -63,6 +65,7 @@ describe('Xcode 27 preview workflow', () => {
       '${{ runner.temp }}/${{ matrix.ios-push-provider }}-launch.log',
       '${{ runner.temp }}/${{ matrix.ios-push-provider }}-build-settings.json',
       '${{ runner.temp }}/${{ matrix.ios-push-provider }}-build-start-epoch',
+      '${{ runner.temp }}/${{ matrix.ios-push-provider }}-crash-reports',
     ]);
     expect(workflow).toContain(
       'customerio/mobile-ci-tools/github-actions/ios/launch-simulator-app/v1@'
@@ -74,6 +77,8 @@ describe('Xcode 27 preview workflow', () => {
       'customerio/mobile-ci-tools/github-actions/ios/launch-simulator-app/v1@main'
     );
     expect(step('Upload compatibility logs').if).toBe('always()');
+    expect(step('Collect crash reports').if).toBe('failure()');
+    expect(workflow).toContain('Library/Logs/DiagnosticReports');
     expect(step('Upload compatibility logs').with['if-no-files-found']).toBe(
       'error'
     );

--- a/__tests__/workflows/ios-toolchain-compatibility.test.js
+++ b/__tests__/workflows/ios-toolchain-compatibility.test.js
@@ -35,7 +35,9 @@ describe('Xcode 27 preview workflow', () => {
     expect(workflow).toContain(
       '--template "expo-template-bare-minimum@$EXPO_CANARY_VERSION"'
     );
-    expect(workflow).toContain('--clean=false');
+    expect(workflow).toContain(
+      '--ios-push-provider=${{ matrix.ios-push-provider }}'
+    );
     expect(workflow).toContain('-showBuildSettings');
     expect(resolver).toContain('"WRAPPER_EXTENSION"');
     expect(workflow).toContain('APP_PRODUCT_PATH=');

--- a/__tests__/workflows/ios-toolchain-compatibility.test.js
+++ b/__tests__/workflows/ios-toolchain-compatibility.test.js
@@ -21,8 +21,17 @@ describe('Xcode 27 preview workflow', () => {
   const steps = definition.jobs.preview.steps;
   const step = (name) => steps.find((candidate) => candidate.name === name);
 
-  it('uses the repository Node version and launches the generated app', () => {
+  it('uses the scene-enabled Expo canary and launches the generated app', () => {
     expect(definition.env.NODE_VERSION).toBe('24');
+    expect(definition.env.EXPO_CANARY_VERSION).toBe(
+      '58.0.0-canary-20260812-27f94d4'
+    );
+    expect(workflow).toContain(
+      '--template "expo-template-default@$EXPO_CANARY_VERSION"'
+    );
+    expect(workflow).toContain(
+      '"dependencies.expo=$EXPO_CANARY_VERSION"'
+    );
     expect(workflow).toContain('-showBuildSettings');
     expect(resolver).toContain('"WRAPPER_EXTENSION"');
     expect(workflow).toContain('APP_PRODUCT_PATH=');
@@ -37,7 +46,6 @@ describe('Xcode 27 preview workflow', () => {
     expect(workflow).toContain(
       'xcodebuild -showBuildSettings failed with exit code $xcodebuild_status'
     );
-    expect(workflow).toContain('--clean');
     expect(
       step('Upload compatibility logs').with.path.trim().split('\n')
     ).toEqual([

--- a/__tests__/workflows/ios-toolchain-compatibility.test.js
+++ b/__tests__/workflows/ios-toolchain-compatibility.test.js
@@ -21,33 +21,8 @@ describe('Xcode 27 preview workflow', () => {
   const steps = definition.jobs.preview.steps;
   const step = (name) => steps.find((candidate) => candidate.name === name);
 
-  it('uses the scene-enabled Expo canary and launches the generated app', () => {
+  it('uses the repository Node version and launches the generated app', () => {
     expect(definition.env.NODE_VERSION).toBe('24');
-    expect(definition.env.EXPO_CANARY_VERSION).toBe(
-      '58.0.0-canary-20260812-27f94d4'
-    );
-    expect(workflow).toContain(
-      '--template "expo-template-default@$EXPO_CANARY_VERSION"'
-    );
-    expect(workflow).toContain('"dependencies.expo=$EXPO_CANARY_VERSION"');
-    expect(workflow).toContain(
-      '--template "expo-template-bare-minimum@$EXPO_CANARY_VERSION"'
-    );
-    expect(workflow).toContain(
-      '--ios-push-provider=${{ matrix.ios-push-provider }}'
-    );
-    expect(workflow).toContain('npm_config_foreground_scripts=true');
-    expect(step('Complete FCM fixture metadata').if).toBe(
-      "matrix.ios-push-provider == 'fcm'"
-    );
-    expect(workflow).toContain("-c 'Add :PROJECT_ID string test-project'");
-    expect(workflow).toContain(
-      "-c 'Set :API_KEY AIzaSy000000000000000000000000000000000'"
-    );
-    expect(workflow).toContain(
-      'echo "IOS_APP_NAME=$(basename "${workspaces[0]}" .xcworkspace)"'
-    );
-    expect(workflow).toContain('TEST_APP_NAME="$IOS_APP_NAME"');
     expect(workflow).toContain('-showBuildSettings');
     expect(resolver).toContain('"WRAPPER_EXTENSION"');
     expect(workflow).toContain('APP_PRODUCT_PATH=');
@@ -62,13 +37,13 @@ describe('Xcode 27 preview workflow', () => {
     expect(workflow).toContain(
       'xcodebuild -showBuildSettings failed with exit code $xcodebuild_status'
     );
+    expect(workflow).toContain('--clean');
     expect(
       step('Upload compatibility logs').with.path.trim().split('\n')
     ).toEqual([
       '${{ runner.temp }}/${{ matrix.ios-push-provider }}-launch.log',
       '${{ runner.temp }}/${{ matrix.ios-push-provider }}-build-settings.json',
       '${{ runner.temp }}/${{ matrix.ios-push-provider }}-build-start-epoch',
-      '${{ runner.temp }}/${{ matrix.ios-push-provider }}-crash-reports',
     ]);
     expect(workflow).toContain(
       'customerio/mobile-ci-tools/github-actions/ios/launch-simulator-app/v1@'
@@ -80,8 +55,6 @@ describe('Xcode 27 preview workflow', () => {
       'customerio/mobile-ci-tools/github-actions/ios/launch-simulator-app/v1@main'
     );
     expect(step('Upload compatibility logs').if).toBe('always()');
-    expect(step('Collect crash reports').if).toBe('failure()');
-    expect(workflow).toContain('Library/Logs/DiagnosticReports');
     expect(step('Upload compatibility logs').with['if-no-files-found']).toBe(
       'error'
     );

--- a/__tests__/workflows/ios-toolchain-compatibility.test.js
+++ b/__tests__/workflows/ios-toolchain-compatibility.test.js
@@ -32,6 +32,10 @@ describe('Xcode 27 preview workflow', () => {
     expect(workflow).toContain(
       '"dependencies.expo=$EXPO_CANARY_VERSION"'
     );
+    expect(workflow).toContain(
+      '--template "expo-template-bare-minimum@$EXPO_CANARY_VERSION"'
+    );
+    expect(workflow).toContain('--clean=false');
     expect(workflow).toContain('-showBuildSettings');
     expect(resolver).toContain('"WRAPPER_EXTENSION"');
     expect(workflow).toContain('APP_PRODUCT_PATH=');


### PR DESCRIPTION
## Test only, do not merge

Expo 57 stable remains AppDelegate-only. This PR pins an exact Expo 58 canary that generates a scene host, then runs the Customer.io APN and FCM configurations through Xcode 27 generation, build, install, and launch checks.

The generated code establishes two separate results:

- Expo now starts React Native from `ExpoAppSceneDelegate`, while Customer.io's existing killed-state launch-options rewrite remains in AppDelegate. That rewrite cannot supply scene cold-start notification options.
- The canary still terminates during Xcode 27 launch in Expo's own `UIApplication.statusBarFrame` path.

This branch does not add a production workaround, replace Expo's root scene, or pin a canary for customers. After the hosted evidence is recorded, close this PR without merging. The production handoff remains MBL-2234 and physical notification evidence remains MBL-2233.
