### PR TITLE
ci: use valid Firebase compatibility fixture key (MBL-2234)

### DIFF
--- a/scripts/compatibility/setup-test-app.js
+++ b/scripts/compatibility/setup-test-app.js
@@ -135,7 +135,7 @@ function execute() {
       <key>GCM_SENDER_ID</key>
       <string>1234567890</string>
       <key>API_KEY</key>
-      <string>test-api-key</string>
+      <string>AIzaSy000000000000000000000000000000000</string>
       <key>CLIENT_ID</key>
       <string>1234567890-abcdefg.apps.googleusercontent.com</string>
     </dict>


### PR DESCRIPTION
## Summary

Use a valid-format dummy iOS Firebase API key in generated compatibility apps. This moves the one-off correction from test-only #395 into the shared fixture so nightly FCM validation reaches the real Expo launch result.

## Validation

- `node --check scripts/compatibility/setup-test-app.js`
- validated the generated key format
- `npm run typescript`
- workflow behavior tests passed
- 461 repository tests passed; 14 fixture-dependent tests require the generated `test-app` and fail when run directly without it

This is CI-only and does not change the published plugin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only test fixture change with no production or security impact; the key remains a dummy value, just in a valid format.
> 
> **Overview**
> Updates the dummy iOS Firebase API key in the generated compatibility test fixture from `test-api-key` to a valid-format `AIzaSy...` placeholder. This consolidates a one-off test correction into the shared setup script so nightly FCM validation exercises the real Expo launch path. CI-only; does not affect the published plugin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10010448c30385a4700199fff0cafaf1043b5b94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->