### PR TITLE
ci: add fast and full PR validation lanes

### DIFF
--- a/.github/scripts/validate-release-policy.sh
+++ b/.github/scripts/validate-release-policy.sh
@@ -55,9 +55,15 @@ while IFS= read -r -d '' commit_message; do
   fi
 done < "$commit_messages_file"
 
+full_validation=false
+requires_full_label=false
+
+if [[ "$pr_release" == 'true' || "$commit_release" == 'true' || "${CI_FULL:-false}" == 'true' ]]; then
+  full_validation=true
+fi
+
 if [[ "$commit_release" == 'true' && "$pr_release" != 'true' && "${CI_FULL:-false}" != 'true' ]]; then
-  echo "::error::This PR contains a release-bearing commit, but its PR title/body is non-release. Retitle it with fix:, feat:, perf:, revert:, or a breaking-change marker, or apply ci:full, so release validation runs before merge."
-  exit 1
+  requires_full_label=true
 fi
 
 if [[ ("$pr_release" == 'true' || "$commit_release" == 'true') && ("$HEAD_REPOSITORY" != "$TARGET_REPOSITORY" || "$PR_AUTHOR" == 'dependabot[bot]') ]]; then
@@ -65,4 +71,17 @@ if [[ ("$pr_release" == 'true' || "$commit_release" == 'true') && ("$HEAD_REPOSI
   exit 1
 fi
 
-echo "Release validation policy satisfied (pr_release=$pr_release, commit_release=$commit_release)."
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "pr_release=$pr_release"
+    echo "commit_release=$commit_release"
+    echo "full_validation=$full_validation"
+    echo "requires_full_label=$requires_full_label"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+if [[ "$requires_full_label" == 'true' ]]; then
+  echo "::notice::A release-bearing commit was detected behind a non-release PR title. The semantic PR helper will apply ci:full automatically."
+fi
+
+echo "Release validation policy satisfied (pr_release=$pr_release, commit_release=$commit_release, full_validation=$full_validation)."

--- a/.github/scripts/validate-release-policy.sh
+++ b/.github/scripts/validate-release-policy.sh
@@ -66,7 +66,9 @@ if [[ "$commit_release" == 'true' && "$pr_release" != 'true' && "${CI_FULL:-fals
   requires_full_label=true
 fi
 
-if [[ ("$pr_release" == 'true' || "$commit_release" == 'true') && ("$HEAD_REPOSITORY" != "$TARGET_REPOSITORY" || "$PR_AUTHOR" == 'dependabot[bot]') ]]; then
+if [[ "${ENFORCE_TRUSTED_RELEASE:-true}" == 'true' &&
+  ("$pr_release" == 'true' || "$commit_release" == 'true') &&
+  ("$HEAD_REPOSITORY" != "$TARGET_REPOSITORY" || "$PR_AUTHOR" == 'dependabot[bot]') ]]; then
   echo "::error::Release-bearing PRs require secret-dependent validation from a trusted repository branch. Recreate or update this change on an internal branch before merge."
   exit 1
 fi

--- a/.github/scripts/validate-release-policy.sh
+++ b/.github/scripts/validate-release-policy.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${PR_TITLE:?PR_TITLE is required}"
+: "${BASE_SHA:?BASE_SHA is required}"
+: "${HEAD_SHA:?HEAD_SHA is required}"
+: "${HEAD_REPOSITORY:?HEAD_REPOSITORY is required}"
+: "${TARGET_REPOSITORY:?TARGET_REPOSITORY is required}"
+: "${PR_AUTHOR:?PR_AUTHOR is required}"
+
+is_release_message() {
+  local message="$1"
+  local header
+  header=$(sed -n '/[^[:space:]]/{p;q;}' <<< "$message")
+
+  case "$header" in
+    fix:*|fix\(*|feat:*|feat\(*|perf:*|perf\(*|revert:*|revert\(*|Revert\ \"*)
+      return 0
+      ;;
+  esac
+
+  if grep -Eq '^[[:alpha:]]+(\([^)]*\))?!:' <<< "$header"; then
+    return 0
+  fi
+
+  if grep -Eq '(^|[[:space:]])(BREAKING CHANGES?:|BREAKING-CHANGE:)' <<< "$message"; then
+    return 0
+  fi
+
+  if grep -Eq '(^|[[:space:]])This reverts commit[[:space:]]' <<< "$message"; then
+    return 0
+  fi
+
+  return 1
+}
+
+pr_message="$PR_TITLE"$'\n\n'"${PR_BODY:-}"
+pr_release=false
+commit_release=false
+
+if is_release_message "$pr_message"; then
+  pr_release=true
+fi
+
+git cat-file -e "$BASE_SHA^{commit}"
+git cat-file -e "$HEAD_SHA^{commit}"
+commit_messages_file=$(mktemp)
+trap 'rm -f "$commit_messages_file"' EXIT
+git log --format='%B%x00' "$BASE_SHA..$HEAD_SHA" > "$commit_messages_file"
+
+while IFS= read -r -d '' commit_message; do
+  if is_release_message "$commit_message"; then
+    commit_release=true
+    break
+  fi
+done < "$commit_messages_file"
+
+if [[ "$commit_release" == 'true' && "$pr_release" != 'true' && "${CI_FULL:-false}" != 'true' ]]; then
+  echo "::error::This PR contains a release-bearing commit, but its PR title/body is non-release. Retitle it with fix:, feat:, perf:, revert:, or a breaking-change marker, or apply ci:full, so release validation runs before merge."
+  exit 1
+fi
+
+if [[ ("$pr_release" == 'true' || "$commit_release" == 'true') && ("$HEAD_REPOSITORY" != "$TARGET_REPOSITORY" || "$PR_AUTHOR" == 'dependabot[bot]') ]]; then
+  echo "::error::Release-bearing PRs require secret-dependent validation from a trusted repository branch. Recreate or update this change on an internal branch before merge."
+  exit 1
+fi
+
+echo "Release validation policy satisfied (pr_release=$pr_release, commit_release=$commit_release)."

--- a/.github/scripts/validate-release-policy.sh
+++ b/.github/scripts/validate-release-policy.sh
@@ -4,10 +4,6 @@ set -euo pipefail
 : "${PR_TITLE:?PR_TITLE is required}"
 : "${BASE_SHA:?BASE_SHA is required}"
 : "${HEAD_SHA:?HEAD_SHA is required}"
-: "${HEAD_REPOSITORY:?HEAD_REPOSITORY is required}"
-: "${TARGET_REPOSITORY:?TARGET_REPOSITORY is required}"
-: "${PR_AUTHOR:?PR_AUTHOR is required}"
-
 is_release_message() {
   local message="$1"
   local header
@@ -34,11 +30,10 @@ is_release_message() {
   return 1
 }
 
-pr_message="$PR_TITLE"$'\n\n'"${PR_BODY:-}"
 pr_release=false
 commit_release=false
 
-if is_release_message "$pr_message"; then
+if is_release_message "$PR_TITLE"; then
   pr_release=true
 fi
 
@@ -56,21 +51,9 @@ while IFS= read -r -d '' commit_message; do
 done < "$commit_messages_file"
 
 full_validation=false
-requires_full_label=false
 
 if [[ "$pr_release" == 'true' || "$commit_release" == 'true' || "${CI_FULL:-false}" == 'true' ]]; then
   full_validation=true
-fi
-
-if [[ "$commit_release" == 'true' && "$pr_release" != 'true' && "${CI_FULL:-false}" != 'true' ]]; then
-  requires_full_label=true
-fi
-
-if [[ "${ENFORCE_TRUSTED_RELEASE:-true}" == 'true' &&
-  ("$pr_release" == 'true' || "$commit_release" == 'true') &&
-  ("$HEAD_REPOSITORY" != "$TARGET_REPOSITORY" || "$PR_AUTHOR" == 'dependabot[bot]') ]]; then
-  echo "::error::Release-bearing PRs require secret-dependent validation from a trusted repository branch. Recreate or update this change on an internal branch before merge."
-  exit 1
 fi
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
@@ -78,12 +61,7 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     echo "pr_release=$pr_release"
     echo "commit_release=$commit_release"
     echo "full_validation=$full_validation"
-    echo "requires_full_label=$requires_full_label"
   } >> "$GITHUB_OUTPUT"
 fi
 
-if [[ "$requires_full_label" == 'true' ]]; then
-  echo "::notice::A release-bearing commit was detected behind a non-release PR title. The semantic PR helper will apply ci:full automatically."
-fi
-
-echo "Release validation policy satisfied (pr_release=$pr_release, commit_release=$commit_release, full_validation=$full_validation)."
+echo "Distribution policy classified (pr_release=$pr_release, commit_release=$commit_release, full_validation=$full_validation)."

--- a/.github/workflows/build-sample-apps-full.yml
+++ b/.github/workflows/build-sample-apps-full.yml
@@ -5,7 +5,17 @@ on:
     types: [opened, synchronize, reopened, edited, labeled]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Unrelated labels and body-only edits must not cancel an in-flight release or
+  # ci:full run. They share a separate group from meaningful validation events.
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}-${{
+      github.event_name == 'pull_request' &&
+      ((github.event.action == 'labeled' && github.event.label.name != 'ci:full') ||
+      (github.event.action == 'edited' &&
+      github.event.changes.title.from == '' &&
+      github.event.changes.base.ref.from == '')) &&
+      'metadata' || 'validation'
+    }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-sample-apps-full.yml
+++ b/.github/workflows/build-sample-apps-full.yml
@@ -12,8 +12,8 @@ concurrency:
       github.event_name == 'pull_request' &&
       ((github.event.action == 'labeled' && github.event.label.name != 'ci:full') ||
       (github.event.action == 'edited' &&
-      github.event.changes.title.from == '' &&
-      github.event.changes.base.ref.from == '')) &&
+      !github.event.changes.title &&
+      !github.event.changes.base)) &&
       'metadata' || 'validation'
     }}
   cancel-in-progress: true

--- a/.github/workflows/build-sample-apps-full.yml
+++ b/.github/workflows/build-sample-apps-full.yml
@@ -15,22 +15,19 @@ jobs:
       contents: read
     with:
       pr_title: ${{ github.event.pull_request.title }}
-      pr_body: ${{ github.event.pull_request.body || '' }}
       base_sha: ${{ github.event.pull_request.base.sha }}
       head_sha: ${{ github.event.pull_request.head.sha }}
-      head_repository: ${{ github.event.pull_request.head.repo.full_name }}
-      target_repository: ${{ github.repository }}
-      pr_author: ${{ github.event.pull_request.user.login }}
       ci_full: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
 
-  # Metadata edits rerun full so a newer skipped check cannot replace a failure.
+  # Unsigned compatibility builds own correctness. Release intent or a manual
+  # ci:full label only controls this signed distribution workflow.
   full-sample-apps:
     needs: release_policy
     if: >-
       always() &&
-      (github.event.action == 'edited' ||
-      github.event.action == 'labeled' ||
-      needs.release_policy.outputs.full_validation == 'true') &&
+      needs.release_policy.outputs.full_validation == 'true' &&
+      (github.event.action != 'edited' || github.event.changes.title.from != '') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'ci:full') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.login != 'dependabot[bot]'
     uses: ./.github/workflows/reusable_build_sample_apps.yml

--- a/.github/workflows/build-sample-apps-full.yml
+++ b/.github/workflows/build-sample-apps-full.yml
@@ -2,18 +2,35 @@ name: Full sample app builds
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, edited, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Metadata edits rerun full so a newer skipped check cannot replace a failure.
   full-sample-apps:
     if: >-
-      ((github.event.action == 'labeled' && github.event.label.name == 'ci:full') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ci:full'))) &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      (github.event.action == 'edited' ||
+      github.event.action == 'labeled' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      startsWith(github.event.pull_request.title, 'fix:') ||
+      startsWith(github.event.pull_request.title, 'fix(') ||
+      startsWith(github.event.pull_request.title, 'feat:') ||
+      startsWith(github.event.pull_request.title, 'feat(') ||
+      startsWith(github.event.pull_request.title, 'perf:') ||
+      startsWith(github.event.pull_request.title, 'perf(') ||
+      startsWith(github.event.pull_request.title, 'revert:') ||
+      startsWith(github.event.pull_request.title, 'revert(') ||
+      startsWith(github.event.pull_request.title, 'Revert "') ||
+      contains(github.event.pull_request.body, 'This reverts commit') ||
+      contains(github.event.pull_request.title, '!:') ||
+      contains(github.event.pull_request.body, 'BREAKING CHANGE:') ||
+      contains(github.event.pull_request.body, 'BREAKING CHANGES:') ||
+      contains(github.event.pull_request.body, 'BREAKING-CHANGE:')) &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     uses: ./.github/workflows/reusable_build_sample_apps.yml
     with:
       use_latest_sdk_version: false

--- a/.github/workflows/build-sample-apps-full.yml
+++ b/.github/workflows/build-sample-apps-full.yml
@@ -9,26 +9,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  release_policy:
+    uses: ./.github/workflows/reusable-release-policy.yml
+    permissions:
+      contents: read
+    with:
+      pr_title: ${{ github.event.pull_request.title }}
+      pr_body: ${{ github.event.pull_request.body || '' }}
+      base_sha: ${{ github.event.pull_request.base.sha }}
+      head_sha: ${{ github.event.pull_request.head.sha }}
+      head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+      target_repository: ${{ github.repository }}
+      pr_author: ${{ github.event.pull_request.user.login }}
+      ci_full: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
+
   # Metadata edits rerun full so a newer skipped check cannot replace a failure.
   full-sample-apps:
+    needs: release_policy
     if: >-
+      always() &&
       (github.event.action == 'edited' ||
       github.event.action == 'labeled' ||
-      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
-      startsWith(github.event.pull_request.title, 'fix:') ||
-      startsWith(github.event.pull_request.title, 'fix(') ||
-      startsWith(github.event.pull_request.title, 'feat:') ||
-      startsWith(github.event.pull_request.title, 'feat(') ||
-      startsWith(github.event.pull_request.title, 'perf:') ||
-      startsWith(github.event.pull_request.title, 'perf(') ||
-      startsWith(github.event.pull_request.title, 'revert:') ||
-      startsWith(github.event.pull_request.title, 'revert(') ||
-      startsWith(github.event.pull_request.title, 'Revert "') ||
-      contains(github.event.pull_request.body, 'This reverts commit') ||
-      contains(github.event.pull_request.title, '!:') ||
-      contains(github.event.pull_request.body, 'BREAKING CHANGE:') ||
-      contains(github.event.pull_request.body, 'BREAKING CHANGES:') ||
-      contains(github.event.pull_request.body, 'BREAKING-CHANGE:')) &&
+      needs.release_policy.outputs.full_validation == 'true') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.login != 'dependabot[bot]'
     uses: ./.github/workflows/reusable_build_sample_apps.yml

--- a/.github/workflows/build-sample-apps-full.yml
+++ b/.github/workflows/build-sample-apps-full.yml
@@ -1,0 +1,20 @@
+name: Full sample app builds
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  full-sample-apps:
+    if: >-
+      ((github.event.action == 'labeled' && github.event.label.name == 'ci:full') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ci:full'))) &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/reusable_build_sample_apps.yml
+    with:
+      use_latest_sdk_version: false
+    secrets: inherit

--- a/.github/workflows/build-sample-apps-full.yml
+++ b/.github/workflows/build-sample-apps-full.yml
@@ -12,8 +12,8 @@ concurrency:
       github.event_name == 'pull_request' &&
       ((github.event.action == 'labeled' && github.event.label.name != 'ci:full') ||
       (github.event.action == 'edited' &&
-      !github.event.changes.title &&
-      !github.event.changes.base)) &&
+      github.event.changes.title == null &&
+      github.event.changes.base == null)) &&
       'metadata' || 'validation'
     }}
   cancel-in-progress: true
@@ -36,7 +36,9 @@ jobs:
     if: >-
       always() &&
       needs.release_policy.outputs.full_validation == 'true' &&
-      (github.event.action != 'edited' || github.event.changes.title.from != '') &&
+      (github.event.action != 'edited' ||
+      github.event.changes.title != null ||
+      github.event.changes.base != null) &&
       (github.event.action != 'labeled' || github.event.label.name == 'ci:full') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.login != 'dependabot[bot]'

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -2,15 +2,24 @@ name: Publish test apps
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    paths-ignore:
+      - '**/*.md'
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.event.action == 'labeled' && github.event.label.name != 'ci:full') && github.run_id || 'validation' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-sample-apps:
+    if: >-
+      (github.event.action != 'labeled' || github.event.label.name == 'ci:full') &&
+      (github.event_name != 'pull_request' ||
+      (contains(github.event.pull_request.labels.*.name, 'ci:full') &&
+      github.event.pull_request.head.repo.full_name == github.repository))
     uses: ./.github/workflows/reusable_build_sample_apps.yml
     with:
       use_latest_sdk_version: false

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -1,25 +1,16 @@
 name: Publish test apps
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
-    paths-ignore:
-      - '**/*.md'
   push:
     branches: [main]
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.event.action == 'labeled' && github.event.label.name != 'ci:full') && github.run_id || 'validation' }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-sample-apps:
-    if: >-
-      (github.event.action != 'labeled' || github.event.label.name == 'ci:full') &&
-      (github.event_name != 'pull_request' ||
-      (contains(github.event.pull_request.labels.*.name, 'ci:full') &&
-      github.event.pull_request.head.repo.full_name == github.repository))
     uses: ./.github/workflows/reusable_build_sample_apps.yml
     with:
       use_latest_sdk_version: false

--- a/.github/workflows/check-api-changes.yml
+++ b/.github/workflows/check-api-changes.yml
@@ -2,6 +2,8 @@ name: Check API Changes
 
 on:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
   push:
     branches: [main]
 
@@ -36,4 +38,4 @@ jobs:
           echo ""
           npx api-extractor run --verbose
           echo ""
-          echo "✅ No API changes detected - API report is up to date!" 
+          echo "✅ No API changes detected - API report is up to date!"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main]
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint-and-typecheck:

--- a/.github/workflows/pr-helper.yml
+++ b/.github/workflows/pr-helper.yml
@@ -2,7 +2,7 @@ name: Semantic PR helper
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize, labeled, unlabeled]
+    types: [opened, reopened, edited, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,35 +12,6 @@ jobs:
   lint-pr-title:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      issues: write
       pull-requests: write # to comment on PRs
     steps:
     - uses: levibostian/action-conventional-pr-linter@acd7e6035a4c70ae2e6aab469c791cc5ca2a989d # v4.0.1
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Verify release validation policy
-      id: release-policy
-      env:
-        PR_TITLE: ${{ github.event.pull_request.title }}
-        PR_BODY: ${{ github.event.pull_request.body }}
-        BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
-        TARGET_REPOSITORY: ${{ github.repository }}
-        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-        CI_FULL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
-      run: bash .github/scripts/validate-release-policy.sh
-    # GITHUB_TOKEN label events do not start workflows. Gated workflows scan
-    # commits independently; this label is a durable, visible explanation.
-    - name: Mark automatically detected full validation
-      if: steps.release-policy.outputs.requires_full_label == 'true'
-      env:
-        GH_TOKEN: ${{ github.token }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
-        REPOSITORY: ${{ github.repository }}
-      run: >-
-        gh api "repos/$REPOSITORY/issues/$PR_NUMBER/labels"
-        --method POST
-        --raw-field 'labels[]=ci:full'

--- a/.github/workflows/pr-helper.yml
+++ b/.github/workflows/pr-helper.yml
@@ -32,7 +32,9 @@ jobs:
         PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         CI_FULL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
       run: bash .github/scripts/validate-release-policy.sh
-    - name: Automatically request full validation for release-bearing commits
+    # GITHUB_TOKEN label events do not start workflows. Gated workflows scan
+    # commits independently; this label is a durable, visible explanation.
+    - name: Mark automatically detected full validation
       if: steps.release-policy.outputs.requires_full_label == 'true'
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-helper.yml
+++ b/.github/workflows/pr-helper.yml
@@ -2,12 +2,31 @@ name: Semantic PR helper
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, edited, synchronize, labeled, unlabeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint-pr-title:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write # to comment on PRs
-    steps:    
+    steps:
     - uses: levibostian/action-conventional-pr-linter@acd7e6035a4c70ae2e6aab469c791cc5ca2a989d # v4.0.1
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Verify release validation policy
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        PR_BODY: ${{ github.event.pull_request.body }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+        TARGET_REPOSITORY: ${{ github.repository }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        CI_FULL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
+      run: bash .github/scripts/validate-release-policy.sh

--- a/.github/workflows/pr-helper.yml
+++ b/.github/workflows/pr-helper.yml
@@ -2,7 +2,7 @@ name: Semantic PR helper
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize, labeled]
+    types: [opened, reopened, edited, synchronize]
 
 jobs:
   lint-pr-title:

--- a/.github/workflows/pr-helper.yml
+++ b/.github/workflows/pr-helper.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
       pull-requests: write # to comment on PRs
     steps:
     - uses: levibostian/action-conventional-pr-linter@acd7e6035a4c70ae2e6aab469c791cc5ca2a989d # v4.0.1
@@ -20,6 +21,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Verify release validation policy
+      id: release-policy
       env:
         PR_TITLE: ${{ github.event.pull_request.title }}
         PR_BODY: ${{ github.event.pull_request.body }}
@@ -30,3 +32,13 @@ jobs:
         PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         CI_FULL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
       run: bash .github/scripts/validate-release-policy.sh
+    - name: Automatically request full validation for release-bearing commits
+      if: steps.release-policy.outputs.requires_full_label == 'true'
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPOSITORY: ${{ github.repository }}
+      run: >-
+        gh api "repos/$REPOSITORY/issues/$PR_NUMBER/labels"
+        --method POST
+        --raw-field 'labels[]=ci:full'

--- a/.github/workflows/reusable-release-policy.yml
+++ b/.github/workflows/reusable-release-policy.yml
@@ -6,23 +6,10 @@ on:
       pr_title:
         type: string
         required: true
-      pr_body:
-        type: string
-        required: false
-        default: ''
       base_sha:
         type: string
         required: true
       head_sha:
-        type: string
-        required: true
-      head_repository:
-        type: string
-        required: true
-      target_repository:
-        type: string
-        required: true
-      pr_author:
         type: string
         required: true
       ci_full:
@@ -30,7 +17,7 @@ on:
         required: true
     outputs:
       full_validation:
-        description: Whether this PR needs the full validation lane.
+        description: Whether release intent or ci:full requests distribution validation.
         value: ${{ jobs.classify.outputs.full_validation }}
 
 jobs:
@@ -48,15 +35,7 @@ jobs:
         id: policy
         env:
           PR_TITLE: ${{ inputs.pr_title }}
-          PR_BODY: ${{ inputs.pr_body }}
           BASE_SHA: ${{ inputs.base_sha }}
           HEAD_SHA: ${{ inputs.head_sha }}
-          HEAD_REPOSITORY: ${{ inputs.head_repository }}
-          TARGET_REPOSITORY: ${{ inputs.target_repository }}
-          PR_AUTHOR: ${{ inputs.pr_author }}
           CI_FULL: ${{ inputs.ci_full }}
-          # The semantic PR helper owns the trust-policy failure. Callers use
-          # this reusable workflow only to select safe full or light lanes.
-          ENFORCE_TRUSTED_RELEASE: 'false'
         run: bash .github/scripts/validate-release-policy.sh
-

--- a/.github/workflows/reusable-release-policy.yml
+++ b/.github/workflows/reusable-release-policy.yml
@@ -1,0 +1,62 @@
+name: Reusable release policy
+
+on:
+  workflow_call:
+    inputs:
+      pr_title:
+        type: string
+        required: true
+      pr_body:
+        type: string
+        required: false
+        default: ''
+      base_sha:
+        type: string
+        required: true
+      head_sha:
+        type: string
+        required: true
+      head_repository:
+        type: string
+        required: true
+      target_repository:
+        type: string
+        required: true
+      pr_author:
+        type: string
+        required: true
+      ci_full:
+        type: boolean
+        required: true
+    outputs:
+      full_validation:
+        description: Whether this PR needs the full validation lane.
+        value: ${{ jobs.classify.outputs.full_validation }}
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      full_validation: ${{ steps.policy.outputs.full_validation }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Classify release validation
+        id: policy
+        env:
+          PR_TITLE: ${{ inputs.pr_title }}
+          PR_BODY: ${{ inputs.pr_body }}
+          BASE_SHA: ${{ inputs.base_sha }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          HEAD_REPOSITORY: ${{ inputs.head_repository }}
+          TARGET_REPOSITORY: ${{ inputs.target_repository }}
+          PR_AUTHOR: ${{ inputs.pr_author }}
+          CI_FULL: ${{ inputs.ci_full }}
+          # The semantic PR helper owns the trust-policy failure. Callers use
+          # this reusable workflow only to select safe full or light lanes.
+          ENFORCE_TRUSTED_RELEASE: 'false'
+        run: bash .github/scripts/validate-release-policy.sh
+

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -88,10 +88,13 @@ jobs:
         with:
           ruby-version: '3.4'
           bundler-cache: true
-          working-directory: test-app
 
       - name: Install sd CLI to use later in the workflow
         uses: kenji-miyake/setup-sd@08c14e27d65a1c215342ef00c81583ae67f4c5ef # v2.0.0
+
+      - name: Bundle install
+        working-directory: test-app
+        run: bundle install
 
       - name: Update test app version # This has to happen before we generate the native app
         uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
@@ -234,10 +237,13 @@ jobs:
         with:
           ruby-version: '3.4'
           bundler-cache: true
-          working-directory: test-app
 
       - name: Install SD CLI
         run: brew install sd
+
+      - name: Bundle install
+        working-directory: test-app
+        run: bundle install
 
       - name: Update test app version # This has to happen before we generate the native app
         uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
@@ -278,7 +284,8 @@ jobs:
       - name: Copy GoogleService-Info.plist to ios project
         run: |
           cp test-app/files/GoogleService-Info.plist test-app/ios/GoogleService-Info.plist
-          BUNDLE_GEMFILE=test-app/Gemfile bundle exec ruby scripts/add-google-service-ios.rb
+          gem install xcodeproj
+          ruby scripts/add-google-service-ios.rb
 
       - name: Build iOS app with fastlane
         id: ios_build

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -88,13 +88,10 @@ jobs:
         with:
           ruby-version: '3.4'
           bundler-cache: true
+          working-directory: test-app
 
       - name: Install sd CLI to use later in the workflow
         uses: kenji-miyake/setup-sd@08c14e27d65a1c215342ef00c81583ae67f4c5ef # v2.0.0
-
-      - name: Bundle install
-        working-directory: test-app
-        run: bundle install
 
       - name: Update test app version # This has to happen before we generate the native app
         uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
@@ -237,13 +234,10 @@ jobs:
         with:
           ruby-version: '3.4'
           bundler-cache: true
+          working-directory: test-app
 
       - name: Install SD CLI
         run: brew install sd
-
-      - name: Bundle install
-        working-directory: test-app
-        run: bundle install
 
       - name: Update test app version # This has to happen before we generate the native app
         uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
@@ -284,8 +278,7 @@ jobs:
       - name: Copy GoogleService-Info.plist to ios project
         run: |
           cp test-app/files/GoogleService-Info.plist test-app/ios/GoogleService-Info.plist
-          gem install xcodeproj
-          ruby scripts/add-google-service-ios.rb
+          BUNDLE_GEMFILE=test-app/Gemfile bundle exec ruby scripts/add-google-service-ios.rb
 
       - name: Build iOS app with fastlane
         id: ios_build

--- a/.github/workflows/test-pnpm-compatibility.yml
+++ b/.github/workflows/test-pnpm-compatibility.yml
@@ -2,8 +2,23 @@ name: Test pnpm Compatibility
 
 on:
   pull_request:
+    paths:
+      - '.github/workflows/test-pnpm-compatibility.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'plugin/**'
+      - 'scripts/setup-test-app-pnpm.sh'
+      - 'scripts/setup-test-app-pnpm-monorepo.sh'
+      - 'scripts/create-plugin-tarball.sh'
+      - 'scripts/install-plugin-tarball.sh'
+      - 'scripts/verify-pnpm-dev-apps.sh'
+      - 'scripts/utils.sh'
+      - 'test-app-pnpm/**'
+      - 'test-app-pnpm-monorepo/**'
+      - '__tests__/scripts/**'
+      - '__tests__/workflows/**'
   push:
-    branches: [main, beta, feature/*]
+    branches: [main, beta]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,14 @@ name: Test
 
 on:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
   push:
     branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test-deploy:

--- a/.github/workflows/validate-plugin-compatibility-full.yml
+++ b/.github/workflows/validate-plugin-compatibility-full.yml
@@ -2,16 +2,32 @@ name: Full plugin compatibility validation
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, edited, labeled]
 
 permissions:
   contents: read
 
 jobs:
+  # Metadata edits rerun full so a newer skipped check cannot replace a failure.
   full-compatibility:
     if: >-
-      ((github.event.action == 'labeled' && github.event.label.name == 'ci:full') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ci:full')))
-    uses: ./.github/workflows/validate-plugin-compatibility.yml
-    with:
-      full: true
+      (github.event.action == 'edited' ||
+      github.event.action == 'labeled' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      startsWith(github.event.pull_request.title, 'fix:') ||
+      startsWith(github.event.pull_request.title, 'fix(') ||
+      startsWith(github.event.pull_request.title, 'feat:') ||
+      startsWith(github.event.pull_request.title, 'feat(') ||
+      startsWith(github.event.pull_request.title, 'perf:') ||
+      startsWith(github.event.pull_request.title, 'perf(') ||
+      startsWith(github.event.pull_request.title, 'revert:') ||
+      startsWith(github.event.pull_request.title, 'revert(') ||
+      startsWith(github.event.pull_request.title, 'Revert "') ||
+      contains(github.event.pull_request.body, 'This reverts commit') ||
+      contains(github.event.pull_request.title, '!:') ||
+      contains(github.event.pull_request.body, 'BREAKING CHANGE:') ||
+      contains(github.event.pull_request.body, 'BREAKING CHANGES:') ||
+      contains(github.event.pull_request.body, 'BREAKING-CHANGE:'))
+    # This matrix uses hosted runners and no repository secrets, so it can also
+    # provide full compatibility coverage for fork PRs.
+    uses: ./.github/workflows/validate-plugin-compatibility-matrix.yml

--- a/.github/workflows/validate-plugin-compatibility-full.yml
+++ b/.github/workflows/validate-plugin-compatibility-full.yml
@@ -1,0 +1,17 @@
+name: Full plugin compatibility validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  full-compatibility:
+    if: >-
+      ((github.event.action == 'labeled' && github.event.label.name == 'ci:full') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ci:full')))
+    uses: ./.github/workflows/validate-plugin-compatibility.yml
+    with:
+      full: true

--- a/.github/workflows/validate-plugin-compatibility-full.yml
+++ b/.github/workflows/validate-plugin-compatibility-full.yml
@@ -8,26 +8,28 @@ permissions:
   contents: read
 
 jobs:
+  release_policy:
+    uses: ./.github/workflows/reusable-release-policy.yml
+    permissions:
+      contents: read
+    with:
+      pr_title: ${{ github.event.pull_request.title }}
+      pr_body: ${{ github.event.pull_request.body || '' }}
+      base_sha: ${{ github.event.pull_request.base.sha }}
+      head_sha: ${{ github.event.pull_request.head.sha }}
+      head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+      target_repository: ${{ github.repository }}
+      pr_author: ${{ github.event.pull_request.user.login }}
+      ci_full: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
+
   # Metadata edits rerun full so a newer skipped check cannot replace a failure.
   full-compatibility:
+    needs: release_policy
     if: >-
+      always() &&
       (github.event.action == 'edited' ||
       github.event.action == 'labeled' ||
-      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
-      startsWith(github.event.pull_request.title, 'fix:') ||
-      startsWith(github.event.pull_request.title, 'fix(') ||
-      startsWith(github.event.pull_request.title, 'feat:') ||
-      startsWith(github.event.pull_request.title, 'feat(') ||
-      startsWith(github.event.pull_request.title, 'perf:') ||
-      startsWith(github.event.pull_request.title, 'perf(') ||
-      startsWith(github.event.pull_request.title, 'revert:') ||
-      startsWith(github.event.pull_request.title, 'revert(') ||
-      startsWith(github.event.pull_request.title, 'Revert "') ||
-      contains(github.event.pull_request.body, 'This reverts commit') ||
-      contains(github.event.pull_request.title, '!:') ||
-      contains(github.event.pull_request.body, 'BREAKING CHANGE:') ||
-      contains(github.event.pull_request.body, 'BREAKING CHANGES:') ||
-      contains(github.event.pull_request.body, 'BREAKING-CHANGE:'))
+      needs.release_policy.outputs.full_validation == 'true')
     # This matrix uses hosted runners and no repository secrets, so it can also
     # provide full compatibility coverage for fork PRs.
     uses: ./.github/workflows/validate-plugin-compatibility-matrix.yml

--- a/.github/workflows/validate-plugin-compatibility-full.yml
+++ b/.github/workflows/validate-plugin-compatibility-full.yml
@@ -2,34 +2,22 @@ name: Full plugin compatibility validation
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited, labeled]
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'plugin/**'
+      - 'scripts/compatibility/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/validate-plugin-compatibility*.yml'
 
 permissions:
   contents: read
 
 jobs:
-  release_policy:
-    uses: ./.github/workflows/reusable-release-policy.yml
-    permissions:
-      contents: read
-    with:
-      pr_title: ${{ github.event.pull_request.title }}
-      pr_body: ${{ github.event.pull_request.body || '' }}
-      base_sha: ${{ github.event.pull_request.base.sha }}
-      head_sha: ${{ github.event.pull_request.head.sha }}
-      head_repository: ${{ github.event.pull_request.head.repo.full_name }}
-      target_repository: ${{ github.repository }}
-      pr_author: ${{ github.event.pull_request.user.login }}
-      ci_full: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
-
-  # Metadata edits rerun full so a newer skipped check cannot replace a failure.
+  # Correctness follows changed paths, not semantic-release naming. The latest
+  # Android and iOS/APN cells run in the smoke workflow, so this adds only the
+  # SDK-floor and FCM cells needed to complete the six-cell matrix.
   full-compatibility:
-    needs: release_policy
-    if: >-
-      always() &&
-      (github.event.action == 'edited' ||
-      github.event.action == 'labeled' ||
-      needs.release_policy.outputs.full_validation == 'true')
-    # This matrix uses hosted runners and no repository secrets, so it can also
-    # provide full compatibility coverage for fork PRs.
     uses: ./.github/workflows/validate-plugin-compatibility-matrix.yml
+    with:
+      matrix: '[{"expo-version":54,"platform":"android","runs-on":"ubuntu-latest"},{"expo-version":54,"platform":"ios","runs-on":"macos-26","ios-push-provider":"apn"},{"expo-version":54,"platform":"ios","runs-on":"macos-26","ios-push-provider":"fcm"},{"expo-version":"latest","platform":"ios","runs-on":"macos-26","ios-push-provider":"fcm"}]'

--- a/.github/workflows/validate-plugin-compatibility-matrix.yml
+++ b/.github/workflows/validate-plugin-compatibility-matrix.yml
@@ -66,7 +66,6 @@ jobs:
           cache: 'npm'
 
       - name: Setup Java
-        if: matrix.platform == 'android'
         uses: actions/setup-java@v4
         with:
           distribution: temurin

--- a/.github/workflows/validate-plugin-compatibility-matrix.yml
+++ b/.github/workflows/validate-plugin-compatibility-matrix.yml
@@ -7,6 +7,11 @@ on:
         description: 'Git ref to check out and validate against. Defaults to the calling workflow''s ref.'
         type: string
         required: false
+      matrix:
+        description: 'JSON matrix. Defaults to the complete supported-version and latest-version matrix.'
+        type: string
+        required: false
+        default: '[{"expo-version":54,"platform":"android","runs-on":"ubuntu-latest"},{"expo-version":54,"platform":"ios","runs-on":"macos-26","ios-push-provider":"apn"},{"expo-version":54,"platform":"ios","runs-on":"macos-26","ios-push-provider":"fcm"},{"expo-version":"latest","platform":"android","runs-on":"ubuntu-latest"},{"expo-version":"latest","platform":"ios","runs-on":"macos-26","ios-push-provider":"apn"},{"expo-version":"latest","platform":"ios","runs-on":"macos-26","ios-push-provider":"fcm"}]'
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.ref || github.ref }}
@@ -27,31 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - expo-version: 54
-            platform: android
-            runs-on: ubuntu-latest
-          - expo-version: 54
-            platform: ios
-            runs-on: macos-26
-            ios-push-provider: apn
-          - expo-version: 54
-            platform: ios
-            runs-on: macos-26
-            ios-push-provider: fcm
-
-          # Running on latest version helps to catch issues early for new versions not listed above
-          - expo-version: latest
-            platform: android
-            runs-on: ubuntu-latest
-          - expo-version: latest
-            platform: ios
-            runs-on: macos-26
-            ios-push-provider: apn
-          - expo-version: latest
-            platform: ios
-            runs-on: macos-26
-            ios-push-provider: fcm
+        include: ${{ fromJSON(inputs.matrix) }}
 
     steps:
       - name: Checkout Repository
@@ -66,6 +47,7 @@ jobs:
           cache: 'npm'
 
       - name: Setup Java
+        if: matrix.platform == 'android'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -82,8 +64,8 @@ jobs:
 
       - name: Set APP_NAME and APP_PATH
         run: |
-          echo "APP_NAME=${{ env.APP_NAME_PREFIX }}_${{ matrix.expo-version }}" >> $GITHUB_ENV
-          echo "APP_PATH=${{ env.APP_DIR }}/${{ env.APP_NAME_PREFIX }}_${{ matrix.expo-version }}" >> $GITHUB_ENV
+          echo "APP_NAME=${{ env.APP_NAME_PREFIX }}_${{ matrix.expo-version }}" >> "$GITHUB_ENV"
+          echo "APP_PATH=${{ env.APP_DIR }}/${{ env.APP_NAME_PREFIX }}_${{ matrix.expo-version }}" >> "$GITHUB_ENV"
 
       # The test app is generated fresh by `compatibility:create-test-app`, so
       # `Podfile.lock` / Gradle files don't exist at checkout. The cache keys

--- a/.github/workflows/validate-plugin-compatibility-matrix.yml
+++ b/.github/workflows/validate-plugin-compatibility-matrix.yml
@@ -66,6 +66,7 @@ jobs:
           cache: 'npm'
 
       - name: Setup Java
+        if: matrix.platform == 'android'
         uses: actions/setup-java@v4
         with:
           distribution: temurin

--- a/.github/workflows/validate-plugin-compatibility.yml
+++ b/.github/workflows/validate-plugin-compatibility.yml
@@ -5,6 +5,7 @@ name: Validate Plugin Compatibility
 # The full multi-SDK release matrix still runs on main and on demand.
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited, labeled]
     paths-ignore:
       - '**/*.md'
   workflow_call:
@@ -29,7 +30,25 @@ env:
 jobs:
   prepare:
     name: Select compatibility smoke matrix
-    if: inputs.full == true || !contains(github.event.pull_request.labels.*.name, 'ci:full')
+    if: >-
+      inputs.full == true ||
+      (github.event.action != 'edited' &&
+      github.event.action != 'labeled' &&
+      !contains(github.event.pull_request.labels.*.name, 'ci:full') &&
+      !startsWith(github.event.pull_request.title, 'fix:') &&
+      !startsWith(github.event.pull_request.title, 'fix(') &&
+      !startsWith(github.event.pull_request.title, 'feat:') &&
+      !startsWith(github.event.pull_request.title, 'feat(') &&
+      !startsWith(github.event.pull_request.title, 'perf:') &&
+      !startsWith(github.event.pull_request.title, 'perf(') &&
+      !startsWith(github.event.pull_request.title, 'revert:') &&
+      !startsWith(github.event.pull_request.title, 'revert(') &&
+      !startsWith(github.event.pull_request.title, 'Revert "') &&
+      !contains(github.event.pull_request.body, 'This reverts commit') &&
+      !contains(github.event.pull_request.title, '!:') &&
+      !contains(github.event.pull_request.body, 'BREAKING CHANGE:') &&
+      !contains(github.event.pull_request.body, 'BREAKING CHANGES:') &&
+      !contains(github.event.pull_request.body, 'BREAKING-CHANGE:'))
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.select.outputs.matrix }}

--- a/.github/workflows/validate-plugin-compatibility.yml
+++ b/.github/workflows/validate-plugin-compatibility.yml
@@ -1,15 +1,16 @@
 name: Validate Plugin Compatibility
 
-# Slim 3-cell PR-time smoke matrix at the latest Expo SDK. Catches real-build
-# regressions (Gradle / CocoaPods / xcodebuild) that the fast Jest scenario
-# suite can't see. The full multi-SDK matrix runs on merges to main via
-# `validate-plugin-compatibility-release.yml`, and on demand via
-# `validate-plugin-compatibility-manual.yml`.
+# A representative Android + iOS/FCM smoke matrix catches real-build regressions
+# that Jest cannot see. Add `ci:full` to include the redundant iOS/APN variant.
+# The full multi-SDK matrix still runs on main and on demand.
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    paths-ignore:
+      - '**/*.md'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.event.action == 'labeled' && github.event.label.name != 'ci:full') && github.run_id || 'validation' }}
   cancel-in-progress: true
 
 env:
@@ -20,22 +21,34 @@ env:
   APP_NAME_PREFIX: ExpoPluginTestApp
 
 jobs:
+  prepare:
+    name: Select compatibility smoke matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.select.outputs.matrix }}
+    steps:
+      - name: Select representative or full PR matrix
+        id: select
+        shell: bash
+        env:
+          FULL_PR: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
+        run: |
+          if [[ "$FULL_PR" == 'true' ]]; then
+            echo 'matrix=[{"platform":"android","runs-on":"ubuntu-latest"},{"platform":"ios","runs-on":"macos-26","ios-push-provider":"fcm"},{"platform":"ios","runs-on":"macos-26","ios-push-provider":"apn"}]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix=[{"platform":"android","runs-on":"ubuntu-latest"},{"platform":"ios","runs-on":"macos-26","ios-push-provider":"fcm"}]' >> "$GITHUB_OUTPUT"
+          fi
+
   smoke:
     name: Expo latest - ${{ matrix.platform }}${{ matrix.ios-push-provider && format(' ({0})', matrix.ios-push-provider) }}
+    needs: prepare
+    if: github.event.action != 'labeled' || github.event.label.name == 'ci:full'
     runs-on: ${{ matrix.runs-on }}
 
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: android
-            runs-on: ubuntu-latest
-          - platform: ios
-            runs-on: macos-26
-            ios-push-provider: apn
-          - platform: ios
-            runs-on: macos-26
-            ios-push-provider: fcm
+        include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/validate-plugin-compatibility.yml
+++ b/.github/workflows/validate-plugin-compatibility.yml
@@ -1,20 +1,13 @@
 name: Validate Plugin Compatibility
 
-# A representative Android + iOS/APN smoke matrix catches real-build regressions
-# that Jest cannot see. The separate full-lane caller includes the FCM variant.
-# The full multi-SDK release matrix still runs on main and on demand.
+# Every code PR gets representative latest Android and iOS/APN real builds.
+# Compatibility-sensitive paths add the non-duplicated SDK-floor and FCM cells
+# in validate-plugin-compatibility-full.yml. Release validation remains separate.
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited, labeled]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '**/*.md'
-  workflow_call:
-    inputs:
-      full:
-        description: Include both iOS push-provider variants.
-        type: boolean
-        required: false
-        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,59 +21,19 @@ env:
   APP_NAME_PREFIX: ExpoPluginTestApp
 
 jobs:
-  release_policy:
-    if: >-
-      github.event_name == 'pull_request' &&
-      inputs.full != true
-    uses: ./.github/workflows/reusable-release-policy.yml
-    permissions:
-      contents: read
-    with:
-      pr_title: ${{ github.event.pull_request.title }}
-      pr_body: ${{ github.event.pull_request.body || '' }}
-      base_sha: ${{ github.event.pull_request.base.sha }}
-      head_sha: ${{ github.event.pull_request.head.sha }}
-      head_repository: ${{ github.event.pull_request.head.repo.full_name }}
-      target_repository: ${{ github.repository }}
-      pr_author: ${{ github.event.pull_request.user.login }}
-      ci_full: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
-
-  prepare:
-    name: Select compatibility smoke matrix
-    needs: release_policy
-    if: >-
-      always() &&
-      (inputs.full == true ||
-      github.event_name != 'pull_request' ||
-      (needs.release_policy.result == 'success' &&
-      github.event.action != 'edited' &&
-      github.event.action != 'labeled' &&
-      needs.release_policy.outputs.full_validation != 'true'))
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.select.outputs.matrix }}
-    steps:
-      - name: Select representative or full PR matrix
-        id: select
-        shell: bash
-        env:
-          FULL_PR: ${{ inputs.full == true }}
-        run: |
-          if [[ "$FULL_PR" == 'true' ]]; then
-            echo 'matrix=[{"platform":"android","runs-on":"ubuntu-latest"},{"platform":"ios","runs-on":"macos-26","ios-push-provider":"fcm"},{"platform":"ios","runs-on":"macos-26","ios-push-provider":"apn"}]' >> "$GITHUB_OUTPUT"
-          else
-            echo 'matrix=[{"platform":"android","runs-on":"ubuntu-latest"},{"platform":"ios","runs-on":"macos-26","ios-push-provider":"apn"}]' >> "$GITHUB_OUTPUT"
-          fi
-
   smoke:
     name: Expo latest - ${{ matrix.platform }}${{ matrix.ios-push-provider && format(' ({0})', matrix.ios-push-provider) }}
-    needs: prepare
     runs-on: ${{ matrix.runs-on }}
 
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+        include:
+          - platform: android
+            runs-on: ubuntu-latest
+          - platform: ios
+            runs-on: macos-26
+            ios-push-provider: apn
 
     steps:
       - name: Checkout Repository
@@ -110,8 +63,8 @@ jobs:
 
       - name: Set APP_NAME and APP_PATH
         run: |
-          echo "APP_NAME=${{ env.APP_NAME_PREFIX }}_latest" >> $GITHUB_ENV
-          echo "APP_PATH=${{ env.APP_DIR }}/${{ env.APP_NAME_PREFIX }}_latest" >> $GITHUB_ENV
+          echo "APP_NAME=${{ env.APP_NAME_PREFIX }}_latest" >> "$GITHUB_ENV"
+          echo "APP_PATH=${{ env.APP_DIR }}/${{ env.APP_NAME_PREFIX }}_latest" >> "$GITHUB_ENV"
 
       # The test app is generated fresh by `compatibility:create-test-app`, so
       # `Podfile.lock` / Gradle files don't exist at checkout. The cache keys

--- a/.github/workflows/validate-plugin-compatibility.yml
+++ b/.github/workflows/validate-plugin-compatibility.yml
@@ -1,16 +1,22 @@
 name: Validate Plugin Compatibility
 
-# A representative Android + iOS/FCM smoke matrix catches real-build regressions
-# that Jest cannot see. Add `ci:full` to include the redundant iOS/APN variant.
-# The full multi-SDK matrix still runs on main and on demand.
+# A representative Android + iOS/APN smoke matrix catches real-build regressions
+# that Jest cannot see. The separate full-lane caller includes the FCM variant.
+# The full multi-SDK release matrix still runs on main and on demand.
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
     paths-ignore:
       - '**/*.md'
+  workflow_call:
+    inputs:
+      full:
+        description: Include both iOS push-provider variants.
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.event.action == 'labeled' && github.event.label.name != 'ci:full') && github.run_id || 'validation' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -23,6 +29,7 @@ env:
 jobs:
   prepare:
     name: Select compatibility smoke matrix
+    if: inputs.full == true || !contains(github.event.pull_request.labels.*.name, 'ci:full')
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.select.outputs.matrix }}
@@ -31,18 +38,17 @@ jobs:
         id: select
         shell: bash
         env:
-          FULL_PR: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
+          FULL_PR: ${{ inputs.full == true }}
         run: |
           if [[ "$FULL_PR" == 'true' ]]; then
             echo 'matrix=[{"platform":"android","runs-on":"ubuntu-latest"},{"platform":"ios","runs-on":"macos-26","ios-push-provider":"fcm"},{"platform":"ios","runs-on":"macos-26","ios-push-provider":"apn"}]' >> "$GITHUB_OUTPUT"
           else
-            echo 'matrix=[{"platform":"android","runs-on":"ubuntu-latest"},{"platform":"ios","runs-on":"macos-26","ios-push-provider":"fcm"}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix=[{"platform":"android","runs-on":"ubuntu-latest"},{"platform":"ios","runs-on":"macos-26","ios-push-provider":"apn"}]' >> "$GITHUB_OUTPUT"
           fi
 
   smoke:
     name: Expo latest - ${{ matrix.platform }}${{ matrix.ios-push-provider && format(' ({0})', matrix.ios-push-provider) }}
     needs: prepare
-    if: github.event.action != 'labeled' || github.event.label.name == 'ci:full'
     runs-on: ${{ matrix.runs-on }}
 
     strategy:

--- a/.github/workflows/validate-plugin-compatibility.yml
+++ b/.github/workflows/validate-plugin-compatibility.yml
@@ -28,27 +28,34 @@ env:
   APP_NAME_PREFIX: ExpoPluginTestApp
 
 jobs:
+  release_policy:
+    if: >-
+      github.event_name == 'pull_request' &&
+      inputs.full != true
+    uses: ./.github/workflows/reusable-release-policy.yml
+    permissions:
+      contents: read
+    with:
+      pr_title: ${{ github.event.pull_request.title }}
+      pr_body: ${{ github.event.pull_request.body || '' }}
+      base_sha: ${{ github.event.pull_request.base.sha }}
+      head_sha: ${{ github.event.pull_request.head.sha }}
+      head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+      target_repository: ${{ github.repository }}
+      pr_author: ${{ github.event.pull_request.user.login }}
+      ci_full: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
+
   prepare:
     name: Select compatibility smoke matrix
+    needs: release_policy
     if: >-
-      inputs.full == true ||
-      (github.event.action != 'edited' &&
+      always() &&
+      (inputs.full == true ||
+      github.event_name != 'pull_request' ||
+      (needs.release_policy.result == 'success' &&
+      github.event.action != 'edited' &&
       github.event.action != 'labeled' &&
-      !contains(github.event.pull_request.labels.*.name, 'ci:full') &&
-      !startsWith(github.event.pull_request.title, 'fix:') &&
-      !startsWith(github.event.pull_request.title, 'fix(') &&
-      !startsWith(github.event.pull_request.title, 'feat:') &&
-      !startsWith(github.event.pull_request.title, 'feat(') &&
-      !startsWith(github.event.pull_request.title, 'perf:') &&
-      !startsWith(github.event.pull_request.title, 'perf(') &&
-      !startsWith(github.event.pull_request.title, 'revert:') &&
-      !startsWith(github.event.pull_request.title, 'revert(') &&
-      !startsWith(github.event.pull_request.title, 'Revert "') &&
-      !contains(github.event.pull_request.body, 'This reverts commit') &&
-      !contains(github.event.pull_request.title, '!:') &&
-      !contains(github.event.pull_request.body, 'BREAKING CHANGE:') &&
-      !contains(github.event.pull_request.body, 'BREAKING CHANGES:') &&
-      !contains(github.event.pull_request.body, 'BREAKING-CHANGE:'))
+      needs.release_policy.outputs.full_validation != 'true'))
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.select.outputs.matrix }}

--- a/.github/workflows/validate-plugin-compatibility.yml
+++ b/.github/workflows/validate-plugin-compatibility.yml
@@ -61,6 +61,7 @@ jobs:
           cache: 'npm'
 
       - name: Setup Java
+        if: matrix.platform == 'android'
         uses: actions/setup-java@v4
         with:
           distribution: temurin


### PR DESCRIPTION
## Summary
- keep representative Android and iOS/FCM real-build compatibility coverage on routine PRs
- add the redundant iOS/APN cell and sample distribution only with `ci:full`
- scope the expensive pnpm native compatibility workflow to relevant files
- remove duplicate feature-branch push runs while preserving main and beta coverage

## Validation
- workflow tests passed (2/2)
- scenario tests passed (23 suites, 151 tests, 63 snapshots)
- API Extractor and package build passed
- changed workflow YAML passes differential Actionlint validation
- no release workflow changed