### PR TITLE
chore: resolve the published SDK version from the release job

### DIFF
--- a/.github/workflows/build-sample-app-for-sdk-release.yml
+++ b/.github/workflows/build-sample-app-for-sdk-release.yml
@@ -2,11 +2,23 @@ name: Publish test apps for SDK release
 
 on:
   workflow_dispatch:
+    inputs:
+      sdk_version:
+        description: "Published plugin version to build the test apps against (e.g. 3.9.0). Leave empty to use the newest tag reachable from this commit."
+        required: false
+        type: string
   workflow_call:
+    inputs:
+      sdk_version:
+        description: "Published plugin version to build the test apps against. The deploy workflow passes the version semantic-release just tagged."
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build-sample-apps:
     uses: ./.github/workflows/reusable_build_sample_apps.yml
     with:
       use_latest_sdk_version: true
+      sdk_version: ${{ inputs.sdk_version }}
     secrets: inherit

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -294,6 +294,12 @@ jobs:
         run: npm publish
 
   publish-sample-apps-public-builds:
-    needs: deploy-npm
+    # `deploy-git-tag` is needed for its `new_release_version` output, not for
+    # ordering — `needs` only exposes the outputs of directly-listed jobs.
+    # Without it the test apps resolve their version with `git describe`, which
+    # walks ancestors only and so names the PREVIOUS release on a release commit.
+    needs: [deploy-git-tag, deploy-npm]
     uses: ./.github/workflows/build-sample-app-for-sdk-release.yml
+    with:
+      sdk_version: ${{ needs.deploy-git-tag.outputs.new_release_version }}
     secrets: inherit

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -8,6 +8,11 @@ on:
         type: boolean
         required: false
         default: false
+      sdk_version:
+        description: "Published SDK version the sample apps should install. The release path passes the version it just published; leave empty to fall back to the newest tag reachable from this commit."
+        type: string
+        required: false
+        default: ""
 
 jobs:
   build-android-app:
@@ -48,11 +53,39 @@ jobs:
       - name: Capture Git Context
         shell: bash
         id: git-context
+        env:
+          SDK_VERSION_INPUT: ${{ inputs.sdk_version }}
+          USE_LATEST_SDK_VERSION: ${{ inputs.use_latest_sdk_version }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           echo "BRANCH_NAME=${{ github.head_ref || github.ref_name }}" >> $GITHUB_ENV
           COMMIT_HASH="${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
           echo "COMMIT_HASH=${COMMIT_HASH:0:7}" >> $GITHUB_ENV
-          echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+
+          # `git describe` answers an ancestry question — "the newest tag
+          # reachable from this commit" — and stays the input to
+          # `commitsAheadCount` below. Do not repurpose it.
+          LATEST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+
+          # "Which published SDK do these apps install" is a different question.
+          # semantic-release tags a NEW CHILD of the commit this job checks out,
+          # and `git describe` only walks ancestors, so on the release path it
+          # names the PREVIOUS release. The release caller therefore passes the
+          # version it just published.
+          if [ -n "$SDK_VERSION_INPUT" ]; then
+            SDK_BUILD_VERSION="$SDK_VERSION_INPUT"
+            echo "Resolved SDK version from the sdk_version input: $SDK_BUILD_VERSION"
+          elif [ "$USE_LATEST_SDK_VERSION" = "true" ] && [ "$EVENT_NAME" != "workflow_dispatch" ]; then
+            # Falling back silently here is what produced a release build whose
+            # app manifest asked for the new SDK while npm installed the old one.
+            echo "::error::Release sample-app build received no sdk_version input. Refusing to fall back to the last reachable tag ('${LATEST_TAG:-none}'), which names the previous release on a release commit."
+            exit 1
+          else
+            SDK_BUILD_VERSION="$LATEST_TAG"
+            echo "Resolved SDK version from the last reachable tag: ${SDK_BUILD_VERSION:-none}"
+          fi
+          echo "SDK_BUILD_VERSION=$SDK_BUILD_VERSION" >> $GITHUB_ENV
 
       - name: Set Default Firebase Distribution Groups
         shell: bash
@@ -81,7 +114,7 @@ jobs:
         if: ${{ inputs.use_latest_sdk_version == true }}
         run: |
           touch "test-app/local.env"
-          echo "sdkVersion=${{ env.LATEST_TAG }}" >> "test-app/local.env"
+          echo "sdkVersion=${{ env.SDK_BUILD_VERSION }}" >> "test-app/local.env"
 
       - name: Install tools from Gemfile (ruby language) used for building our apps with
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
@@ -101,7 +134,7 @@ jobs:
         with:
           lane: update_expo_test_app_version
           subdirectory: test-app
-          options: ${{ inputs.use_latest_sdk_version == true && format('{{"sdk_version":"{0}"}}', env.LATEST_TAG) || '' }}
+          options: ${{ inputs.use_latest_sdk_version == true && format('{{"sdk_version":"{0}"}}', env.SDK_BUILD_VERSION) || '' }}
 
       - name: Install plugin dependencies
         working-directory: plugin
@@ -147,7 +180,7 @@ jobs:
           instructions_guide_link: ${{ secrets.SAMPLE_APPS_INSTRUCTIONS_GUIDE_LINK }}
           platform: "android"
           sdk_name: "Expo Plugin"
-          sdk_version: ${{ env.LATEST_TAG }}
+          sdk_version: ${{ env.SDK_BUILD_VERSION }}
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   build-ios-app:
@@ -173,11 +206,39 @@ jobs:
       - name: Capture Git Context
         shell: bash
         id: git-context
+        env:
+          SDK_VERSION_INPUT: ${{ inputs.sdk_version }}
+          USE_LATEST_SDK_VERSION: ${{ inputs.use_latest_sdk_version }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           echo "BRANCH_NAME=${{ github.head_ref || github.ref_name }}" >> $GITHUB_ENV
           COMMIT_HASH="${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
           echo "COMMIT_HASH=${COMMIT_HASH:0:7}" >> $GITHUB_ENV
-          echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+
+          # `git describe` answers an ancestry question — "the newest tag
+          # reachable from this commit" — and stays the input to
+          # `commitsAheadCount` below. Do not repurpose it.
+          LATEST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+
+          # "Which published SDK do these apps install" is a different question.
+          # semantic-release tags a NEW CHILD of the commit this job checks out,
+          # and `git describe` only walks ancestors, so on the release path it
+          # names the PREVIOUS release. The release caller therefore passes the
+          # version it just published.
+          if [ -n "$SDK_VERSION_INPUT" ]; then
+            SDK_BUILD_VERSION="$SDK_VERSION_INPUT"
+            echo "Resolved SDK version from the sdk_version input: $SDK_BUILD_VERSION"
+          elif [ "$USE_LATEST_SDK_VERSION" = "true" ] && [ "$EVENT_NAME" != "workflow_dispatch" ]; then
+            # Falling back silently here is what produced a release build whose
+            # app manifest asked for the new SDK while npm installed the old one.
+            echo "::error::Release sample-app build received no sdk_version input. Refusing to fall back to the last reachable tag ('${LATEST_TAG:-none}'), which names the previous release on a release commit."
+            exit 1
+          else
+            SDK_BUILD_VERSION="$LATEST_TAG"
+            echo "Resolved SDK version from the last reachable tag: ${SDK_BUILD_VERSION:-none}"
+          fi
+          echo "SDK_BUILD_VERSION=$SDK_BUILD_VERSION" >> $GITHUB_ENV
 
       - name: Set Default Firebase Distribution Groups
         shell: bash
@@ -210,7 +271,7 @@ jobs:
         run: |
           touch "test-app/local.env"
           if [ "${{ inputs.use_latest_sdk_version }}" == "true" ]; then
-            echo "sdkVersion=${{ env.LATEST_TAG }}" >> "test-app/local.env"
+            echo "sdkVersion=${{ env.SDK_BUILD_VERSION }}" >> "test-app/local.env"
           fi
           echo "pushProvider=${{ matrix.push_provider }}" >> "test-app/local.env"
 
@@ -250,7 +311,7 @@ jobs:
         with:
           lane: update_expo_test_app_version
           subdirectory: test-app
-          options: ${{ inputs.use_latest_sdk_version == true && format('{{"sdk_version":"{0}"}}', env.LATEST_TAG) || '' }}
+          options: ${{ inputs.use_latest_sdk_version == true && format('{{"sdk_version":"{0}"}}', env.SDK_BUILD_VERSION) || '' }}
 
       - name: Install plugin dependencies
         working-directory: plugin
@@ -312,5 +373,5 @@ jobs:
           instructions_guide_link: ${{ secrets.SAMPLE_APPS_INSTRUCTIONS_GUIDE_LINK }}
           platform: "ios"
           sdk_name: "Expo Plugin"
-          sdk_version: ${{ env.LATEST_TAG }}
+          sdk_version: ${{ env.SDK_BUILD_VERSION }}
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Fixes MBL-2324

## Problem

`reusable_build_sample_apps.yml` resolved the SDK version to build the test apps against with `git describe --tags --abbrev=0`, evaluated on the **pre-release** commit.

semantic-release tags a **new child commit** of that commit. `git describe` only walks ancestors, so on the release path it returns the *previous* release. That value became `sdkVersion=` in `test-app/local.env`, and `scripts/applyLocalEnvValues.js` → `updateSdkVersion()` installed that stale plugin version.

Confirmed in [run 33082901972](https://github.com/customerio/customerio-expo-plugin/actions/runs/33082901972): the release commit raised the test app's `customerio-reactnative` constraint to `^6.9.0`, but CI installed plugin **3.8.0**, whose exact peer is `6.6.3` → `npm ERESOLVE`. Not a publish race — 3.9.0 was on npm at 14:36:10Z and the failing install ran at 14:37:34Z. The job simply asked for the wrong version. Same fingerprint in four earlier runs.

## Fix

`LATEST_TAG` was answering two different questions with one value. They are now separated:

| value | question | source |
| --- | --- | --- |
| `LATEST_TAG` | "newest tag reachable from this commit" — an **ancestry** question | `git describe` (unchanged) |
| `SDK_BUILD_VERSION` | "which published SDK do these apps install" | new `sdk_version` input, falling back to `LATEST_TAG` |

- `reusable_build_sample_apps.yml` gains an optional `sdk_version` input. When it is non-empty it wins; otherwise the job falls back to `git describe`.
- On a **release** build (`use_latest_sdk_version: true`) that is *not* a `workflow_dispatch`, an empty input is now a hard error rather than a silent fallback — that silent fallback is exactly what shipped the wrong version.
- `commitsAheadCount` still reads `LATEST_TAG`. `git describe` is the correct answer there and restricting it would have broken every PR and push build.
- `SDK_BUILD_VERSION` also drives the two other "which version is this app" consumers — the `update_expo_test_app_version` fastlane stamp and the `sdk_version` field in the sample-app Slack notification — which were reporting the stale tag for the same reason. On non-release builds the input is empty, so both resolve to `LATEST_TAG` exactly as before; nothing changes for PR/push runs.
- `build-sample-app-for-sdk-release.yml` accepts and forwards `sdk_version` on both `workflow_dispatch` and `workflow_call`.
- `deploy-sdk.yml`: `needs: deploy-npm` → `needs: [deploy-git-tag, deploy-npm]`, so `needs.deploy-git-tag.outputs.new_release_version` is reachable. `deploy-git-tag` already declared that output; `needs` exposes outputs of directly-listed jobs only, so this is purely about reach — the ordering was already guaranteed transitively through `deploy-npm`, and no job gating changes.

The deploy path is a nested reusable-workflow `uses:` chain (`deploy-sdk` → `build-sample-app-for-sdk-release` → `reusable_build_sample_apps`), so `github.event_name` inside the reusable workflow is the originating event. A manual dispatch of `build-sample-app-for-sdk-release.yml` therefore still reports `workflow_dispatch` and keeps its `git describe` fallback, which is correct there — no release is being cut concurrently.

Reference implementation: `customerio-reactnative`'s `build-release-sample-apps.yml` (read only; unchanged).

## Notes / risk

- Behaviour on PR and push builds is byte-identical: the input is empty, so `SDK_BUILD_VERSION == LATEST_TAG`.
- The exact `customerio-reactnative` peer pin in `package.json` is deliberately **untouched**. `plugin/src/utils/writeExpoVersion.ts` writes into `node_modules/customerio-reactnative/package.json` and `plugin/src/helpers/utils/injectCIOPodfileCode.ts` resolves that SDK's pods by `:path`; 25+ commits move it in lockstep. The bug was CI asking for the wrong version, not the pin.
- Verified with `actionlint` (clean apart from pre-existing `SC2086:info` on unquoted `$GITHUB_ENV`, which matches the file's existing style).