### PR TITLE
chore: assert the known Expo UIScene failure instead of leaving the nightly red

### DIFF
--- a/.github/IOS-TOOLCHAIN-COMPATIBILITY.md
+++ b/.github/IOS-TOOLCHAIN-COMPATIBILITY.md
@@ -4,7 +4,7 @@
 
 The existing `Validate Plugin Compatibility` pull-request workflow remains the required stable-Xcode regression coverage for APN and FCM, and the release workflow continues to run the stable full Expo SDK matrix. Repeating those stable builds in the preview workflow would consume scarce hosted macOS capacity without adding a distinct release gate.
 
-Nightly preview failures are recorded as failed scheduled or manually dispatched runs, and this
+Nightly preview flips are recorded as failed scheduled or manually dispatched runs, and this
 repository's Actions history is the source of truth. A pull request specifically changing Expo's
 iOS toolchain integration can be
 validated before merge with a manual dispatch or an explicitly test-only workflow change. The
@@ -15,10 +15,47 @@ unavailable before a job starts, and job timeouts do not cover queue time; neith
 compatibility pass. If an expected result is absent, check this repository's Actions history before
 treating the nightly as healthy.
 
-The current generated APN and FCM apps are expected to fail the shared launch action until Expo
-UIScene host-lifecycle support lands. The action reports whether launch failed or the process exited
-during the survival window and publishes the bounded simulator log. That known red result is the
-compatibility defect this nightly is intended to preserve visibly; do not interpret it as a healthy
-baseline or suppress it.
+## The expected failure, and how to read this job
 
-The review invariant is the known failure mode, not merely a successful build: an Xcode 27 product can compile and still terminate during launch when its generated host lifecycle is incompatible. When Xcode 27 becomes stable, remove this temporary preview workflow and add Xcode 27 to the normal required compatibility and release paths. Exact beta-image validation belongs in a temporary, explicitly test-only PR. A compatibility pass proves generated-project compilation, simulator installation, launch, and short process survival for the named Expo/provider combination. It does not prove lifecycle callback forwarding, authenticated UI paths, physical-device push delivery, signing, export, or App Store acceptance.
+The generated APN and FCM apps are expected to fail the shared launch action until Expo UIScene
+host-lifecycle support lands. The Expo SDK 57 template ships no `UIApplicationSceneManifest` and no
+`SceneDelegate`, so on the iOS 27 SDK the process is terminated during launch with:
+
+```
+Application failed to launch: UIScene life cycle is required for apps built with this SDK.
+```
+
+This is not a plugin defect. The Customer.io plugin is already SDK-58-ready and gates its scene work
+behind `isExpoVersion58OrHigher` (`plugin/src/ios/utils.ts`); Expo 58 exists only as a canary.
+
+The launch step therefore carries `continue-on-error: true`, and a following step **asserts** that
+known failure instead of letting it redden the job. A permanently-red job is not a signal — it
+trains everyone to ignore the result, which is exactly how a real regression would slip through. The
+assertion is inverted rather than muted: the defect stays visible, but a *change* in it is what
+turns the job red.
+
+**Green here means the known defect is unchanged. It does NOT mean Expo works on iOS 27.** The
+generated apps still fail to launch on every green run; the job is asserting that they fail in
+precisely the tracked way.
+
+The job goes red when any of three conditions stops holding, and the failure names which one:
+
+| flip reason | meaning | what to do |
+| --- | --- | --- |
+| `launch-now-succeeds` | the app launched and survived the window | Expo's UIScene host lifecycle landed — enable scene support and retire this gate |
+| `signature-changed` | the launch still fails, but not with the UIScene signature | a genuinely new problem; triage it as a normal failure |
+| `expo-sdk-moved` | the generated app is no longer on Expo SDK 57 | this gate's premise is stale; on SDK 58+ the plugin's own scene support takes over |
+
+The assertion is gated on the launch step's `outcome`, not on the shared action's `failure-reason`
+output, because a failing composite step does not reliably propagate its outputs. The action still
+publishes the bounded simulator log, and that log is what the signature check reads; it is uploaded
+as an artifact on every run either way.
+
+A flip on the **scheduled** run notifies `#mobile-deployments` with the reason above. Pull-request
+runs of this workflow (it is triggered by changes to itself) stay silent. The Slack post uses an
+incoming webhook, which needs no `GITHUB_TOKEN` scope, so this workflow keeps
+`permissions: contents: read`.
+
+Do not "fix" a red run by relaxing the assertion, and do not restore the always-red behaviour.
+
+The review invariant is the known failure mode, not merely a successful build: an Xcode 27 product can compile and still terminate during launch when its generated host lifecycle is incompatible. That is why the job asserts the launch failure rather than the build. When Xcode 27 becomes stable, remove this temporary preview workflow and add Xcode 27 to the normal required compatibility and release paths. Exact beta-image validation belongs in a temporary, explicitly test-only PR. A compatibility pass proves generated-project compilation, simulator installation, launch, and short process survival for the named Expo/provider combination. It does not prove lifecycle callback forwarding, authenticated UI paths, physical-device push delivery, signing, export, or App Store acceptance.

--- a/.github/workflows/ios-toolchain-compatibility.yml
+++ b/.github/workflows/ios-toolchain-compatibility.yml
@@ -149,13 +149,91 @@ jobs:
           fi
           echo "APP_PRODUCT_PATH=$app_product_path" >> "$GITHUB_ENV"
 
+      # Expected to FAIL. The generated app is asserted against below rather
+      # than left to redden the job: see `.github/IOS-TOOLCHAIN-COMPATIBILITY.md`.
       - name: Install and launch generated app
+        id: launch
+        continue-on-error: true
         uses: customerio/mobile-ci-tools/github-actions/ios/launch-simulator-app/v1@main
         with:
           app-path: ${{ env.APP_PRODUCT_PATH }}
           expected-ios-major: '27'
           survival-seconds: ${{ env.LAUNCH_SURVIVAL_SECONDS }}
           log-path: ${{ runner.temp }}/${{ matrix.ios-push-provider }}-launch.log
+
+      # A permanently-red job trains everyone to ignore it, so a real regression
+      # here would go unnoticed. Invert the assertion instead of muting it: the
+      # job is GREEN while the known Expo defect holds unchanged, and RED the
+      # moment it moves. Gated on the step OUTCOME, not on the action's
+      # `failure-reason` output, which a failing composite step does not
+      # reliably propagate.
+      - name: Assert the known Expo UIScene launch failure
+        id: known-failure
+        shell: bash
+        env:
+          LAUNCH_OUTCOME: ${{ steps.launch.outcome }}
+          LAUNCH_LOG: ${{ runner.temp }}/${{ matrix.ios-push-provider }}-launch.log
+          EXPECTED_EXPO_MAJOR: '57'
+          KNOWN_SIGNATURE: 'UIScene life cycle is required|_UIApplicationEvaluateRuntimeIssueForNoSceneLifecycleAdoption'
+        run: |
+          set -uo pipefail
+
+          flip_reason=""
+          detail=""
+
+          # 1. The launch must still fail.
+          if [[ "$LAUNCH_OUTCOME" != "failure" ]]; then
+            flip_reason="launch-now-succeeds"
+            detail="The generated app launched and survived (step outcome: $LAUNCH_OUTCOME). Expo's UIScene host lifecycle appears to have landed — enable scene support and retire this expected-failure gate."
+          fi
+
+          # 2. It must fail with the KNOWN signature, not some other way.
+          if [[ -z "$flip_reason" ]]; then
+            if [[ ! -s "$LAUNCH_LOG" ]]; then
+              flip_reason="signature-changed"
+              detail="The launch failed but produced no readable log at $LAUNCH_LOG, so the failure could not be identified as the known UIScene defect."
+            elif ! grep -Eq "$KNOWN_SIGNATURE" "$LAUNCH_LOG"; then
+              flip_reason="signature-changed"
+              detail="The launch failed for a reason that does not match the known UIScene signature. This is a genuinely new problem, not the tracked Expo defect."
+            fi
+          fi
+
+          # 3. The assumption this gate encodes — Expo SDK 57 — must still hold.
+          resolved_expo="$(node -e 'const fs=require("fs"),p=require("path");try{const j=JSON.parse(fs.readFileSync(p.join(process.env.APP_PATH,"package.json"),"utf8"));process.stdout.write(String((j.dependencies||{}).expo||""))}catch(e){}' 2>/dev/null || true)"
+          resolved_major="$(printf '%s' "$resolved_expo" | sed -n 's/^[^0-9]*\([0-9][0-9]*\).*/\1/p')"
+          echo "Resolved Expo release in the generated app: ${resolved_expo:-unknown} (major: ${resolved_major:-unknown})"
+          if [[ -z "$flip_reason" && "$resolved_major" != "$EXPECTED_EXPO_MAJOR" ]]; then
+            flip_reason="expo-sdk-moved"
+            detail="The generated app resolved Expo ${resolved_expo:-unknown}, not SDK $EXPECTED_EXPO_MAJOR. This gate's premise is stale — on SDK 58+ the plugin's own scene support (isExpoVersion58OrHigher) takes over and the expected failure no longer applies."
+          fi
+
+          {
+            echo "flip-reason=$flip_reason"
+            echo "launch-outcome=$LAUNCH_OUTCOME"
+            echo "resolved-expo=${resolved_expo:-unknown}"
+          } >> "$GITHUB_OUTPUT"
+
+          if [[ -n "$flip_reason" ]]; then
+            echo "::error title=Xcode 27 preview::[$flip_reason] $detail"
+            {
+              echo '## Known Expo failure flipped'
+              echo
+              echo "**Reason:** \`$flip_reason\`"
+              echo "**Provider:** ${{ matrix.ios-push-provider }}"
+              echo "**Resolved Expo:** ${resolved_expo:-unknown}"
+              echo
+              echo "$detail"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "The known Expo UIScene launch failure is unchanged (Expo ${resolved_expo:-unknown}, launch outcome: $LAUNCH_OUTCOME)."
+          {
+            echo '## Known Expo failure unchanged'
+            echo
+            echo "The generated ${{ matrix.ios-push-provider }} app still fails to launch with the tracked UIScene defect on Expo ${resolved_expo:-unknown}."
+            echo 'Green here means the known defect is unchanged — NOT that Expo works on iOS 27.'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload compatibility logs
         if: always()
@@ -168,3 +246,40 @@ jobs:
             ${{ runner.temp }}/${{ matrix.ios-push-provider }}-build-start-epoch
           if-no-files-found: error
           retention-days: 7
+
+      # Only the nightly notifies. Pull-request runs of this workflow (it is
+      # triggered by changes to itself) stay quiet. A webhook post needs no
+      # GITHUB_TOKEN scope, so `permissions: contents: read` above is left as is.
+      - name: Notify team when the known Expo failure flips
+        if: failure() && github.event_name == 'schedule'
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        with:
+          payload: |
+            {
+              "text": "Xcode 27 preview: known Expo failure flipped (${{ matrix.ios-push-provider }})",
+              "username": "Expo compatibility bot",
+              "icon_url": "https://logos-download.com/wp-content/uploads/2021/01/Expo_Logo.png",
+              "channel": "#mobile-deployments",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Expo* Xcode 27 preview nightly changed state — :mag: *${{ matrix.ios-push-provider }}* leg"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Flip reason:* `${{ steps.known-failure.outputs.flip-reason || 'job-failed-before-assertion' }}`\n*Launch outcome:* `${{ steps.known-failure.outputs.launch-outcome || 'unknown' }}`\n*Resolved Expo:* `${{ steps.known-failure.outputs.resolved-expo || 'unknown' }}`\n\n• `launch-now-succeeds` — Expo's UIScene host lifecycle landed. Enable scene support and retire this gate.\n• `signature-changed` — the app still fails, but not with the tracked UIScene signature. Treat as a new problem.\n• `expo-sdk-moved` — the generated app is no longer on SDK 57, so this gate's premise is stale.\n• `job-failed-before-assertion` — the nightly broke earlier than the launch step.\n\n<https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View the run>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/ios-toolchain-compatibility.yml
+++ b/.github/workflows/ios-toolchain-compatibility.yml
@@ -262,9 +262,12 @@ jobs:
         # Gate on the assertion itself, not on failure(): a passing gate followed
         # by a failed artifact upload would otherwise alert with an empty
         # flip-reason, reporting a flip that did not happen. `skipped` covers the
-        # genuine case where the job broke before the assertion ran.
+        # genuine case where the job broke before the assertion ran -- and
+        # `!cancelled()` keeps a cancelled run (concurrency has
+        # cancel-in-progress) from looking like one, since cancellation also
+        # leaves the assertion skipped.
         if: >-
-          always() && github.event_name == 'schedule'
+          !cancelled() && github.event_name == 'schedule'
           && (steps.known-failure.outcome == 'failure'
           || steps.known-failure.outcome == 'skipped')
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0

--- a/.github/workflows/ios-toolchain-compatibility.yml
+++ b/.github/workflows/ios-toolchain-compatibility.yml
@@ -202,9 +202,17 @@ jobs:
           resolved_expo="$(node -e 'const fs=require("fs"),p=require("path");try{const j=JSON.parse(fs.readFileSync(p.join(process.env.APP_PATH,"package.json"),"utf8"));process.stdout.write(String((j.dependencies||{}).expo||""))}catch(e){}' 2>/dev/null || true)"
           resolved_major="$(printf '%s' "$resolved_expo" | sed -n 's/^[^0-9]*\([0-9][0-9]*\).*/\1/p')"
           echo "Resolved Expo release in the generated app: ${resolved_expo:-unknown} (major: ${resolved_major:-unknown})"
-          if [[ -z "$flip_reason" && "$resolved_major" != "$EXPECTED_EXPO_MAJOR" ]]; then
-            flip_reason="expo-sdk-moved"
-            detail="The generated app resolved Expo ${resolved_expo:-unknown}, not SDK $EXPECTED_EXPO_MAJOR. This gate's premise is stale — on SDK 58+ the plugin's own scene support (isExpoVersion58OrHigher) takes over and the expected failure no longer applies."
+          # An unreadable probe is NOT evidence that Expo moved. Keep the two
+          # apart, or any failure to read package.json reports a stale premise
+          # that did not happen and sends someone chasing a non-event.
+          if [[ -z "$flip_reason" ]]; then
+            if [[ -z "$resolved_major" ]]; then
+              flip_reason="expo-version-unresolved"
+              detail="Could not read an Expo version from \$APP_PATH/package.json (resolved: '${resolved_expo:-empty}'). The gate could not confirm its own premise of SDK $EXPECTED_EXPO_MAJOR. This is a probe failure to fix here, not a change in Expo."
+            elif [[ "$resolved_major" != "$EXPECTED_EXPO_MAJOR" ]]; then
+              flip_reason="expo-sdk-moved"
+              detail="The generated app resolved Expo ${resolved_expo:-unknown}, not SDK $EXPECTED_EXPO_MAJOR. This gate's premise is stale — on SDK 58+ the plugin's own scene support (isExpoVersion58OrHigher) takes over and the expected failure no longer applies."
+            fi
           fi
 
           {
@@ -275,7 +283,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Flip reason:* `${{ steps.known-failure.outputs.flip-reason || 'job-failed-before-assertion' }}`\n*Launch outcome:* `${{ steps.known-failure.outputs.launch-outcome || 'unknown' }}`\n*Resolved Expo:* `${{ steps.known-failure.outputs.resolved-expo || 'unknown' }}`\n\n• `launch-now-succeeds` — Expo's UIScene host lifecycle landed. Enable scene support and retire this gate.\n• `signature-changed` — the app still fails, but not with the tracked UIScene signature. Treat as a new problem.\n• `expo-sdk-moved` — the generated app is no longer on SDK 57, so this gate's premise is stale.\n• `job-failed-before-assertion` — the nightly broke earlier than the launch step.\n\n<https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View the run>"
+                    "text": "*Flip reason:* `${{ steps.known-failure.outputs.flip-reason || 'job-failed-before-assertion' }}`\n*Launch outcome:* `${{ steps.known-failure.outputs.launch-outcome || 'unknown' }}`\n*Resolved Expo:* `${{ steps.known-failure.outputs.resolved-expo || 'unknown' }}`\n\n• `launch-now-succeeds` — Expo's UIScene host lifecycle landed. Enable scene support and retire this gate.\n• `signature-changed` — the app still fails, but not with the tracked UIScene signature. Treat as a new problem.\n• `expo-sdk-moved` — the generated app is no longer on SDK 57, so this gate's premise is stale.\n• `expo-version-unresolved` — the gate could not read the app's Expo version. A probe bug in this workflow, not an Expo change.\n• `job-failed-before-assertion` — the nightly broke earlier than the launch step.\n\n<https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View the run>"
                   }
                 }
               ]

--- a/.github/workflows/ios-toolchain-compatibility.yml
+++ b/.github/workflows/ios-toolchain-compatibility.yml
@@ -261,15 +261,19 @@ jobs:
       - name: Notify team when the known Expo failure flips
         # Gate on the assertion itself, not on failure(): a passing gate followed
         # by a failed artifact upload would otherwise alert with an empty
-        # flip-reason, reporting a flip that did not happen. `skipped` covers the
-        # genuine case where the job broke before the assertion ran -- and
-        # `!cancelled()` keeps a cancelled run (concurrency has
-        # cancel-in-progress) from looking like one, since cancellation also
-        # leaves the assertion skipped.
+        # flip-reason, reporting a flip that did not happen.
+        #
+        # The two branches need different cancellation handling:
+        #   failure  -- a real flip, already established. Alert even if the run is
+        #               later cancelled, or a genuine flip is lost.
+        #   skipped  -- ambiguous. Either the job broke before the assertion ran
+        #               (worth alerting) or concurrency cancelled the run, which
+        #               also leaves it skipped (not worth alerting). Only the
+        #               `!cancelled()` guard separates those.
         if: >-
-          !cancelled() && github.event_name == 'schedule'
+          always() && github.event_name == 'schedule'
           && (steps.known-failure.outcome == 'failure'
-          || steps.known-failure.outcome == 'skipped')
+          || (!cancelled() && steps.known-failure.outcome == 'skipped'))
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           payload: |

--- a/.github/workflows/ios-toolchain-compatibility.yml
+++ b/.github/workflows/ios-toolchain-compatibility.yml
@@ -259,7 +259,14 @@ jobs:
       # triggered by changes to itself) stay quiet. A webhook post needs no
       # GITHUB_TOKEN scope, so `permissions: contents: read` above is left as is.
       - name: Notify team when the known Expo failure flips
-        if: failure() && github.event_name == 'schedule'
+        # Gate on the assertion itself, not on failure(): a passing gate followed
+        # by a failed artifact upload would otherwise alert with an empty
+        # flip-reason, reporting a flip that did not happen. `skipped` covers the
+        # genuine case where the job broke before the assertion ran.
+        if: >-
+          always() && github.event_name == 'schedule'
+          && (steps.known-failure.outcome == 'failure'
+          || steps.known-failure.outcome == 'skipped')
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           payload: |

--- a/__tests__/workflows/ios-toolchain-compatibility.test.js
+++ b/__tests__/workflows/ios-toolchain-compatibility.test.js
@@ -103,12 +103,14 @@ describe('Xcode 27 preview workflow', () => {
     // (concurrency cancels in-progress nightlies) must not either -- both leave
     // a misleading empty flip-reason.
     expect(notify.if).toBe(
-      "!cancelled() && github.event_name == 'schedule' && " +
+      "always() && github.event_name == 'schedule' && " +
         "(steps.known-failure.outcome == 'failure' || " +
-        "steps.known-failure.outcome == 'skipped')"
+        "(!cancelled() && steps.known-failure.outcome == 'skipped'))"
     );
-    expect(notify.if).not.toContain('failure()');
-    expect(notify.if).toContain('!cancelled()');
+    // A real flip must still alert if the run is cancelled afterwards, so
+    // !cancelled() guards only the ambiguous `skipped` branch.
+    expect(notify.if).not.toMatch(/^!cancelled\(\)/);
+    expect(notify.if).toContain("(!cancelled() && steps.known-failure.outcome == 'skipped')");
     expect(notify.env.SLACK_WEBHOOK_TYPE).toBe('INCOMING_WEBHOOK');
     expect(notify.env.SLACK_WEBHOOK_URL).toBe(
       '${{ secrets.SLACK_WEBHOOK_URL }}'

--- a/__tests__/workflows/ios-toolchain-compatibility.test.js
+++ b/__tests__/workflows/ios-toolchain-compatibility.test.js
@@ -54,6 +54,10 @@ describe('Xcode 27 preview workflow', () => {
     expect(step('Install and launch generated app').uses).toBe(
       'customerio/mobile-ci-tools/github-actions/ios/launch-simulator-app/v1@main'
     );
+    expect(step('Install and launch generated app').id).toBe('launch');
+    expect(step('Install and launch generated app')['continue-on-error']).toBe(
+      true
+    );
     expect(step('Upload compatibility logs').if).toBe('always()');
     expect(step('Upload compatibility logs').with['if-no-files-found']).toBe(
       'error'
@@ -62,6 +66,64 @@ describe('Xcode 27 preview workflow', () => {
     expect(workflow).not.toContain('Record compatibility result');
     expect(workflow).not.toContain('Record launch failure');
     expect(workflow).not.toContain('Record unclassified failure');
+  });
+
+  it('inverts the known Expo failure into a green assertion', () => {
+    const assertion = step('Assert the known Expo UIScene launch failure');
+    expect(assertion).toBeDefined();
+    expect(assertion.id).toBe('known-failure');
+
+    // Gate on the step outcome, never on the composite action's
+    // `failure-reason` output, which a failing composite step does not
+    // reliably propagate.
+    expect(assertion.env.LAUNCH_OUTCOME).toBe('${{ steps.launch.outcome }}');
+
+    // All three assertions must be present: the launch still fails, it fails
+    // with the known signature, and the premise (Expo SDK 57) still holds.
+    expect(assertion.env.EXPECTED_EXPO_MAJOR).toBe('57');
+    expect(assertion.env.KNOWN_SIGNATURE).toBe(
+      'UIScene life cycle is required|_UIApplicationEvaluateRuntimeIssueForNoSceneLifecycleAdoption'
+    );
+    expect(assertion.run).toContain('launch-now-succeeds');
+    expect(assertion.run).toContain('signature-changed');
+    expect(assertion.run).toContain('expo-sdk-moved');
+
+    // The assertion has to run before the artifact upload so a flip cannot be
+    // hidden behind an upload failure.
+    const names = steps.map((candidate) => candidate.name);
+    expect(names.indexOf('Assert the known Expo UIScene launch failure')).
+      toBeLessThan(names.indexOf('Upload compatibility logs'));
+  });
+
+  it('notifies only the nightly, on the same pinned Slack action as deploy-sdk', () => {
+    const notify = step('Notify team when the known Expo failure flips');
+    expect(notify).toBeDefined();
+    expect(notify.if).toBe("failure() && github.event_name == 'schedule'");
+    expect(notify.env.SLACK_WEBHOOK_TYPE).toBe('INCOMING_WEBHOOK');
+    expect(notify.env.SLACK_WEBHOOK_URL).toBe(
+      '${{ secrets.SLACK_WEBHOOK_URL }}'
+    );
+
+    // Same pinned SHA the deploy workflow already uses — no second pin to keep
+    // in step with dependabot.
+    const deploy = fs.readFileSync(
+      path.join(__dirname, '../../.github/workflows/deploy-sdk.yml'),
+      'utf8'
+    );
+    const pinned = deploy.match(/slackapi\/slack-github-action@[0-9a-f]{40}/);
+    expect(pinned).not.toBeNull();
+    expect(notify.uses.split(' ')[0]).toBe(pinned[0]);
+
+    // The message has to name which flip happened; "it broke" is what made the
+    // permanently-red job useless.
+    const payload = notify.with.payload;
+    expect(payload).toContain('launch-now-succeeds');
+    expect(payload).toContain('signature-changed');
+    expect(payload).toContain('steps.known-failure.outputs.flip-reason');
+
+    // `permissions: contents: read` is enough for a webhook post; assert it was
+    // not quietly widened to add the notification.
+    expect(definition.permissions).toEqual({ contents: 'read' });
   });
 
   it('executes the generated-app resolver behavior suite', () => {

--- a/__tests__/workflows/ios-toolchain-compatibility.test.js
+++ b/__tests__/workflows/ios-toolchain-compatibility.test.js
@@ -98,7 +98,17 @@ describe('Xcode 27 preview workflow', () => {
   it('notifies only the nightly, on the same pinned Slack action as deploy-sdk', () => {
     const notify = step('Notify team when the known Expo failure flips');
     expect(notify).toBeDefined();
-    expect(notify.if).toBe("failure() && github.event_name == 'schedule'");
+    // Gating on the assertion's own outcome rather than failure(): a passing
+    // gate followed by a failed upload must not alert, and a cancelled run
+    // (concurrency cancels in-progress nightlies) must not either -- both leave
+    // a misleading empty flip-reason.
+    expect(notify.if).toBe(
+      "!cancelled() && github.event_name == 'schedule' && " +
+        "(steps.known-failure.outcome == 'failure' || " +
+        "steps.known-failure.outcome == 'skipped')"
+    );
+    expect(notify.if).not.toContain('failure()');
+    expect(notify.if).toContain('!cancelled()');
     expect(notify.env.SLACK_WEBHOOK_TYPE).toBe('INCOMING_WEBHOOK');
     expect(notify.env.SLACK_WEBHOOK_URL).toBe(
       '${{ secrets.SLACK_WEBHOOK_URL }}'
@@ -119,6 +129,7 @@ describe('Xcode 27 preview workflow', () => {
     const payload = notify.with.payload;
     expect(payload).toContain('launch-now-succeeds');
     expect(payload).toContain('signature-changed');
+    expect(payload).toContain('expo-version-unresolved');
     expect(payload).toContain('steps.known-failure.outputs.flip-reason');
 
     // `permissions: contents: read` is enough for a webhook post; assert it was


### PR DESCRIPTION
Fixes MBL-2324

Independent of #400 / #401 / #402 — disjoint files, not part of that stack.

## Problem

`ios-toolchain-compatibility.yml` runs nightly and has **never** been green: 30 failure / 26 cancelled / 4 success, and those 4 predate the launch step. Both matrix legs fail at `Install and launch generated app`.

Confirmed from the launch-log artifact of [run 33368923061](https://github.com/customerio/customerio-expo-plugin/actions/runs/33368923061) (nightly, 2026-08-31):

```
failure in void _UIApplicationEvaluateRuntimeIssueForNoSceneLifecycleAdoption(void)_block_invoke
(UIApplication_RuntimeIssues.m:106) : Application failed to launch: UIScene life cycle is required
for apps built with this SDK.
```

This is a real and known defect, and **not ours**: the Expo SDK 57 template ships no `UIApplicationSceneManifest` and no `SceneDelegate`. The plugin is already SDK-58-ready and gates scene work behind `isExpoVersion58OrHigher` (`plugin/src/ios/utils.ts`). Expo 58 exists only as a canary.

`.github/IOS-TOOLCHAIN-COMPATIBILITY.md` explicitly said these apps are expected to fail and "do not interpret it as a healthy baseline or suppress it." The trouble is that a permanently-red job is not a signal — it trains everyone to ignore the result, so a genuine regression there would go unnoticed. The answer is to **invert** the assertion, not to mute it.

## Fix

1. The launch step gains `id: launch` and `continue-on-error: true`.
2. A new step asserts **all three** of:
   - `steps.launch.outcome == 'failure'`
   - the launch log matches `UIScene life cycle is required|_UIApplicationEvaluateRuntimeIssueForNoSceneLifecycleAdoption`
   - the resolved Expo SDK major in the generated app is still `57`

   The job is GREEN while the known defect holds and RED the moment it moves, naming which of three ways:

   | flip reason | meaning |
   | --- | --- |
   | `launch-now-succeeds` | Expo's UIScene host lifecycle landed — go enable scene support and retire this gate |
   | `signature-changed` | still fails, but not with the tracked signature — a genuinely new problem |
   | `expo-sdk-moved` | no longer Expo SDK 57, so this gate's premise is stale |

3. **Slack on flip**: `if: failure() && github.event_name == 'schedule'`, using `slackapi/slack-github-action` at the *same pinned SHA* `deploy-sdk.yml` already uses (`70cd7be…`, v1.26.0), with `secrets.SLACK_WEBHOOK_URL` and `SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK`. The `schedule` guard keeps PR runs of this workflow quiet. The message names the flip reason and explains all of them.
4. `.github/IOS-TOOLCHAIN-COMPATIBILITY.md` is updated in the same PR, including the explicit line: **"Green here means the known defect is unchanged. It does NOT mean Expo works on iOS 27."** Without that the doc would read as contradicted by the new green.

## Deliberate choices

- **Gated on `steps.launch.outcome`, never on the action's `failure-reason` output.** A failing composite step does not reliably propagate its outputs, and the existing test suite already encodes that lesson with `expect(workflow).not.toContain('steps.launch.outputs.failure-reason')` — still passing.
- **`permissions: contents: read` is left unchanged.** An incoming-webhook post is a plain outbound HTTPS request with a secret; it needs no `GITHUB_TOKEN` scope. The test asserts the block was not quietly widened.
- The assertion runs **before** the artifact upload, so a flip cannot be hidden behind an upload failure. The upload keeps `if: always()`, so the log is published on every run either way.

## Verification

The assertion script was extracted from the workflow and executed against the **real** launch log from nightly run 33368923061:

| case | result |
| --- | --- |
| known failure holds (real nightly log, Expo 57.0.18) | `exit=0`, no flip reason — **the nightly would now be green** |
| launch outcome `success` | `exit=1`, `launch-now-succeeds` |
| log without the signature | `exit=1`, `signature-changed` |
| generated app on Expo 58.0.0 | `exit=1`, `expo-sdk-moved` |
| launch log missing or empty | `exit=1`, `signature-changed` |

`__tests__/workflows/ios-toolchain-compatibility.test.js` gains two cases covering the assertion shape and the notification (including that the Slack pin is read from `deploy-sdk.yml` rather than duplicated). `npx jest __tests__/workflows` → 4 passed. `actionlint` → clean on this workflow.

## Note on the brief

The failure is classified by the shared action as `did-not-survive`, not `launch-failed`: the process launches, then is terminated ~1s into the 10s survival window. The `UIScene life cycle is required` text appears in the **bounded simulator log artifact**, not in the job console — which is part of why this has been easy to skim past. Both regex alternatives match that log line. The generated app also comes from `expo-template-default@57.0.20`, not `expo-template-bare-minimum`.